### PR TITLE
Fix bug with unauthenticated usage tracking requests

### DIFF
--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -331,7 +331,7 @@ export function findConfig(directory: string): string | null {
   );
 }
 
-export function getEnv(nameOrId: string | number): Environment {
+export function getEnv(nameOrId?: string | number): Environment {
   let env: Environment = ENVIRONMENTS.PROD;
   const config = getAndLoadConfigIfNeeded();
   const accountId = getAccountId(nameOrId);

--- a/config/index.ts
+++ b/config/index.ts
@@ -199,7 +199,7 @@ export function isTrackingAllowed() {
   return config_DEPRECATED.isTrackingAllowed();
 }
 
-export function getEnv(nameOrId: string | number) {
+export function getEnv(nameOrId?: string | number) {
   if (CLIConfiguration.isActive()) {
     return CLIConfiguration.getEnv(nameOrId);
   }

--- a/lib/trackUsage.ts
+++ b/lib/trackUsage.ts
@@ -1,3 +1,5 @@
+import axios from 'axios';
+import { getAxiosConfig } from '../http/getAxiosConfig';
 import { debug } from '../utils/logger';
 import http from '../http';
 import { getAccountConfig, getEnv } from '../config';
@@ -9,7 +11,7 @@ export async function trackUsage(
   eventName: string,
   eventClass: string,
   meta = {},
-  accountId: number
+  accountId?: number
 ): Promise<void> {
   const usageEvent = {
     accountId,
@@ -49,11 +51,12 @@ export async function trackUsage(
   }
 
   const env = getEnv(accountId);
-  debug(`${i18nKey}.sendingEventUnauthenticated`);
-  http.post<void>(accountId, {
+  const axiosConfig = getAxiosConfig({
     env,
     url: path,
     data: usageEvent,
     resolveWithFullResponse: true,
   });
+  debug(`${i18nKey}.sendingEventUnauthenticated`);
+  axios({ ...axiosConfig, method: 'post' });
 }


### PR DESCRIPTION
## Description and Context
Previously, `trackUsage` was attempting to make an authenticated request without an `accountId`. This fixes it so it matches the behavior in cli-lib

## Who to Notify
@brandenrodgers 
