### PR TITLE
Support interpolation in log callbacks

### DIFF
--- a/types/Lang.ts
+++ b/types/Lang.ts
@@ -8,3 +8,7 @@ export type GenericLanguageObject = {
 export type LanguageObject = typeof lang;
 
 export type LangKey = Leaves<LanguageObject>;
+
+export type InterpolationData = {
+  [identifier: string]: string | number;
+};

--- a/types/LogCallbacks.ts
+++ b/types/LogCallbacks.ts
@@ -1,5 +1,7 @@
+import { InterpolationData } from './Lang';
+
 export type LogCallbacks<T extends string> = {
-  [key in T]?: () => void;
+  [key in T]?: (interpolationData?: InterpolationData) => void;
 };
 
 export type LogCallbacksArg<T extends readonly string[]> = {

--- a/utils/lang.ts
+++ b/utils/lang.ts
@@ -1,5 +1,10 @@
 import en from '../lang/en.json';
-import { LanguageObject, GenericLanguageObject, LangKey } from '../types/Lang';
+import {
+  LanguageObject,
+  GenericLanguageObject,
+  LangKey,
+  InterpolationData,
+} from '../types/Lang';
 
 const LANGUAGES: { [language: string]: LanguageObject } = {
   en,
@@ -68,10 +73,6 @@ function generateReplaceFn(
     }${currentStringValue.slice(startIndex + matchedText.length)}`;
   };
 }
-
-type InterpolationData = {
-  [identifier: string]: string | number;
-};
 
 export function interpolate(
   stringValue: string,

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,19 +1,19 @@
 import { i18n } from './lang';
 import { logger } from '../lib/logging/logger';
 import { LogCallbacks } from '../types/LogCallbacks';
-import { LangKey } from '../types/Lang';
+import { InterpolationData, LangKey } from '../types/Lang';
 
 export function log<T extends string>(
   key: T,
   callbacks?: LogCallbacks<T>,
   debugKey?: LangKey,
-  debugInterpolation?: { [key: string]: string | number }
+  interpolationData?: InterpolationData
 ): void {
   if (callbacks && callbacks[key]) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    callbacks[key]!();
+    callbacks[key]!(interpolationData);
   } else if (debugKey) {
-    debug(debugKey, debugInterpolation);
+    debug(debugKey, interpolationData);
   }
 }
 
@@ -25,13 +25,13 @@ export function makeTypedLogger<T extends readonly string[]>(
   return (
     key: ValidateCallbackKeys,
     debugKey?: LangKey,
-    debugInterpolation?: { [key: string]: string | number }
-  ) => log<ValidateCallbackKeys>(key, callbacks, debugKey, debugInterpolation);
+    interpolationData?: InterpolationData
+  ) => log<ValidateCallbackKeys>(key, callbacks, debugKey, interpolationData);
 }
 
 export function debug(
   identifier: LangKey,
-  interpolation?: { [key: string]: string | number }
+  interpolationData?: InterpolationData
 ): void {
-  logger.debug(i18n(identifier, interpolation));
+  logger.debug(i18n(identifier, interpolationData));
 }


### PR DESCRIPTION
## Description and Context
Realized while swapping out more dependancies in the CLI that we weren't actually passing interpolation data into the log callback functions - this fixes that. 

## Who to Notify
@brandenrodgers 
