### PR TITLE
Refactor watch

### DIFF
--- a/lib/cms/watch.ts
+++ b/lib/cms/watch.ts
@@ -187,9 +187,9 @@ export function watch(
   postInitialUploadCallback:
     | ((result: Array<UploadFolderResults>) => void)
     | null = null,
-  logCallbacks?: WatchLogCallbacks,
   onUploadFolderError?: ErrorHandler,
-  onQueueAddError?: ErrorHandler
+  onQueueAddError?: ErrorHandler,
+  logCallbacks?: WatchLogCallbacks
 ) {
   const logger = makeLogger(logCallbacks, 'watch');
   const regex = new RegExp(`^${escapeRegExp(src)}`);


### PR DESCRIPTION
## Description and Context
This refactors the `watch` function to accept callbacks to handle errors gracefully. This allows `watch` to retain its current functionality without breaking our rules for throwing errors.

## Who to Notify
@brandenrodgers @jsines 
