### PR TITLE
Fix issue with downloading images from GitHub repos

### DIFF
--- a/api/github.ts
+++ b/api/github.ts
@@ -64,6 +64,7 @@ export async function fetchRepoFileByDownloadUrl(
 ): Promise<AxiosResponse<Buffer>> {
   return axios.get<Buffer>(downloadUrl, {
     headers: { ...getDefaultUserAgentHeader(), ...GITHUB_AUTH_HEADERS },
+    responseType: 'arraybuffer',
   });
 }
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -148,11 +148,15 @@ async function fetchGitHubRepoContentFromDownloadUrl(
   downloadUrl: string
 ): Promise<void> {
   const resp = await fetchRepoFileByDownloadUrl(downloadUrl);
-  const fileContents =
-    typeof resp.data === 'string'
-      ? resp.data
-      : JSON.stringify(resp.data, null, 2);
-  fs.outputFileSync(dest, fileContents, 'utf8');
+  const contentType = resp.headers['content-type'];
+  let fileContents;
+
+  if (contentType.startsWith('text')) {
+    fileContents = Buffer.from(resp.data).toString('utf8');
+  } else {
+    fileContents = resp.data;
+  }
+  await fs.outputFileSync(dest, fileContents);
 }
 
 // Writes files from a public repository to the destination folder

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -143,7 +143,7 @@ export async function cloneGithubRepo(
   return success;
 }
 
-async function fetchGitHubRepoContentFromDownloadUrl(
+export async function fetchGitHubRepoContentFromDownloadUrl(
   dest: string,
   downloadUrl: string
 ): Promise<void> {


### PR DESCRIPTION
## Description and Context
We discovered a bug with the `hs project create` command: image files were not being downloaded correctly. Images were being stored as strings and written in `utf8`. Now we store them as array buffers and write them out to a binary file. 

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Test out the PR. You can download a sample template with png file with the `hs project create --templateSource=kemmerle/sample-projects` command. 
- [x] Address any feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@sejal27 @brandenrodgers @camden11 @joe-yeager 