### PR TITLE
Account type string names

### DIFF
--- a/constants/config.ts
+++ b/constants/config.ts
@@ -16,9 +16,9 @@ export const HUBSPOT_ACCOUNT_TYPES = {
 } as const;
 
 export const HUBSPOT_ACCOUNT_TYPE_STRINGS = {
-  DEVELOPMENT_SANDBOX: i18n('lib.sandboxes.accountType.developmentSandbox'),
-  STANDARD_SANDBOX: i18n('lib.sandboxes.accountType.standardSandbox'),
-  DEVELOPER_TEST: i18n('lib.sandboxes.accountType.developerTest'),
-  APP_DEVELOPER: i18n('lib.sandboxes.accountType.appDeveloper'),
-  STANDARD: i18n('lib.sandboxes.accountType.standard'),
+  DEVELOPMENT_SANDBOX: i18n('lib.accountTypes.developmentSandbox'),
+  STANDARD_SANDBOX: i18n('lib.accountTypes.standardSandbox'),
+  DEVELOPER_TEST: i18n('lib.accountTypes.developerTest'),
+  APP_DEVELOPER: i18n('lib.accountTypes.appDeveloper'),
+  STANDARD: i18n('lib.accountTypes.standard'),
 } as const;

--- a/lang/en.json
+++ b/lang/en.json
@@ -239,14 +239,12 @@
         "incompleteFetch": "Not all files in folder \"{{ src }}\" were successfully fetched.  Re-run the last command to try again"
       }
     },
-    "sandboxes": {
-      "accountType": {
-        "developmentSandbox": "development sandbox",
-        "standardSandbox": "standard sandbox",
-        "developerTest": "developer test account",
-        "appDeveloper": "app developer account",
-        "standard": "production account"
-      }
+    "accountTypes": {
+      "developmentSandbox": "development sandbox",
+      "standardSandbox": "standard sandbox",
+      "developerTest": "developer test account",
+      "appDeveloper": "app developer account",
+      "standard": "production account"
     }
   },
   "config": {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Adds string names for all the new account types we support in the CLI. This is used in hubspot-cli for piecing together account names in messages + error message bodies. 

Related CLI PR: https://github.com/HubSpot/hubspot-cli/pull/1005#pullrequestreview-1886193313

## Screenshots
<!-- Provide images of the before and after functionality -->
n/a

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
I'll include usage links once I post the other related PR in hubspot-cli

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@shannon-lichtenwalter 
