### PR TITLE
Fix import that blocks port to HubSpot CLI (See corresponding PR in hubspot-cli)

### DIFF
--- a/lib/cms/processFieldsJs.ts
+++ b/lib/cms/processFieldsJs.ts
@@ -3,11 +3,11 @@
 import path from 'path';
 import fs from 'fs';
 import semver from 'semver';
+import { pathToFileURL } from 'url';
 import { getExt } from '../path';
 import { throwError, throwErrorWithMessage } from '../../errors/standardErrors';
 import { FieldsJs } from './handleFieldsJS';
 import { i18n } from '../../utils/lang';
-import { pathToFileURL } from 'url';
 
 const i18nKey = 'lib.cms.processFieldsJs';
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

See corresponding PR for full testing instructions: https://github.com/HubSpot/hubspot-cli/pull/1008

While porting the `handleFieldsJS.js` import to the `hubspot-cli`, @camden11 and I discovered multiple bugs when using import in the `processFieldsJs.js` file. I will list them below:

1) To fix a TS type issue in a dynamic import statement in the `processFieldsJs.js` file, we had changed `pathToFileURL(filePath)` to `pathToFileURL(filePath).toString()`. That was initially breaking the import statement.
2) Once we fixed that issue, the node cjs loader threw an error. It has a [check](https://github.com/nodejs/node/blob/v21.6.1/lib/internal/modules/cjs/loader.js#L1230) to ensure that id is a string in require statements.
3) TypeScript then transformed our import statement into a require statement, which then failed this check (@brandenrodgers discovered this).

We've now resolved this by writing the import statement with `new Function`. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 
