### PR TITLE
Fix github download logic to accept arrays

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -146,7 +146,11 @@ async function fetchGitHubRepoContentFromDownloadUrl(
   downloadUrl: string
 ): Promise<void> {
   const resp = await fetchRepoFileByDownloadUrl(downloadUrl);
-  fs.writeFileSync(dest, resp.data, 'utf8');
+  const fileContents =
+    typeof resp.data === 'string'
+      ? resp.data
+      : JSON.stringify(resp.data, null, 2);
+  fs.outputFileSync(dest, fileContents, 'utf8');
 }
 
 // Writes files from a public repository to the destination folder

--- a/types/Utils.ts
+++ b/types/Utils.ts
@@ -9,5 +9,5 @@ type Join<K, P> = K extends string | number
 export type Leaves<T> = [10] extends [never]
   ? never
   : T extends object
-  ? { [K in keyof T]-?: Join<K, Leaves<T[K]>> }[keyof T]
-  : '';
+    ? { [K in keyof T]-?: Join<K, Leaves<T[K]>> }[keyof T]
+    : '';


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This fixes this error:
`[ERROR] A Error has occurred. TypeError: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Array`

It would get thrown when attempting to download a module using `hs create module`. The issue happens when it gets to [fields.json](https://github.com/HubSpot/cms-sample-assets/blob/main/modules/Sample.module/fields.json), which is an array.

I need this for: https://github.com/HubSpot/hubspot-cli/pull/977
## Screenshots
<!-- Provide images of the before and after functionality -->

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify
<!-- /cc those you wish to know about the PR -->
