### PR TITLE
Fix hubdb API bug

### DIFF
--- a/api/hubdb.ts
+++ b/api/hubdb.ts
@@ -46,6 +46,9 @@ export async function publishTable(
 ): Promise<Table> {
   return http.post(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/draft/publish`,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   });
 }
 


### PR DESCRIPTION
## Description and Context
The `hubdb` publish endpoint was getting hit with the incorrect `Content-Type` (`axios` didn't assume `application/json` because there was no request body). This was causing `415` errors even with correctly formatted hubdb tables

## Who to Notify
@brandenrodgers @kemmerle 
