### PR TITLE
fix: Add keepAlive to axios agent

### DIFF
--- a/http/__tests__/index.ts
+++ b/http/__tests__/index.ts
@@ -23,7 +23,7 @@ jest.mock('http', () => ({
 
 jest.mock('https', () => ({
   Agent: jest.fn().mockReturnValue({
-    options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+    options: { keepAlive: true, maxSockets: 6, maxTotalSockets: 26 },
   }),
 }));
 
@@ -167,7 +167,7 @@ describe('http/index', () => {
           options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
         },
         httpsAgent: {
-          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+          options: { keepAlive: true, maxSockets: 6, maxTotalSockets: 26 },
         },
       });
     });
@@ -210,7 +210,7 @@ describe('http/index', () => {
           options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
         },
         httpsAgent: {
-          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+          options: { keepAlive: true, maxSockets: 6, maxTotalSockets: 26 },
         },
       });
     });
@@ -252,7 +252,7 @@ describe('http/index', () => {
           options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
         },
         httpsAgent: {
-          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+          options: { keepAlive: true, maxSockets: 6, maxTotalSockets: 26 },
         },
       });
     });

--- a/http/__tests__/index.ts
+++ b/http/__tests__/index.ts
@@ -15,6 +15,18 @@ jest.mock('axios');
 jest.mock('../../config');
 jest.mock('../../lib/logger');
 
+jest.mock('http', () => ({
+  Agent: jest.fn().mockReturnValue({
+    options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+  }),
+}));
+
+jest.mock('https', () => ({
+  Agent: jest.fn().mockReturnValue({
+    options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+  }),
+}));
+
 const mockedAxios = jest.mocked(axios);
 const getAndLoadConfigIfNeeded =
   __getAndLoadConfigIfNeeded as jest.MockedFunction<
@@ -151,6 +163,12 @@ describe('http/index', () => {
         transitional: {
           clarifyTimeoutError: true,
         },
+        httpAgent: {
+          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+        },
+        httpsAgent: {
+          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+        },
       });
     });
     it('adds authorization header when using a user token', async () => {
@@ -188,6 +206,12 @@ describe('http/index', () => {
         transitional: {
           clarifyTimeoutError: true,
         },
+        httpAgent: {
+          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+        },
+        httpsAgent: {
+          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+        },
       });
     });
 
@@ -223,6 +247,12 @@ describe('http/index', () => {
         },
         transitional: {
           clarifyTimeoutError: true,
+        },
+        httpAgent: {
+          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+        },
+        httpsAgent: {
+          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
         },
       });
     });

--- a/http/getAxiosConfig.ts
+++ b/http/getAxiosConfig.ts
@@ -7,8 +7,23 @@ import { AxiosRequestConfig } from 'axios';
 import https from 'https';
 import http from 'https';
 
