### PR TITLE
Add code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,60 @@
+# HubSpot Local Dev Lib Code of Conduct
+
+## Our Pledge to you, our community of developers
+
+We pledge to make participation in this community a harassment-free experience for everyone regardless of age, body size, disability (visible or invisible), ethnicity, sexual characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards and Expectations
+
+At HubSpot, we don’t have pages of policies or procedures and instead have a three-word policy of “Use Good Judgement” (UGJ) and to always have HEART. We encourage our community to also UGJ and to share in the following core values of HubSpot:
+
+**Be Humble:** Nothing is perfect, especially when it comes to coding. Be self-aware and always be respectful. **Be Empathetic:** Don’t just be understanding of someone’s comments or questions, also act with compassion and respect for all. **Be Adaptable:** Be curious, ask questions, and always be ready to change. Be a life-long learner. **Be Remarkable:** Share your knowledge, provide resources for others to view, and don’t be afraid to be awesome. **Be Transparent:** Be open and honest with others, most importantly, yourself.
+
+### Examples of behavior that follows UGJ and HEART
+
+- Demonstrating empathy and kindness toward other people who are trying to learn
+- Being respectful of differing opinions, viewpoints, and levels of experience
+- Giving and gracefully accepting constructive criticism
+- Providing sources of information when providing feedback on code
+
+### Examples of unacceptable behavior
+
+- Trolling, insulting, or personally attacking another person's code, PR, or experience level
+- Publishing private information such as physical addresses, email information, credentials, or phone numbers of users
+- Posting of inappropriate language or imagery within code, comments, or PRs
+- Unsolicited and/or unrelated mentions or pings to members of the community
+- Commenting or publishing content for promotional purposes only
+- Other conduct that could reasonably be considered inappropriate in a professional setting
+
+### On the use of AI-generated solutions and content
+
+At HubSpot, if there’s one thing we love, it's technology. As generative AI tooling is advancing and iterating, many users are still getting accustomed to using such technology.
+
+The following are guidelines as they relate to the use of generative AI when submitting code:
+
+- You are responsible for what you post, make sure to review, to the best of your ability, what is posted before publishing and revise the content. You're remarkable and we want to hear from you.
+- Be Transparent: Just as our HEART value on transparency explains, be open and honest in your use of generative AI when posting.
+- It's important to specify which AI was used when generating your code as each AI might provide different results from the same prompt.
+- Do not just copy and paste AI content to answer questions, provide solutions, or give a false impression of your experience.
+
+Not following the guidelines above may, in some situations, result in a violation of this code of conduct. Please refer to the next section concerning violations and enforcement of this code of conduct.
+
+## Enforcement of our Code of Conduct
+
+HubSpot’s DPG Developer Tooling team is responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior or actions that violate this code of conduct.
+
+Actions we may take include but are not limited to:
+
+- Removing, editing, or rejecting commits, code, comments, issues, or other content contributions to this organization and its repositories.
+- Blocking (also known as Banning) a user's access to the organization or repository for either a certain length of time or indefinitely
+- Implementation of temporary interaction limits in response to incidents
+
+It’s important to understand that actions taken regarding violations may warrant additional disciplinary action that extends to other areas of HubSpot’s Community such as the HubSpot Developer Slack and HubSpot’s Community Forums.
+
+When these actions are taken, the reasoning for moderation-based decisions will be provided where applicable and when appropriate.
+
+Contacting a member of the HubSpot DPG Developer Tooling team, members of the HubSpot Organization and/or community via unsolicited mentions or pings is strongly discouraged and may be considered a violation of our code of conduct with regards to harassment.
+
+## Attribution
+
+This Code of Conduct is adapted from the [HubSpot Developer Relations Global Code of Conduct](https://github.com/hubspotdev/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -41,7 +41,7 @@ Not following the guidelines above may, in some situations, result in a violatio
 
 ## Enforcement of our Code of Conduct
 
-HubSpot’s Developer Relations and DPG Developer Tooling Teams, along with select members of the HubSpot Organization and community, are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior or actions that violate this code of conduct.
+HubSpot’s Developer Relations and Developer Teams, along with select members of the HubSpot Organization and community, are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior or actions that violate this code of conduct.
 
 Actions we may take include but are not limited to:
 
@@ -57,7 +57,7 @@ When these actions are taken, the reasoning for moderation-based decisions will 
 
 To report violations of this code of conduct, please fill in the following form located at the link below: [HubSpot Developer Community Code of Conduct Violation Reporting](https://form.asana.com/?k=p7aM0fpd3G4JGETDL_nYXg&d=8587152060687)
 
-Contacting a member of the HubSpot Developer Relations or the DPG Developer Tooling team, members of the HubSpot Organization and/or community via unsolicited mentions or pings is strongly discouraged and may be considered a violation of our code of conduct with regards to harassment.
+Contacting a member of the HubSpot Developer Relations or HubSpot Developer teams, members of the HubSpot Organization and/or community via unsolicited mentions or pings is strongly discouraged and may be considered a violation of our code of conduct with regards to harassment.
 
 ## Attribution
 

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -41,7 +41,7 @@ Not following the guidelines above may, in some situations, result in a violatio
 
 ## Enforcement of our Code of Conduct
 
-HubSpot’s DPG Developer Tooling team is responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior or actions that violate this code of conduct.
+HubSpot’s Developer Relations and DPG Developer Tooling Teams, along with select members of the HubSpot Organization and community, are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior or actions that violate this code of conduct.
 
 Actions we may take include but are not limited to:
 
@@ -53,7 +53,11 @@ It’s important to understand that actions taken regarding violations may warra
 
 When these actions are taken, the reasoning for moderation-based decisions will be provided where applicable and when appropriate.
 
-Contacting a member of the HubSpot DPG Developer Tooling team, members of the HubSpot Organization and/or community via unsolicited mentions or pings is strongly discouraged and may be considered a violation of our code of conduct with regards to harassment.
+## Reporting violations of the Code of Conduct
+
+To report violations of this code of conduct, please fill in the following form located at the link below: [HubSpot Developer Community Code of Conduct Violation Reporting](https://form.asana.com/?k=p7aM0fpd3G4JGETDL_nYXg&d=8587152060687)
+
+Contacting a member of the HubSpot Developer Relations or the DPG Developer Tooling team, members of the HubSpot Organization and/or community via unsolicited mentions or pings is strongly discouraged and may be considered a violation of our code of conduct with regards to harassment.
 
 ## Attribution
 


### PR DESCRIPTION
## Description and Context
In our efforts to deprecate the `cli-lib` library in favor of `local-dev-lib`, we are adding a code of conduct for HubSpot developers who would like to contribute here. 

Based on our discussions in Slack, I've based this code of conduct on the developer relation team's [CoC](https://github.com/hubspotdev/.github/blob/main/CODE_OF_CONDUCT.md) which @ajlaporte was kind enough to link me to. 

My main questions now are:

1) What kind of promises would we like to make to our developer community? 
2) Should we provide a form for developers to report any violations, as the DevRel team does? 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address any feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@joe-yeager @camden11 @brandenrodgers 
