### PR TITLE
Update sandbox types, replace polling API endpoint

### DIFF
--- a/api/sandboxSync.ts
+++ b/api/sandboxSync.ts
@@ -1,9 +1,9 @@
 import http from '../http';
 import {
   InitiateSyncResponse,
-  Task,
-  SyncTask,
   FetchTypesResponse,
+  TaskRequestData,
+  SyncTaskStatusType,
 } from '../types/Sandbox';
 import { SANDBOX_TIMEOUT } from '../constants/api';
 const SANDBOXES_SYNC_API_PATH = 'sandboxes-sync/v1';
@@ -11,7 +11,7 @@ const SANDBOXES_SYNC_API_PATH = 'sandboxes-sync/v1';
 export async function initiateSync(
   fromHubId: number,
   toHubId: number,
-  tasks: Array<SyncTask>,
+  tasks: Array<TaskRequestData>,
   sandboxHubId: number
 ): Promise<InitiateSyncResponse> {
   return http.post(fromHubId, {
@@ -30,9 +30,9 @@ export async function initiateSync(
 export async function fetchTaskStatus(
   accountId: number,
   taskId: number
-): Promise<Task> {
+): Promise<SyncTaskStatusType> {
   return http.get(accountId, {
-    url: `${SANDBOXES_SYNC_API_PATH}/tasks/${taskId}`,
+    url: `${SANDBOXES_SYNC_API_PATH}/tasks/${taskId}/status`,
   });
 }
 

--- a/lib/sandboxes.ts
+++ b/lib/sandboxes.ts
@@ -12,8 +12,8 @@ import {
   InitiateSyncResponse,
   Sandbox,
   SandboxType,
-  SyncTask,
-  Task,
+  SyncTaskStatusType,
+  TaskRequestData,
   Usage,
 } from '../types/Sandbox';
 import { AxiosError } from 'axios';
@@ -69,7 +69,7 @@ export async function getSandboxUsageLimits(
 export async function initiateSync(
   fromHubId: number,
   toHubId: number,
-  tasks: Array<SyncTask>,
+  tasks: Array<TaskRequestData>,
   sandboxHubId: number
 ): Promise<InitiateSyncResponse> {
   try {
@@ -82,9 +82,10 @@ export async function initiateSync(
 export async function fetchTaskStatus(
   accountId: number,
   taskId: number
-): Promise<Task> {
+): Promise<SyncTaskStatusType> {
   try {
-    return await _fetchTaskStatus(accountId, taskId);
+    const result = await _fetchTaskStatus(accountId, taskId);
+    return result;
   } catch (err) {
     throwApiError(err as AxiosError);
   }

--- a/types/Sandbox.ts
+++ b/types/Sandbox.ts
@@ -49,14 +49,20 @@ type MutationError = {
   };
 };
 
-type TaskStatus = {
+export type SyncTaskStatusType = {
+  status: string;
+  result?: string;
+  tasks: Pick<CompositeSyncTask, 'type' | 'status'>[];
+};
+
+type SyncMutationData = {
   numRequests: number;
   numSuccesses: number;
   errors: Array<TaskError>;
   mutationErrors: Array<MutationError>;
 };
 
-export type Task = {
+export type CompositeSyncTask = {
   id: string;
   parentHubId: number;
   sandboxHubId: number;
@@ -73,11 +79,29 @@ export type Task = {
   startedAt: string;
   completedAt: string;
   error: MutationError;
-  creates: TaskStatus;
-  updates: TaskStatus;
-  deletes: TaskStatus;
+  creates: SyncMutationData;
+  updates: SyncMutationData;
+  deletes: SyncMutationData;
   diffSummary: string;
   portableKeys: Array<string>;
+};
+
+export type SyncTask = {
+  id: string;
+  parentHubId: number;
+  sandboxHubId: number;
+  fromHubId: number;
+  toHubId: number;
+  command: string;
+  status: string;
+  result: string;
+  sandboxType: string;
+  requestedAt: string;
+  requestedByUserId: number;
+  requestedByUser: User;
+  startedAt: string;
+  completedAt: string;
+  tasks: Array<CompositeSyncTask>;
 };
 
 export type Sandbox = {
@@ -92,23 +116,7 @@ export type Sandbox = {
   domain: string;
   createdByUser: User;
   updatedByUser?: User | null;
-  lastSync?: {
-    id: string;
-    parentHubId: number;
-    sandboxHubId: number;
-    fromHubId: number;
-    toHubId: number;
-    command: string;
-    status: string;
-    result: string;
-    sandboxType: string;
-    requestedAt: string;
-    requestedByUserId: number;
-    requestedByUser: User;
-    startedAt: string;
-    completedAt: string;
-    tasks: Array<Task>;
-  };
+  lastSync?: SyncTask;
   currentUserHasAccess?: boolean;
   currentUserHasSuperAdminAccess?: boolean;
   requestAccessFrom?: User | null;
@@ -137,7 +145,7 @@ export type SandboxUsageLimitsResponse = {
   usage: Usage;
 };
 
-export type SyncTask = {
+export type TaskRequestData = {
   type: string;
 };
 
@@ -145,19 +153,7 @@ export type InitiateSyncResponse = {
   links: {
     status: string;
   };
-  sync: {
-    id: string;
-    parentHubId: number;
-    sandboxHubId: number;
-    fromHubId: number;
-    toHubId: number;
-    command: string;
-    status: string;
-    sandboxType: string;
-    requestedAt: string;
-    requestedByUserId: number;
-    tasks: Array<Task>;
-  };
+  sync: SyncTask;
   id: string;
 };
 


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This PR replaces an endpoint that sandboxes was using to poll for sync updates with a much simpler and more performant one. No changes are needed in hubspot-cli as the data that [pollSyncTaskStatus](https://github.com/HubSpot/hubspot-cli/blob/main/packages/cli/lib/sandboxes.js#L265-L326) expects does not change with this endpoint swap. 

I've also gone ahead and cleaned up some types that were ported over in a slightly weird state. 

To run this locally, navigate to your local instance of `hubspot-local-dev-lib` and run `yarn run local-dev`. Then go into your local instance of `hubspot-cli` and run `yarn link @hubspot/local-dev-lib` to link the local version. You can now run `yarn hs sandbox sync` to verify that everything still works. There should be no changes to what is displayed. 

## Screenshots
<!-- Provide images of the before and after functionality -->
No changes to the polling UI, tested and is still same as before
<img width="1261" alt="Screenshot 2024-05-06 at 17 17 25" src="https://github.com/HubSpot/hubspot-local-dev-lib/assets/16788677/7403cd74-c362-4740-956d-f9a24bb5644e">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
n/a

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@shannon-lichtenwalter 

