### PR TITLE
Remove postinstall script on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "lint": "eslint --max-warnings=0 . && prettier --check ./**/*.ts",
     "local-dev": "yarn build && cd dist && yarn link && cd .. && tsc --watch --rootDir . --outdir dist",
     "postinstall": "husky install",
-    "prepack": "pinst --disable",
-    "postpack": "pinst --enable",
     "prettier:write": "prettier --write ./**/*.{ts,js,json}",
     "pub": "cd dist && npm publish --tag latest && cd ..",
     "push": "git push --atomic origin main v$npm_package_version",
@@ -45,7 +43,6 @@
     "eslint": "^8.35.0",
     "husky": "^8.0.0",
     "jest": "^29.5.0",
-    "pinst": "^3.0.0",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.5"
   },


### PR DESCRIPTION
## Description and Context
`husky` now requires you to run `husky install` in your `prepare` or `postinstall` script, but this doesn't work for npm packages because `husky` is a `devDependancy` and won't be there. Looks like a simple way to fix this is just to delete the `postinstall` script in the built version of the project. See https://joshtronic.com/2022/07/10/husky-command-not-found-with-npm-install-production/

## Who to Notify
@brandenrodgers 
