### PR TITLE
chore: Set jest `clearMocks` to true.  Remove manual mock clear calls

### DIFF
--- a/config/__tests__/config.ts
+++ b/config/__tests__/config.ts
@@ -105,7 +105,6 @@ function getAccountByAuthType(
 }
 
 describe('config/config', () => {
-
   const globalConsole = global.console;
   beforeAll(() => {
     global.console.error = jest.fn();
@@ -655,7 +654,6 @@ describe('config/config', () => {
           .mockImplementation(() => {
             return false;
           });
-        fsWriteFileSyncSpy.mockClear();
       });
 
       afterAll(() => {
@@ -686,7 +684,6 @@ describe('config/config', () => {
 
             return false;
           });
-        fsWriteFileSyncSpy.mockClear();
       });
 
       afterAll(() => {
@@ -704,7 +701,6 @@ describe('config/config', () => {
       beforeAll(() => {
         setConfigPath(CONFIG_PATHS.none);
         mockedConfigPath = CONFIG_PATHS.none;
-        fsWriteFileSyncSpy.mockClear();
       });
 
       it('creates a config at the specified path', () => {

--- a/http/__tests__/index.ts
+++ b/http/__tests__/index.ts
@@ -46,7 +46,6 @@ fs.createWriteStream = jest.fn().mockReturnValue({
 
 describe('http/index', () => {
   afterEach(() => {
-    jest.clearAllMocks();
     getAndLoadConfigIfNeeded.mockReset();
     getAccountConfig.mockReset();
   });

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
   setupFiles: ['./setupTests.ts'],
   transformIgnorePatterns: ['node_modules/(?!variables/.*)'],
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
+  clearMocks: true,
 };

--- a/lib/__tests__/customObjects.ts
+++ b/lib/__tests__/customObjects.ts
@@ -25,10 +25,6 @@ const fetchObjectSchemas = __fetchObjectSchemas as jest.MockedFunction<
 >;
 
 describe('lib/customObjects', () => {
-  beforeEach(() => {
-    outputFileSyncSpy.mockClear();
-  });
-
   describe('writeSchemaToDisk()', () => {
     it('writes schema to disk', async () => {
       await writeSchemaToDisk(basicSchema);

--- a/lib/__tests__/fileMapper.ts
+++ b/lib/__tests__/fileMapper.ts
@@ -203,9 +203,6 @@ describe('lib/fileMapper', () => {
 
   describe('fetchFolderFromApi()', () => {
     const accountId = 67890;
-    beforeEach(() => {
-      download.mockClear();
-    });
 
     it('folder: should execute the download client per the request input', async () => {
       const src = '1234';
@@ -255,7 +252,6 @@ describe('lib/fileMapper', () => {
       utimesSpy.mockImplementationOnce(() => null);
       ensureDirSpy.mockImplementationOnce(() => true);
 
-      fetchFileStream.mockClear();
       fetchFileStream.mockResolvedValueOnce({
         name: '',
         createdAt: 1,
@@ -265,7 +261,6 @@ describe('lib/fileMapper', () => {
         folder: false,
         children: [],
       });
-      utimesSpy.mockClear();
     });
 
     it('should execute downloadFile', async () => {

--- a/lib/__tests__/hubdb.ts
+++ b/lib/__tests__/hubdb.ts
@@ -40,7 +40,6 @@ describe('lib/hubdb', () => {
     const projectCwd = '/home/tom/projects';
 
     beforeEach(() => {
-      mockedFS.outputFile.mockClear();
       getCwd.mockReturnValue(projectCwd);
       fetchRows.mockResolvedValue(hubdbFetchRowResponse);
       fetchTable.mockResolvedValue(hubdbTableResponse);

--- a/lib/__tests__/personalAccessKey.ts
+++ b/lib/__tests__/personalAccessKey.ts
@@ -194,14 +194,7 @@ describe('lib/personalAccessKey', () => {
   });
 
   describe('updateConfigWithPersonalAccessKey()', () => {
-    beforeEach(() => {
-      fetchAccessToken.mockClear();
-      updateAccountConfig.mockClear();
-    });
-
     it('updates the config with the new account', async () => {
-      fetchAccessToken.mockClear();
-
       const freshAccessToken = 'fresh-token';
       fetchAccessToken.mockResolvedValue({
         oauthAccessToken: freshAccessToken,

--- a/lib/__tests__/templates.ts
+++ b/lib/__tests__/templates.ts
@@ -58,10 +58,6 @@ describe('lib/cms/templates', () => {
   });
 
   describe('createTemplate()', () => {
-    beforeEach(() => {
-      downloadGithubRepoContents.mockClear();
-    });
-
     it('downloads a template from the HubSpot/cms-sample-assets repo', async () => {
       jest.spyOn(fs, 'mkdirp').mockReturnValue();
       jest.spyOn(fs, 'existsSync').mockReturnValue(false);

--- a/lib/__tests__/trackUsage.ts
+++ b/lib/__tests__/trackUsage.ts
@@ -43,7 +43,6 @@ const usageTrackingMeta = {
 describe('lib/trackUsage', () => {
   describe('trackUsage()', () => {
     beforeEach(() => {
-      mockedAxios.mockClear();
       getAccountConfig.mockReset();
       getAccountConfig.mockReturnValue(account);
     });

--- a/lib/__tests__/uploadFolder.ts
+++ b/lib/__tests__/uploadFolder.ts
@@ -85,7 +85,6 @@ describe('lib/cms/uploadFolder', () => {
     createIgnoreFilter.mockImplementation(() => () => true);
   });
   beforeEach(() => {
-    FieldsJs.mockClear();
     createTmpDirSync.mockReset();
     listFilesInDir.mockReset();
   });
@@ -198,7 +197,6 @@ describe('lib/cms/uploadFolder', () => {
     const convertedModuleFilePath = convertedModuleFieldsObj.outputPath;
 
     beforeEach(() => {
-      FieldsJs.mockClear();
       jest.resetModules();
     });
     it('outputs getFilesByType with no processing if convertFields is false', async () => {

--- a/lib/__tests__/uploadFolder.ts
+++ b/lib/__tests__/uploadFolder.ts
@@ -164,6 +164,7 @@ describe('lib/cms/uploadFolder', () => {
     });
 
     it('deletes the temporary directory', async () => {
+      createTmpDirSync.mockReturnValue('folder');
       const deleteDirSpy = cleanupTmpDirSync.mockImplementation(() => '');
 
       upload.mockResolvedValue();


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Jest sets [`clearMocks`](https://jestjs.io/docs/configuration#clearmocks-boolean) to false by default which means that unless mocks are explicitly cleared between test invocations, the mocks states are carried between tests. which can lead to having tests that aren't well isolated and depend on the tests that come before them.

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @kemmerle @camden11 