### PR TITLE
Fix isApiUploadValidationError

### DIFF
--- a/errors/apiErrors.ts
+++ b/errors/apiErrors.ts
@@ -60,7 +60,7 @@ export function isTimeoutError(err: Error | AxiosError): boolean {
 export function isApiUploadValidationError(err: AxiosError<any>): boolean {
   return (
     err.isAxiosError &&
-    err.status === 400 &&
+    (err.status === 400 || err.response?.status === 400) &&
     !!err.response &&
     !!(err.response?.data?.message || !!err.response?.data?.errors)
   );


### PR DESCRIPTION
## Description and Context
AxiosErrors don't reliably have `status` attached to the top level error, so this is necessary to make sure we catch every validation error

## Who to Notify
@brandenrodgers @kemmerle
