### PR TITLE
Remove duplicate mode constant, add default mode export

### DIFF
--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -12,7 +12,8 @@ import {
 import { commaSeparatedValues } from '../lib/text';
 import { ENVIRONMENTS } from '../constants/environments';
 import { API_KEY_AUTH_METHOD } from '../constants/auth';
-import { DEFAULT_MODES, MIN_HTTP_TIMEOUT } from '../constants/config';
+import { MIN_HTTP_TIMEOUT } from '../constants/config';
+import { MODE } from '../constants/files';
 import { CLIConfig_NEW, Environment } from '../types/Config';
 import {
   CLIAccount_NEW,
@@ -352,9 +353,8 @@ class CLIConfiguration {
     const updatedEnv = getValidEnv(
       env || (currentAccountConfig && currentAccountConfig.env)
     );
-    const updatedDefaultMode: ValueOf<typeof DEFAULT_MODES> | undefined =
-      defaultMode &&
-      (defaultMode.toLowerCase() as ValueOf<typeof DEFAULT_MODES>);
+    const updatedDefaultMode: ValueOf<typeof MODE> | undefined =
+      defaultMode && (defaultMode.toLowerCase() as ValueOf<typeof MODE>);
 
     safelyApplyUpdates('name', name);
     safelyApplyUpdates('env', updatedEnv);
@@ -366,7 +366,7 @@ class CLIConfiguration {
     }
     if (typeof updatedDefaultMode !== 'undefined') {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      safelyApplyUpdates('defaultMode', DEFAULT_MODES[updatedDefaultMode]);
+      safelyApplyUpdates('defaultMode', MODE[updatedDefaultMode]);
     }
     safelyApplyUpdates('personalAccessKey', personalAccessKey);
     safelyApplyUpdates('sandboxAccountType', sandboxAccountType);
@@ -480,7 +480,7 @@ class CLIConfiguration {
     if (!this.config) {
       throwErrorWithMessage(`${i18nKey}.noConfigLoaded`);
     }
-    const ALL_MODES = Object.values(DEFAULT_MODES);
+    const ALL_MODES = Object.values(MODE);
     if (!defaultMode || !ALL_MODES.find(m => m === defaultMode)) {
       throwErrorWithMessage(`${i18nKey}.updateDefaultMode`, {
         defaultMode,

--- a/constants/config.ts
+++ b/constants/config.ts
@@ -4,9 +4,4 @@ export const DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME = 'hubspot.config.yml';
 export const HUBSPOT_CONFIGURATION_FOLDER = '.hubspot';
 export const HUBSPOT_CONFIGURATION_FILE = 'config.yml';
 
-export const DEFAULT_MODES = {
-  draft: 'draft',
-  publish: 'publish',
-} as const;
-
 export const MIN_HTTP_TIMEOUT = 3000;

--- a/constants/files.ts
+++ b/constants/files.ts
@@ -9,6 +9,8 @@ export const MODE = {
   publish: 'publish',
 } as const;
 
+export const DEFAULT_MODE = MODE.publish;
+
 export const FILE_UPLOAD_RESULT_TYPES = {
   SUCCESS: 'SUCCESS',
   FAILURE: 'FAILURE',


### PR DESCRIPTION
## Description and Context
`local-dev-lib` somehow ended up with a `DEFAULT_MODES` constant that was exactly the same as `MODE`. This fixes that, and adds the real `DEFAULT_MODE` constant, which is used in the CLI.

## Who to Notify
@brandenrodgers 
