### PR TITLE
Fix callback key types

### DIFF
--- a/http/index.ts
+++ b/http/index.ts
@@ -162,7 +162,7 @@ async function deleteRequest<T>(
   return data;
 }
 
-const getRequestStreamCallbackKeys = ['onWrite'];
+const getRequestStreamCallbackKeys = ['onWrite'] as const;
 
 function createGetRequestStream(contentType: string) {
   return async (

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -16,7 +16,7 @@ type ZipData = {
   tmpDir: string;
 };
 
-const archiveCallbackKeys = ['init', 'copy'];
+const archiveCallbackKeys = ['init', 'copy'] as const;
 
 async function extractZip(
   name: string,

--- a/lib/cms/functions.ts
+++ b/lib/cms/functions.ts
@@ -11,6 +11,14 @@ import { LogCallbacksArg } from '../../types/LogCallbacks';
 
 const i18nKey = 'lib.cms.functions';
 
+const createFunctionCallbackKeys = [
+  'destPathAlreadyExists',
+  'createdDest',
+  'createdFunctionFile',
+  'createdConfigFile',
+  'success',
+] as const;
+
 type Config = {
   runtime: string;
   version: string;
@@ -145,14 +153,6 @@ type FunctionInfo = {
 type FunctionOptions = {
   allowExistingFile?: boolean;
 };
-
-const createFunctionCallbackKeys = [
-  'destPathAlreadyExists',
-  'createdDest',
-  'createdFunctionFile',
-  'createdConfigFile',
-  'success',
-];
 
 export async function createFunction(
   functionInfo: FunctionInfo,

--- a/lib/cms/modules.ts
+++ b/lib/cms/modules.ts
@@ -15,6 +15,8 @@ import { PathInput } from '../../types/Modules';
 
 const i18nKey = 'lib.cms.modules';
 
+const createModuleCallbackKeys = ['creatingPath', 'creatingModule'] as const;
+
 // Ids for testing
 export const ValidationIds = {
   SRC_REQUIRED: 'SRC_REQUIRED',
@@ -107,8 +109,6 @@ type ModuleDefinition = {
   moduleLabel: string;
   global: boolean;
 };
-
-const createModuleCallbackKeys = ['creatingPath', 'creatingModule'] as const;
 
 export async function createModule(
   moduleDefinition: ModuleDefinition,

--- a/lib/cms/templates.ts
+++ b/lib/cms/templates.ts
@@ -7,6 +7,8 @@ import { LogCallbacksArg } from '../../types/LogCallbacks';
 
 const i18nKey = 'lib.cms.templates';
 
+const templatesCallbackKeys = ['creatingFile'] as const;
+
 // Matches the .html file extension, excluding module.html
 const TEMPLATE_EXTENSION_REGEX = new RegExp(/(?<!module)\.html$/);
 
@@ -49,8 +51,6 @@ const ASSET_PATHS = {
   'search-template': 'templates/search-template.html',
   section: 'templates/section.html',
 } as const;
-
-const templatesCallbackKeys = ['creatingFile'];
 
 export async function createTemplate(
   name: string,

--- a/lib/cms/uploadFolder.ts
+++ b/lib/cms/uploadFolder.ts
@@ -25,6 +25,8 @@ import { Mode } from '../../types/Files';
 
 const i18nKey = 'lib.cms.uploadFolder';
 
+const uploadFolderCallbackKeys = ['success'] as const;
+
 const queue = new PQueue({
   concurrency: 10,
 });
@@ -116,8 +118,6 @@ export async function getFilesByType(
   }
   return [filePathsByType, fieldsJsObjects];
 }
-
-const uploadFolderCallbackKeys = ['success'];
 
 export async function uploadFolder(
   accountId: number,

--- a/lib/fileManager.ts
+++ b/lib/fileManager.ts
@@ -36,14 +36,14 @@ type SimplifiedFolder = Partial<Folder> & Pick<Folder, 'id' | 'name'>;
 
 const i18nKey = 'lib.fileManager';
 
-const uploadCallbackKeys = ['uploadSuccess'];
+const uploadCallbackKeys = ['uploadSuccess'] as const;
 const downloadCallbackKeys = [
   'skippedExisting',
   'fetchFolderStarted',
   'fetchFolderSuccess',
   'fetchFileStarted',
   'fetchFileSuccess',
-];
+] as const;
 
 export async function uploadFolder(
   accountId: number,

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -31,6 +31,14 @@ import { makeTypedLogger } from '../utils/logger';
 
 const i18nKey = 'lib.fileMapper';
 
+const filemapperCallbackKeys = [
+  'skippedExisting',
+  'wroteFolder',
+  'completedFetch',
+  'folderFetch',
+  'completedFolderFetch',
+] as const;
+
 const queue = new PQueue({
   concurrency: 10,
 });
@@ -186,8 +194,6 @@ async function skipExisting(
   }
   return false;
 }
-
-const filemapperCallbackKeys = ['skippedExisting', 'wroteFolder'];
 
 async function fetchAndWriteFileStream(
   accountId: number,

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -18,6 +18,8 @@ import {
 
 const i18nKey = 'lib.github';
 
+const cloneGithubRepoCallbackKeys = ['success'] as const;
+
 type RepoPath = `${string}/${string}`;
 
 export async function fetchFileFromRepository(
@@ -113,8 +115,6 @@ type CloneGithubRepoOptions = {
   tag?: string; // Repo tag
   sourceDir?: string; // The directory within the downloaded repo to write after extraction
 };
-
-const cloneGithubRepoCallbackKeys = ['success'];
 
 export async function cloneGithubRepo(
   repoPath: RepoPath,

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -11,6 +11,8 @@ import { updateAccountConfig, writeConfig } from '../config';
 
 const i18nKey = 'lib.oauth';
 
+const addOauthToAccountConfigCallbackKeys = ['init', 'success'] as const;
+
 const oauthManagers = new Map<number, OAuth2Manager>();
 
 function writeOauthTokenInfo(accountConfig: FlatAccountFields): void {
@@ -36,8 +38,6 @@ export function getOauthManager(
   }
   return oauthManagers.get(accountId);
 }
-
-const addOauthToAccountConfigCallbackKeys = ['init', 'success'];
 
 export function addOauthToAccountConfig(
   oauth: OAuth2Manager,


### PR DESCRIPTION
## Description and Context
A few callback keys were not assigned `as const`, which makes it easier to make type mistakes when passing keys into a logger. This fixes that + also moves all keys to the top of files, which I have found makes it a little less cumbersome to find which keys you need to pass in from the CLI

## Who to Notify
@brandenrodgers 
