### PR TITLE
Streamline error messaging

### DIFF
--- a/errors/standardErrors.ts
+++ b/errors/standardErrors.ts
@@ -73,8 +73,10 @@ export function throwError(error: BaseError): never {
     throwStatusCodeError(error as StatusCodeError);
   } else {
     // Error or Error subclass
-    const name = error.name || 'Error';
-    const message = [i18n('errors.generic', { name })];
+    const message =
+      error.name && error.name !== 'Error'
+        ? [i18n('errors.generic', { name: error.name })]
+        : [];
     [error.message, error.reason].forEach(msg => {
       if (msg) {
         message.push(msg);

--- a/lang/en.json
+++ b/lang/en.json
@@ -378,6 +378,6 @@
         "generic": "The {{ messageDetail }} failed."
       }
     },
-    "generic": "A {{ name }} has occurred"
+    "generic": "{{ name }}:"
   }
 }


### PR DESCRIPTION
## Description and Context
I initially pulled a lot of the messaging from the error utils from the old `standardErrors` module. Now that `standardErrors` is being used in the CLI to log errors thrown by `local-dev-lib`, we're ending up with some very redundant error messages. This makes some tweak to the copy of `throwError` so it still alerts users of specific types of errors without saying "an error has occurred" over and over again

## Screenshots
Before
<img width="725" alt="Screenshot 2023-12-11 at 1 23 44 PM" src="https://github.com/HubSpot/hubspot-local-dev-lib/assets/10413161/c90b3829-ae8e-46ae-bad0-ca0c2efa12ba">

After
<img width="556" alt="Screenshot 2023-12-11 at 1 28 29 PM" src="https://github.com/HubSpot/hubspot-local-dev-lib/assets/10413161/4c4087fe-13ca-4b27-8f9e-543ad02c618e">

## Who to Notify
@brandenrodgers 
