### PR TITLE
Minor fixes to archive

### DIFF
--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -1,16 +1,13 @@
 import fs from 'fs-extra';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { promisify } from 'util';
-import __extract from 'extract-zip';
+import extract from 'extract-zip';
 
 import { throwFileSystemError } from '../errors/fileSystemErrors';
 import { throwErrorWithMessage } from '../errors/standardErrors';
 import { debug, makeTypedLogger } from '../utils/logger';
 import { BaseError } from '../types/Error';
 import { LogCallbacksArg } from '../types/LogCallbacks';
-
-const extract = promisify(__extract);
 
 const i18nKey = 'lib.archive';
 


### PR DESCRIPTION
## Description and Context
This makes a few small changes to `archive`
* The current version of `extract-zip` no longer needs to be promisified
* Switched debug logs to console logs

## Who to Notify
@brandenrodgers 
