### PR TITLE
Fix fetchRepoAsZip

### DIFF
--- a/api/github.ts
+++ b/api/github.ts
@@ -39,6 +39,7 @@ export async function fetchRepoAsZip(
   zipUrl: string
 ): Promise<AxiosResponse<Buffer>> {
   return axios.get<Buffer>(zipUrl, {
+    responseType: 'arraybuffer',
     headers: { ...DEFAULT_USER_AGENT_HEADERS, ...GITHUB_AUTH_HEADERS },
   });
 }


### PR DESCRIPTION
## Description and Context
Another bug switching from `request` to `axios`. This was causing the downloaded zip files to be corrupted

## Who to Notify
@kemmerle @brandenrodgers 
