### PR TITLE
Lazy load lang data, allow overriding of lang files

### DIFF
--- a/config/__tests__/configFile.ts
+++ b/config/__tests__/configFile.ts
@@ -140,6 +140,9 @@ describe('config/configFile', () => {
     it('writes the config to a file', () => {
       ensureFileSyncSpy.mockImplementation(() => null);
       writeFileSyncSpy.mockImplementation(() => null);
+      readFileSyncSpy.mockImplementation(() => Buffer.from('content'));
+      loadSpy.mockImplementation(() => ({}))
+
       writeConfigToFile(CONFIG);
 
       expect(ensureFileSyncSpy).toHaveBeenCalled();

--- a/utils/lang.ts
+++ b/utils/lang.ts
@@ -137,4 +137,4 @@ export function i18n(
 export const setLangData = (newLocale: string, newLangObj: LanguageObject) => {
   locale = newLocale;
   languageObj = newLangObj;
-}
+};


### PR DESCRIPTION
## Description and Context
This PR is a mirror of another from `cli-lib` back in May: https://github.com/HubSpot/hubspot-cli/pull/836/files

Changes `lang.ts` to load language data at first use instead of at initial module import time. Adds a function to allow for overriding the language data loading. This is necessary for VSCode extension usage, as this dependency gets bundled with webpack and when the language data attempts to load at run time it searches from `__dirname`, leading to undefined behavior.

@camden11 is there plans to bundle the language data in instead of trying to fetch it at runtime? We have a somewhat wonky setup to [work around this in the extension ](https://github.com/HubSpot/hubspot-cms-vscode/pull/226) but it would nice to have it work seamlessly

## Who to Notify
<!-- /cc those you wish to know about the PR -->

@HubSpot/cms-developer-tooling 