### PR TITLE
[Option 1] Fix api error handling

### DIFF
--- a/api/projects.ts
+++ b/api/projects.ts
@@ -30,12 +30,16 @@ export async function createProject(
   accountId: number,
   name: string
 ): Promise<Project> {
-  return http.post(accountId, {
-    url: PROJECTS_API_PATH,
-    data: {
-      name,
+  return http.post(
+    accountId,
+    {
+      url: PROJECTS_API_PATH,
+      data: {
+        name,
+      },
     },
-  });
+    { projectName: name }
+  );
 }
 
 export async function uploadProject(
@@ -53,21 +57,29 @@ export async function uploadProject(
     formData.platformVersion = platformVersion;
   }
 
-  return http.post(accountId, {
-    url: `${PROJECTS_API_PATH}/upload/${encodeURIComponent(projectName)}`,
-    timeout: 60000,
-    data: formData,
-    headers: { 'Content-Type': 'multipart/form-data' },
-  });
+  return http.post(
+    accountId,
+    {
+      url: `${PROJECTS_API_PATH}/upload/${encodeURIComponent(projectName)}`,
+      timeout: 60000,
+      data: formData,
+      headers: { 'Content-Type': 'multipart/form-data' },
+    },
+    { projectName }
+  );
 }
 
 export async function fetchProject(
   accountId: number,
   projectName: string
 ): Promise<Project> {
-  return http.get(accountId, {
-    url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
-  });
+  return http.get(
+    accountId,
+    {
+      url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
+    },
+    { projectName }
+  );
 }
 
 export async function downloadProject(
@@ -75,22 +87,33 @@ export async function downloadProject(
   projectName: string,
   buildId: number
 ): Promise<Buffer> {
-  return http.get(accountId, {
-    url: `${PROJECTS_API_PATH}/${encodeURIComponent(
-      projectName
-    )}/builds/${buildId}/archive-full`,
-    encoding: null,
-    headers: { accept: 'application/zip', 'Content-Type': 'application/json' },
-  });
+  return http.get(
+    accountId,
+    {
+      url: `${PROJECTS_API_PATH}/${encodeURIComponent(
+        projectName
+      )}/builds/${buildId}/archive-full`,
+      encoding: null,
+      headers: {
+        accept: 'application/zip',
+        'Content-Type': 'application/json',
+      },
+    },
+    { projectName }
+  );
 }
 
 export async function deleteProject(
   accountId: number,
   projectName: string
 ): Promise<void> {
-  return http.delete(accountId, {
-    url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
-  });
+  return http.delete(
+    accountId,
+    {
+      url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
+    },
+    { projectName }
+  );
 }
 
 type FetchPlatformVersionResponse = {
@@ -111,10 +134,14 @@ export async function fetchProjectBuilds(
   projectName: string,
   query: QueryParams
 ): Promise<FetchProjectBuildsResponse> {
-  return http.get(accountId, {
-    url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/builds`,
-    query,
-  });
+  return http.get(
+    accountId,
+    {
+      url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/builds`,
+      query,
+    },
+    { projectName }
+  );
 }
 
 export async function getBuildStatus(
@@ -122,11 +149,15 @@ export async function getBuildStatus(
   projectName: string,
   buildId: number
 ): Promise<Build> {
-  return http.get(accountId, {
-    url: `${PROJECTS_API_PATH}/${encodeURIComponent(
-      projectName
-    )}/builds/${buildId}/status`,
-  });
+  return http.get(
+    accountId,
+    {
+      url: `${PROJECTS_API_PATH}/${encodeURIComponent(
+        projectName
+      )}/builds/${buildId}/status`,
+    },
+    { projectName }
+  );
 }
 
 export async function getBuildStructure(
@@ -134,11 +165,15 @@ export async function getBuildStructure(
   projectName: string,
   buildId: number
 ): Promise<ComponentStructureResponse> {
-  return http.get(accountId, {
-    url: `dfs/v1/builds/by-project-name/${encodeURIComponent(
-      projectName
-    )}/builds/${buildId}/structure`,
-  });
+  return http.get(
+    accountId,
+    {
+      url: `dfs/v1/builds/by-project-name/${encodeURIComponent(
+        projectName
+      )}/builds/${buildId}/structure`,
+    },
+    { projectName }
+  );
 }
 
 export async function deployProject(
@@ -146,13 +181,17 @@ export async function deployProject(
   projectName: string,
   buildId: number
 ): Promise<ProjectDeployResponse> {
-  return http.post(accountId, {
-    url: `${PROJECTS_DEPLOY_API_PATH}/deploys/queue/async`,
-    data: {
-      projectName,
-      buildId,
+  return http.post(
+    accountId,
+    {
+      url: `${PROJECTS_DEPLOY_API_PATH}/deploys/queue/async`,
+      data: {
+        projectName,
+        buildId,
+      },
     },
-  });
+    { projectName }
+  );
 }
 
 export async function getDeployStatus(
@@ -160,11 +199,15 @@ export async function getDeployStatus(
   projectName: string,
   deployId: number
 ): Promise<Deploy> {
-  return http.get(accountId, {
-    url: `${PROJECTS_DEPLOY_API_PATH}/deploy-status/projects/${encodeURIComponent(
-      projectName
-    )}/deploys/${deployId}`,
-  });
+  return http.get(
+    accountId,
+    {
+      url: `${PROJECTS_DEPLOY_API_PATH}/deploy-status/projects/${encodeURIComponent(
+        projectName
+      )}/deploys/${deployId}`,
+    },
+    { projectName }
+  );
 }
 
 export async function getDeployStructure(
@@ -172,20 +215,28 @@ export async function getDeployStructure(
   projectName: string,
   deployId: number
 ): Promise<ComponentStructureResponse> {
-  return http.get(accountId, {
-    url: `${PROJECTS_DEPLOY_API_PATH}/deploys/by-project-name/${encodeURIComponent(
-      projectName
-    )}/deploys/${deployId}/structure`,
-  });
+  return http.get(
+    accountId,
+    {
+      url: `${PROJECTS_DEPLOY_API_PATH}/deploys/by-project-name/${encodeURIComponent(
+        projectName
+      )}/deploys/${deployId}/structure`,
+    },
+    { projectName }
+  );
 }
 
 export async function fetchProjectSettings(
   accountId: number,
   projectName: string
 ): Promise<ProjectSettings> {
-  return http.get(accountId, {
-    url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/settings`,
-  });
+  return http.get(
+    accountId,
+    {
+      url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/settings`,
+    },
+    { projectName }
+  );
 }
 
 export async function fetchDeployComponentsMetadata(
@@ -201,9 +252,13 @@ export async function cancelStagedBuild(
   accountId: number,
   projectName: string
 ): Promise<void> {
-  return http.post(accountId, {
-    url: `${PROJECTS_API_PATH}/${encodeURIComponent(
-      projectName
-    )}/builds/staged/cancel`,
-  });
+  return http.post(
+    accountId,
+    {
+      url: `${PROJECTS_API_PATH}/${encodeURIComponent(
+        projectName
+      )}/builds/staged/cancel`,
+    },
+    { projectName }
+  );
 }

--- a/api/secrets.ts
+++ b/api/secrets.ts
@@ -11,13 +11,17 @@ export async function addSecret(
   key: string,
   value: string
 ): Promise<void> {
-  return http.post(accountId, {
-    url: SECRETS_API_PATH,
-    data: {
-      key,
-      secret: value,
+  return http.post(
+    accountId,
+    {
+      url: SECRETS_API_PATH,
+      data: {
+        key,
+        secret: value,
+      },
     },
-  });
+    { request: 'add secret' }
+  );
 }
 
 export async function updateSecret(
@@ -25,28 +29,40 @@ export async function updateSecret(
   key: string,
   value: string
 ): Promise<void> {
-  return http.put(accountId, {
-    url: SECRETS_API_PATH,
-    data: {
-      key,
-      secret: value,
+  return http.put(
+    accountId,
+    {
+      url: SECRETS_API_PATH,
+      data: {
+        key,
+        secret: value,
+      },
     },
-  });
+    { request: 'update secret' }
+  );
 }
 
 export async function deleteSecret(
   accountId: number,
   key: string
 ): Promise<void> {
-  return http.delete(accountId, {
-    url: `${SECRETS_API_PATH}/${key}`,
-  });
+  return http.delete(
+    accountId,
+    {
+      url: `${SECRETS_API_PATH}/${key}`,
+    },
+    { request: 'delete secret' }
+  );
 }
 
 export async function fetchSecrets(
   accountId: number
 ): Promise<FetchSecretsResponse> {
-  return http.get(accountId, {
-    url: `${SECRETS_API_PATH}`,
-  });
+  return http.get(
+    accountId,
+    {
+      url: `${SECRETS_API_PATH}`,
+    },
+    { request: 'fetch secret' }
+  );
 }


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
We're trying to find a pattern that will enable us to throw api errors when calls are made from within local-dev-lib, and log api errors when calls are made from within the CLI.

Currently, there is duplicated code between local-dev-lib and the CLI:
- [logApiStatusCodeError](https://github.com/HubSpot/hubspot-cli/blob/master/packages/cli/lib/errorHandlers/apiErrors.js#L154) in the CLI handles the logging of api errors when it calls api modules exported from cli-lib (soon to be local-dev-lib)
- [throwAxiosErrorWithContext](https://github.com/HubSpot/hubspot-local-dev-lib/blob/main/errors/apiErrors.ts#L100) in local-dev-lib handles throwing api errors 

Both of these utils use the same logic to make sense of the api errors and format them into something more useful. We need a pattern that can DRY things up and make it simpler to manage errors in both projects.
 
## [Option 1] Wrap every local-dev-lib/http/index.ts export in a try/catch
In this option we put a wrapper ([axiosRequestWithErrorHandling](https://github.com/HubSpot/hubspot-local-dev-lib/compare/br-wrap-api-calls?expand=1#diff-532eb1339ff89fe8def2236e4adf5e934cded29294493828f6df77d8e1df7f8bR120)) around every axios call made in the http file. This makes sure that all of the request errors get caught within local-dev-lib, and we re-throw them using [throwApiError](https://github.com/HubSpot/hubspot-local-dev-lib/blob/main/errors/apiErrors.ts#L209).

This would manifest itself in the CLI like this:
```js
import { someRequest } from '@hubspot/local-dev-lib/api/someFile';

try {
 await someRequest();
} catch (error) {
  // Original error now lives in error.cause
  if (error.cause.statusCode = 404) {
    logger.error('This was a 404 error');
  } else {
    // Now we use logErrorInstance since the error has already been processed in local-dev-lib
    logErrorInstance(error)
  }
}
```

### Pros
- DRY-er than what we have today. We would be able to remove `logApiStatusCodeError` from the CLI entirely since every api error will be pre-processed in local-dev-lib.
- Easy to log the errors coming from api calls in the CLI. We don't need to construct our own api context objects anymore like we currently have to do [here](https://github.com/HubSpot/hubspot-cli/blob/00c922db7661e0d02bffa94ccfe2174991e8e4a4/packages/cli/commands/remove.js#L41).
- Lets us remove some try/catch blocks in local-dev-lib because all of our api calls will already be wrapped by a handler that will safely throw formatted errors. (note: I didn't do this in the PR)
- One the usage end, this solution is very concise. 

### Cons
- This axios wrapper is adding another layer of abstraction around the thrown api errors. The original errors now live inside `error.cause`. This may not be obvious for someone new or someone trying to debug request failures.
- This does not account for the scenario where the CLI wants to make its own api requests (not sure if this use case exists, but consider an area where we may want to make un-authed requests and still handle the errors gracefully)
- It requires all of the api modules in local-dev-lib to pass an additional `context` argument that can be used in `throwApiError`
- This makes the assumption that all of the context required for the error will be passed to the api module, which may not always be the case.
- There's more overlap between error handling utils in the CLI and in local-dev-lib ([logFileSystemErrorInstance](https://github.com/HubSpot/hubspot-cli/blob/00c922db7661e0d02bffa94ccfe2174991e8e4a4/packages/cli/lib/errorHandlers/fileSystemErrors.js#L29) and [throwFileSystemError](https://github.com/HubSpot/hubspot-local-dev-lib/blob/main/errors/fileSystemErrors.ts#L10)). Our fixes for these issues will look different than our solution here, which means that we will be stuck with multiple error handling patterns.
- The level of abstraction around our api calls is getting a little deeper. This means it will be harder and harder to make new changes and/or modify existing functionality. The trade-off of doing more "magic" here is that the logic is harder to follow and things get a bit more rigid.