### PR TITLE
Add function to hit test portal installs endpoint

### DIFF
--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -1,5 +1,5 @@
 import http from '../http';
-import { PublicApp } from '../types/Apps';
+import { PublicApp, DeveloperTestAccountInstallData } from '../types/Apps';
 
 const APPS_DEV_API_PATH = 'apps-dev/external/public/v3';
 
@@ -15,4 +15,13 @@ export async function fetchPublicAppsForPortal(
   });
 
   return resp ? resp.results : [];
+}
+
+export function fetchDeveloperTestAccountInstalls(
+  appId: number,
+  accountId: number
+): Promise<DeveloperTestAccountInstallData> {
+  return http.get<DeveloperTestAccountInstallData>(accountId, {
+    url: `${APPS_DEV_API_PATH}/${appId}/test-portal-installs`,
+  });
 }

--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -2,6 +2,7 @@ import http from '../http';
 import {
   PublicApp,
   PublicAppDeveloperTestAccountInstallData,
+  PublicAppInstallationAccount,
 } from '../types/Apps';
 
 const APPS_DEV_API_PATH = 'apps-dev/external/public/v3';
@@ -10,12 +11,30 @@ type FetchPublicAppsForPortalResponse = {
   results: Array<PublicApp>;
 };
 
+type FetchPublicAppInstallationAccountsResponse = {
+  results: Array<PublicAppInstallationAccount>;
+};
+
 export async function fetchPublicAppsForPortal(
   accountId: number
 ): Promise<Array<PublicApp>> {
   const resp = await http.get<FetchPublicAppsForPortalResponse>(accountId, {
     url: `${APPS_DEV_API_PATH}/full/portal`,
   });
+
+  return resp ? resp.results : [];
+}
+
+export async function fetchPublicAppInstallationAccounts(
+  appId: number,
+  accountId: number
+): Promise<Array<PublicAppInstallationAccount>> {
+  const resp = await http.get<FetchPublicAppInstallationAccountsResponse>(
+    accountId,
+    {
+      url: `appinstalls/v3/app-install/internal/portals-with-active-installs/${appId}/`,
+    }
+  );
 
   return resp ? resp.results : [];
 }

--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -39,7 +39,7 @@ export async function fetchPublicAppInstallationAccounts(
   return resp ? resp.results : [];
 }
 
-export function fetchPublicAppDeveloperTestAccountInstalls(
+export function fetchPublicAppDeveloperTestAccountInstallData(
   appId: number,
   accountId: number
 ): Promise<PublicAppDeveloperTestAccountInstallData> {

--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -1,5 +1,8 @@
 import http from '../http';
-import { PublicApp, DeveloperTestAccountInstallData } from '../types/Apps';
+import {
+  PublicApp,
+  PublicAppDeveloperTestAccountInstallData,
+} from '../types/Apps';
 
 const APPS_DEV_API_PATH = 'apps-dev/external/public/v3';
 
@@ -17,11 +20,11 @@ export async function fetchPublicAppsForPortal(
   return resp ? resp.results : [];
 }
 
-export function fetchDeveloperTestAccountInstalls(
+export function fetchPublicAppDeveloperTestAccountInstalls(
   appId: number,
   accountId: number
-): Promise<DeveloperTestAccountInstallData> {
-  return http.get<DeveloperTestAccountInstallData>(accountId, {
+): Promise<PublicAppDeveloperTestAccountInstallData> {
+  return http.get<PublicAppDeveloperTestAccountInstallData>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/test-portal-installs`,
   });
 }

--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -2,7 +2,6 @@ import http from '../http';
 import {
   PublicApp,
   PublicAppDeveloperTestAccountInstallData,
-  PublicAppInstallationAccount,
 } from '../types/Apps';
 
 const APPS_DEV_API_PATH = 'apps-dev/external/public/v3';
@@ -11,30 +10,12 @@ type FetchPublicAppsForPortalResponse = {
   results: Array<PublicApp>;
 };
 
-type FetchPublicAppInstallationAccountsResponse = {
-  results: Array<PublicAppInstallationAccount>;
-};
-
 export async function fetchPublicAppsForPortal(
   accountId: number
 ): Promise<Array<PublicApp>> {
   const resp = await http.get<FetchPublicAppsForPortalResponse>(accountId, {
     url: `${APPS_DEV_API_PATH}/full/portal`,
   });
-
-  return resp ? resp.results : [];
-}
-
-export async function fetchPublicAppInstallationAccounts(
-  appId: number,
-  accountId: number
-): Promise<Array<PublicAppInstallationAccount>> {
-  const resp = await http.get<FetchPublicAppInstallationAccountsResponse>(
-    accountId,
-    {
-      url: `appinstalls/v3/app-install/internal/portals-with-active-installs/${appId}/`,
-    }
-  );
 
   return resp ? resp.results : [];
 }

--- a/types/Apps.ts
+++ b/types/Apps.ts
@@ -7,6 +7,11 @@ export type PublicAppInstallationData = {
   }>;
 };
 
+export type PublicAppInstallationAccount = {
+  portalId: number;
+  initiatingUserId: number;
+};
+
 export type PublicAppDeveloperTestAccountInstallData = {
   testPortalInstalls: Array<{
     portalId: number;

--- a/types/Apps.ts
+++ b/types/Apps.ts
@@ -7,6 +7,14 @@ export type PublicAppInstallationData = {
   }>;
 };
 
+export type DeveloperTestAccountInstallData = {
+  testPortalInstalls: Array<{
+    portalId: number;
+    accountName: string;
+  }>;
+  testPortalInstallCount: string;
+};
+
 export type PublicApp = {
   id: number;
   name: string;

--- a/types/Apps.ts
+++ b/types/Apps.ts
@@ -7,7 +7,7 @@ export type PublicAppInstallationData = {
   }>;
 };
 
-export type DeveloperTestAccountInstallData = {
+export type PublicAppDeveloperTestAccountInstallData = {
   testPortalInstalls: Array<{
     portalId: number;
     accountName: string;

--- a/types/Apps.ts
+++ b/types/Apps.ts
@@ -7,11 +7,6 @@ export type PublicAppInstallationData = {
   }>;
 };
 
-export type PublicAppInstallationAccount = {
-  portalId: number;
-  initiatingUserId: number;
-};
-
 export type PublicAppDeveloperTestAccountInstallData = {
   testPortalInstalls: Array<{
     portalId: number;


### PR DESCRIPTION
## Description and Context
This adds functionality to hit a new endpoint that returns the number of installs a public app has in developer test account. We'll use this on the CLI to determine if an app has installs that _aren't_ on test accounts (see https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/571)

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
