### PR TITLE
Downgrade debounce to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "chokidar": "^3.5.3",
     "content-disposition": "^0.5.4",
     "cors": "^2.8.5",
-    "debounce": "^2.0.0",
+    "debounce": "^1.2.0",
     "express": "^4.18.2",
     "extract-zip": "^2.0.1",
     "findup-sync": "^5.0.0",


### PR DESCRIPTION
## Description and Context
Debounce `2.0.0` requires node 18, but local-dev-lib only requires 16. Downgrading `debounce` to `1.2.0`, the same thats currently used by cli-lib

## Who to Notify
@brandenrodgers @kemmerle @jsines 
