### PR TITLE
Update naming of JSR -> React

### DIFF
--- a/lib/cms/modules.ts
+++ b/lib/cms/modules.ts
@@ -112,13 +112,13 @@ export async function validateSrcAndDestPaths(
 const MODULE_STRING_TRANSFORMATIONS = [
   {
     regex: /\/\* import global styles \*\//g,
-    string: 'import "./global-samplejsr.css";',
+    string: 'import "./global-sample-react-module.css";',
     fallback: '',
   },
   {
     regex: /\/\* Default config \*\//g,
     string:
-      'export const defaultModuleConfig = { \n  moduleName: "sample_jsr", \n  version: 0, \n};',
+      'export const defaultModuleConfig = { \n  moduleName: "sample_react-module", \n  version: 0, \n};',
     fallback: '',
   },
 ];
@@ -249,7 +249,7 @@ export async function createModule(
           return false;
         }
         return true;
-      case 'global-samplejsr.css':
+      case 'global-sample-react-module.css':
       case 'stories':
       case 'tests':
         if (getInternalVersion) {


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
We want to ensure we use the "React module" naming for public facing content as opposed to our internal acronym, JSR. This is just a text update, and has [a sibling PR in cms-sample-assets](https://github.com/HubSpot/cms-sample-assets/pull/7) where this code pulls from.
