### PR TITLE
chore: Add a setupFile, delete process.env.HUBAPI_DOMAIN_OVERRIDE before tests execute

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   transform: {
     'node_modules/variables/.+\\.(j|t)sx?$': 'ts-jest',
   },
+  setupFiles: ['./setupTests.ts'],
   transformIgnorePatterns: ['node_modules/(?!variables/.*)'],
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
 };

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,0 +1,3 @@
+// Clear out the env variable HUBAPI_DOMAIN_OVERRIDE so it doesn't impact tests
+// if it is set in the users local environment
+delete process.env.HUBAPI_DOMAIN_OVERRIDE;


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
- Adds a setup file that runs before the tests executre
- delete `process.env.HUBAPI_DOMAIN_OVERRIDE` so in the event a user has an `export HUBAPI_DOMAIN_OVERRIDE` in their shell profile the tests will not use that value
