### PR TITLE
Add FOLDER_DOT_EXTENSIONS constant

### DIFF
--- a/constants/extensions.ts
+++ b/constants/extensions.ts
@@ -22,3 +22,4 @@ export const ALLOWED_EXTENSIONS = new Set([
 export const HUBL_EXTENSIONS = new Set(['css', 'html', 'js']);
 export const MODULE_EXTENSION = 'module';
 export const FUNCTIONS_EXTENSION = 'functions';
+export const FOLDER_DOT_EXTENSIONS = [FUNCTIONS_EXTENSION, MODULE_EXTENSION];


### PR DESCRIPTION
## Description and Context
This constant isn't used in `local-dev-lib`, but is used by both the CLI and the VSCode extension, so adding it here

## Who to Notify
@brandenrodgers @kemmerle 
