### PR TITLE
Fix issue with generic errors being returned with gating errors

### DIFF
--- a/errors/__tests__/apiErrors.ts
+++ b/errors/__tests__/apiErrors.ts
@@ -231,7 +231,11 @@ describe('errors/apiErrors', () => {
       });
 
       it('generates a generic 400 api status code error', () => {
-        const error = newAxiosError({ status: 499 });
+        const error = newAxiosError({
+          response: {
+            status: 499,
+          },
+        });
         const axiosErrorWithContext = getAxiosErrorWithContext(error);
         expect(axiosErrorWithContext.message).toBe(
           'The request failed due to a client error.'
@@ -239,13 +243,21 @@ describe('errors/apiErrors', () => {
       });
 
       it('generates a 400 api status code error', () => {
-        const error = newAxiosError({ status: 400 });
+        const error = newAxiosError({
+          response: {
+            status: 400,
+          },
+        });
         const axiosErrorWithContext = getAxiosErrorWithContext(error);
         expect(axiosErrorWithContext.message).toBe('The request was bad.');
       });
 
       it('generates a 401 api status code error', () => {
-        const error = newAxiosError({ status: 401 });
+        const error = newAxiosError({
+          response: {
+            status: 401,
+          },
+        });
         const axiosErrorWithContext = getAxiosErrorWithContext(error);
         expect(axiosErrorWithContext.message).toBe(
           'The request was unauthorized.'
@@ -253,7 +265,11 @@ describe('errors/apiErrors', () => {
       });
 
       it('generates a 403 api status code error', () => {
-        const error = newAxiosError({ status: 403 });
+        const error = newAxiosError({
+          response: {
+            status: 403,
+          },
+        });
         const axiosErrorWithContext = getAxiosErrorWithContext(error);
         expect(axiosErrorWithContext.message).toBe(
           'The request was forbidden.'
@@ -261,7 +277,11 @@ describe('errors/apiErrors', () => {
       });
 
       it('generates a 404 api status code error', () => {
-        const error = newAxiosError({ status: 404 });
+        const error = newAxiosError({
+          response: {
+            status: 404,
+          },
+        });
         const axiosErrorWithContext = getAxiosErrorWithContext(error);
         expect(axiosErrorWithContext.message).toBe(
           'The request was not found.'
@@ -269,7 +289,11 @@ describe('errors/apiErrors', () => {
       });
 
       it('generates a 429 api status code error', () => {
-        const error = newAxiosError({ status: 429 });
+        const error = newAxiosError({
+          response: {
+            status: 429,
+          },
+        });
         const axiosErrorWithContext = getAxiosErrorWithContext(error);
         expect(axiosErrorWithContext.message).toBe(
           'The request surpassed the rate limit. Retry in one minute.'
@@ -277,7 +301,11 @@ describe('errors/apiErrors', () => {
       });
 
       it('generates a generic 500 api status code error', () => {
-        const error = newAxiosError({ status: 599 });
+        const error = newAxiosError({
+          response: {
+            status: 599,
+          },
+        });
         const axiosErrorWithContext = getAxiosErrorWithContext(error);
         expect(axiosErrorWithContext.message).toContain(
           'The request failed due to a server error.'
@@ -285,7 +313,11 @@ describe('errors/apiErrors', () => {
       });
 
       it('generates a 503 api status code error', () => {
-        const error = newAxiosError({ status: 503 });
+        const error = newAxiosError({
+          response: {
+            status: 503,
+          },
+        });
         const axiosErrorWithContext = getAxiosErrorWithContext(error);
         expect(axiosErrorWithContext.message).toContain(
           'The request could not be handled at this time.'

--- a/errors/apiErrors.ts
+++ b/errors/apiErrors.ts
@@ -1,4 +1,4 @@
-import { AxiosError } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import {
   GenericError,
   AxiosErrorContext,
@@ -130,7 +130,7 @@ export function getAxiosErrorWithContext(
   error: AxiosError<any>,
   context: AxiosErrorContext = {}
 ): Error {
-  const { status } = error;
+  const { status } = error.response as AxiosResponse;
   const method = error.config?.method as HttpMethod;
   const { projectName } = context;
 
@@ -163,8 +163,9 @@ export function getAxiosErrorWithContext(
       i18n(`${i18nKey}.unableToUpload`, { payload: context.payload })
     );
   }
-  const isProjectMissingScopeError = isMissingScopeError(error) && projectName;
-  const isProjectGatingError = isGatingError(error) && projectName;
+  const isProjectMissingScopeError =
+    isMissingScopeError(error) && !!projectName;
+  const isProjectGatingError = isGatingError(error) && !!projectName;
 
   switch (status) {
     case 400:

--- a/errors/apiErrors.ts
+++ b/errors/apiErrors.ts
@@ -1,4 +1,4 @@
-import { AxiosError, AxiosResponse } from 'axios';
+import { AxiosError } from 'axios';
 import {
   GenericError,
   AxiosErrorContext,
@@ -130,7 +130,10 @@ export function getAxiosErrorWithContext(
   error: AxiosError<any>,
   context: AxiosErrorContext = {}
 ): Error {
-  const { status } = error.response as AxiosResponse;
+  let status;
+  if (error.response) {
+    status = error.response.status;
+  }
   const method = error.config?.method as HttpMethod;
   const { projectName } = context;
 

--- a/errors/apiErrors.ts
+++ b/errors/apiErrors.ts
@@ -130,10 +130,7 @@ export function getAxiosErrorWithContext(
   error: AxiosError<any>,
   context: AxiosErrorContext = {}
 ): Error {
-  let status;
-  if (error.response) {
-    status = error.response.status;
-  }
+  const status = error.response?.status;
   const method = error.config?.method as HttpMethod;
   const { projectName } = context;
 


### PR DESCRIPTION
## Description and Context
During our latest bug bashes, folks were receiving generic errors while attempting the `hs project upload` command, particularly when their accounts had gating issues. 

With @joe-yeager's help (he gave me access to his account, so I could reproduce the error), I found that we were destructuring the error object incorrectly and therefore not passing the correct status code to the switch statement in the `getAxiosErrorWithContext` function. 

## Screenshots
<!-- Provide images of the before and after functionality -->

BEFORE (Yucky, generic error):

<img width="2377" alt="Screenshot 2024-04-17 at 4 56 53 PM" src="https://github.com/HubSpot/hubspot-local-dev-lib/assets/25392256/31bccd9d-2993-483e-a39e-58857a973d4f">

AFTER (Beautiful, descriptive error):

<img width="2557" alt="Screenshot 2024-04-17 at 4 57 25 PM" src="https://github.com/HubSpot/hubspot-local-dev-lib/assets/25392256/4baac6ce-c133-4d39-a7fa-61198d5f02a1">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address any feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->

@joe-yeager @brandenrodgers 