### PR TITLE
Fix bug with isObject

### DIFF
--- a/lib/cms/functions.ts
+++ b/lib/cms/functions.ts
@@ -4,7 +4,6 @@ import findup from 'findup-sync';
 import { getCwd } from '../path';
 import { downloadGithubRepoContents } from '../github';
 import { debug, makeTypedLogger } from '../../utils/logger';
-import { isObjectOrFunction } from '../../utils/objectUtils';
 import { throwErrorWithMessage } from '../../errors/standardErrors';
 import { throwFileSystemError } from '../../errors/fileSystemErrors';
 import { BaseError } from '../../types/Error';
@@ -24,6 +23,11 @@ type Config = {
     };
   };
 };
+
+function isObjectOrFunction(value: object): boolean {
+  const type = typeof value;
+  return value != null && (type === 'object' || type === 'function');
+}
 
 function createEndpoint(
   endpointMethod: string,

--- a/utils/objectUtils.ts
+++ b/utils/objectUtils.ts
@@ -1,8 +1,3 @@
-export function isObjectOrFunction(value: object): boolean {
-  const type = typeof value;
-  return value != null && (type === 'object' || type === 'function');
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isObject(item: any) {
   return item && typeof item === 'object' && !Array.isArray(item);


### PR DESCRIPTION
## Description and Context
`cli-lib` has two different functions called `isObject`, one that returns `true` for functions and one that doesn't. We were using one of these `isObject` functions where the other should have been used. This fixes that bug and renames one of them to clear things up.

## Who to Notify
@brandenrodgers 
