### PR TITLE
try fixing GH action

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "include": [
     "api",

--- a/types/Utils.ts
+++ b/types/Utils.ts
@@ -9,5 +9,5 @@ type Join<K, P> = K extends string | number
 export type Leaves<T> = [10] extends [never]
   ? never
   : T extends object
-    ? { [K in keyof T]-?: Join<K, Leaves<T[K]>> }[keyof T]
-    : '';
+  ? { [K in keyof T]-?: Join<K, Leaves<T[K]>> }[keyof T]
+  : '';


### PR DESCRIPTION
## Description and Context
For some reason, the gh build action started failing a few days ago. Not sure why, since we didn't change anything that seems like it would have affected it (may have been a patch update to a dependancy).

`skipLibCheck` tells the typescript compiler to ignore errors coming from declaration files, and one of the intended uses is to silence errors within dependancies. Since we don't have any of our own declaration files in local-dev-lib, I don't think there will be any drawbacks to using this option. Some more info here: https://www.testim.io/blog/typescript-skiplibcheck/

Might be worth checking in the future if we can remove it.

## Who to Notify
@brandenrodgers 