-const httpAgent = new http.Agent({ keepAlive: true });
-const httpsAgent = new https.Agent({ keepAlive: true });
+// Total number of sockets across all hosts
+const MAX_TOTAL_SOCKETS = 50;
+
+// Total number of sockets per each host
+const MAX_SOCKETS_PER_HOST = 10;
+
+const httpAgent = new http.Agent({
+  keepAlive: true,
+  maxTotalSockets: MAX_TOTAL_SOCKETS,
+  maxSockets: MAX_SOCKETS_PER_HOST,
+});
+
+const httpsAgent = new https.Agent({
+  keepAlive: true,
+  maxTotalSockets: MAX_TOTAL_SOCKETS,
+  maxSockets: MAX_SOCKETS_PER_HOST,
+});
 
 export const USER_AGENTS: { [key: string]: string } = {
   'HubSpot Local Dev Lib': version,
@@ -38,7 +53,6 @@ export function getAxiosConfig(
   const { env, localHostOverride, headers, ...rest } = options;
   const { httpTimeout, httpUseLocalhost } =
     getAndLoadConfigIfNeeded() as CLIConfig;
-
   return {
     baseURL: getHubSpotApiOrigin(
       env,

--- a/http/getAxiosConfig.ts
+++ b/http/getAxiosConfig.ts
@@ -5,7 +5,7 @@ import { AxiosConfigOptions } from '../types/Http';
 import { CLIConfig } from '../types/Config';
 import { AxiosRequestConfig } from 'axios';
 import https from 'https';
-import http from 'https';
+import http from 'http';
 
 // Total number of sockets across all hosts
 const MAX_TOTAL_SOCKETS = 25;

--- a/http/getAxiosConfig.ts
+++ b/http/getAxiosConfig.ts
@@ -4,6 +4,11 @@ import { getHubSpotApiOrigin } from '../lib/urls';
 import { AxiosConfigOptions } from '../types/Http';
 import { CLIConfig } from '../types/Config';
 import { AxiosRequestConfig } from 'axios';
+import https from 'https';
+import http from 'https';
+
+const httpAgent = new http.Agent({ keepAlive: true });
+const httpsAgent = new https.Agent({ keepAlive: true });
 
 export const USER_AGENTS: { [key: string]: string } = {
   'HubSpot Local Dev Lib': version,
@@ -45,6 +50,8 @@ export function getAxiosConfig(
     },
     timeout: httpTimeout || 15000,
     transitional: DEFAULT_TRANSITIONAL,
+    httpAgent,
+    httpsAgent,
     ...rest,
   };
 }

--- a/http/getAxiosConfig.ts
+++ b/http/getAxiosConfig.ts
@@ -8,10 +8,10 @@ import https from 'https';
 import http from 'https';
 
 // Total number of sockets across all hosts
-const MAX_TOTAL_SOCKETS = 50;
+const MAX_TOTAL_SOCKETS = 25;
 
 // Total number of sockets per each host
-const MAX_SOCKETS_PER_HOST = 10;
+const MAX_SOCKETS_PER_HOST = 5;
 
 const httpAgent = new http.Agent({
   keepAlive: true,

--- a/types/Utils.ts
+++ b/types/Utils.ts
@@ -9,5 +9,5 @@ type Join<K, P> = K extends string | number
 export type Leaves<T> = [10] extends [never]
   ? never
   : T extends object
-    ? { [K in keyof T]-?: Join<K, Leaves<T[K]>> }[keyof T]
-    : '';
+  ? { [K in keyof T]-?: Join<K, Leaves<T[K]>> }[keyof T]
+  : '';

--- a/types/Utils.ts
+++ b/types/Utils.ts
@@ -6,6 +6,7 @@ type Join<K, P> = K extends string | number
     : never
   : never;
 
+// prettier-ignore
 export type Leaves<T> = [10] extends [never]
   ? never
   : T extends object

--- a/types/Utils.ts
+++ b/types/Utils.ts
@@ -9,5 +9,5 @@ type Join<K, P> = K extends string | number
 export type Leaves<T> = [10] extends [never]
   ? never
   : T extends object
-  ? { [K in keyof T]-?: Join<K, Leaves<T[K]>> }[keyof T]
-  : '';
+    ? { [K in keyof T]-?: Join<K, Leaves<T[K]>> }[keyof T]
+    : '';


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
We were getting `ENOMEM` errors from `axios` because it appears to have a [memory leak starting in](https://github.com/axios/axios/issues/5641) `1.4.0` and in versions as late as `1.6.8`. The leak is caused by event listeners not being closed when http calls complete.  A solution to fix or at least limit the impact is to set `keepAlive` to true and limit the number of sockets which causes `axios` to reuse the connections instead of creating new ones.  

As an aside, we **_might_** notice some minor performance benefits as well on request heavy operations because we will be reusing connections.

[More context on connection management](https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x)

Changes:
- Pass custom `http` and `https` agents to `axios`
- Set `keepAlive` to true to allow connections to be kept open
- Set a limit on the number of total connections
- Set a limit on the number of connections per domain

## Who to Notify
<!-- /cc those you wish to know about the PR -->
