### PR TITLE
Fix axios formdata requests

### DIFF
--- a/api/fileManager.ts
+++ b/api/fileManager.ts
@@ -36,7 +36,8 @@ export async function uploadFile(
 
   return http.post(accountId, {
     url: `${FILE_MANAGER_V3_API_PATH}/files/upload`,
-    formData,
+    data: formData,
+    headers: { 'Content-Type': 'multipart/form-data' },
   });
 }
 

--- a/api/fileMapper.ts
+++ b/api/fileMapper.ts
@@ -49,9 +49,10 @@ export async function upload(
 ): Promise<void> {
   return http.post<void>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/upload/${encodeURIComponent(dest)}`,
-    formData: {
+    data: {
       file: fs.createReadStream(path.resolve(getCwd(), src)),
     },
+    headers: { 'Content-Type': 'multipart/form-data' },
     ...options,
   });
 }

--- a/api/projects.ts
+++ b/api/projects.ts
@@ -56,7 +56,8 @@ export async function uploadProject(
   return http.post(accountId, {
     url: `${PROJECTS_API_PATH}/upload/${encodeURIComponent(projectName)}`,
     timeout: 60000,
-    formData,
+    data: formData,
+    headers: { 'Content-Type': 'multipart/form-data' },
   });
 }
 

--- a/types/Http.ts
+++ b/types/Http.ts
@@ -26,7 +26,6 @@ export type FormData = {
 
 export type HttpOptions = AxiosConfigOptions & {
   query?: QueryParams;
-  formData?: FormData;
   timeout?: number;
   encoding?: string | null;
   headers?: { [header: string]: string | string[] | undefined };


### PR DESCRIPTION
## Description and Context
Turns out there is another slight discrepancy between `axios` and `request`, this time, when it comes to posting `formData`. This updates all places where `formData` is use to use the proper `axios` api

## Who to Notify
@brandenrodgers 
