### PR TITLE
Add endpoints for project warn logs (Sister PR in hubspot-cli) 

### DIFF
--- a/api/projects.ts
+++ b/api/projects.ts
@@ -13,7 +13,7 @@ import {
   ComponentStructureResponse,
 } from '../types/ComponentStructure';
 import { Deploy, ProjectDeployResponse } from '../types/Deploy';
-import { Log } from '../types/Log';
+import { ProjectLog } from '../types/ProjectLog';
 
 const PROJECTS_API_PATH = 'dfs/v1/projects';
 const PROJECTS_DEPLOY_API_PATH = 'dfs/deploy/v1';
@@ -273,7 +273,7 @@ export async function fetchBuildWarnLogs(
   accountId: number,
   projectName: string,
   buildId: number
-): Promise<{ logs: Array<Log> }> {
+): Promise<{ logs: Array<ProjectLog> }> {
   return http.get(accountId, {
     url: `${PROJECTS_LOGS_API_PATH}/logs/projects/${projectName}/builds/${buildId}/combined/warn`,
   });
@@ -283,7 +283,7 @@ export async function fetchDeployWarnLogs(
   accountId: number,
   projectName: string,
   deployId: number
-): Promise<{ logs: Array<Log> }> {
+): Promise<{ logs: Array<ProjectLog> }> {
   return http.get(accountId, {
     url: `${PROJECTS_LOGS_API_PATH}/logs/projects/${projectName}/deploys/${deployId}/combined/warn`,
   });

--- a/types/ProjectLog.ts
+++ b/types/ProjectLog.ts
@@ -1,4 +1,4 @@
-export type Log = {
+export type ProjectLog = {
   lineNumber: number;
   logLevel: string;
   message: string;


### PR DESCRIPTION
## Description and Context
@m-roll suggested that we show warning logs for successful build and deploys. He created new endpoints to return the logs, and I added those endpoints to local dev lib in this PR. In a [sister PR](https://github.com/HubSpot/hubspot-cli/pull/1031), I also added the logs to the upload and dev commands in the CLI. 

## Screenshots
<!-- Provide images of the before and after functionality -->

<img width="2560" alt="Screenshot 2024-04-08 at 2 30 43 PM" src="https://github.com/HubSpot/hubspot-local-dev-lib/assets/25392256/529d204f-73a8-42d1-bab2-3110ba07de3b">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @m-roll 
