### PR TITLE
Use res.sendStatus on PortManagerServer

### DIFF
--- a/utils/PortManagerServer.ts
+++ b/utils/PortManagerServer.ts
@@ -181,7 +181,7 @@ class PortManagerServer {
 
     if (port) {
       this.deletePort(instanceId);
-      res.send(200);
+      res.sendStatus(200);
     } else {
       this.send404(res, instanceId);
     }
@@ -190,7 +190,7 @@ class PortManagerServer {
   closeServer = (req: Request, res: Response): void => {
     if (this.server) {
       debug(`${i18nKey}.close`);
-      res.send(200);
+      res.sendStatus(200);
       this.server.close();
       this.reset();
     }


### PR DESCRIPTION
## Description and Context
See https://hubspot.slack.com/archives/C0242BLSY2F/p1702518991396989
@joe-yeager pointed out that `res.send(status)` is now deprecated (and logs a deprecation message to the CLI) so updating to use `res.sendStatus`

## Who to Notify
@brandenrodgers 
