### PR TITLE
Slight tweaks to updateConfigWithPersonalAccessKey

### DIFF
--- a/lib/__tests__/personalAccessKey.ts
+++ b/lib/__tests__/personalAccessKey.ts
@@ -198,8 +198,8 @@ describe('lib/personalAccessKey', () => {
 
       await updateConfigWithPersonalAccessKey(
         'pak_123',
-        'account-name',
-        ENVIRONMENTS.QA
+        ENVIRONMENTS.QA,
+        'account-name'
       );
 
       expect(updateAccountConfig).toHaveBeenCalledWith(
@@ -222,8 +222,8 @@ describe('lib/personalAccessKey', () => {
 
       await updateConfigWithPersonalAccessKey(
         'pak_123',
-        'account-name',
-        ENVIRONMENTS.QA
+        ENVIRONMENTS.QA,
+        'account-name'
       );
 
       expect(updateAccountConfig).toHaveBeenCalledWith(

--- a/lib/personalAccessKey.ts
+++ b/lib/personalAccessKey.ts
@@ -149,8 +149,8 @@ export async function accessTokenForPersonalAccessKey(
 // Adds an account to the config using authType: personalAccessKey
 export const updateConfigWithPersonalAccessKey = async (
   personalAccessKey: string,
-  name: string,
-  env: Environment,
+  env?: Environment,
+  name?: string,
   makeDefault = false
 ): Promise<CLIAccount | null> => {
   const accountEnv = env || getEnv(name);
@@ -192,7 +192,7 @@ export const updateConfigWithPersonalAccessKey = async (
   });
   writeConfig();
 
-  if (makeDefault) {
+  if (makeDefault && name) {
     updateDefaultAccount(name);
   }
 


### PR DESCRIPTION
## Description and Context
This changes the order of the arguments + updates types for `updateConfigWithPersonalAccessKey`, since `name` is not required and is frequently not passed in.

## Who to Notify
@brandenrodgers 
