### PR TITLE
Add functions to sanitize file name and validate path (Sister PR in cli-lib)

### DIFF
--- a/lib/path.ts
+++ b/lib/path.ts
@@ -88,3 +88,44 @@ export function isAllowedExtension(
 export function getAbsoluteFilePath(_path: string): string {
   return path.resolve(getCwd(), _path);
 }
+
+// Reserved names (Windows specific)
+const reservedNames = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i;
+
+// Based on the node-sanitize-filename package: https://github.com/parshap/node-sanitize-filename/blob/master/index.js
+export function sanitizeFileName(fileName: string): string {
+  // Windows invalid/control characters
+  // eslint-disable-next-line no-control-regex
+  const invalidChars = /[<>:"/|?*\x00-\x1F]/g;
+
+  //Replace invalid characters with dash
+  let sanitizedFileName = fileName.replace(invalidChars, '-');
+
+  // Removes trailing periods and spaces for Windows
+  sanitizedFileName = sanitizedFileName.replace(/[. ]+$/, '');
+
+  //Reserved names check for Windows
+  if (reservedNames.test(sanitizedFileName)) {
+    sanitizedFileName = `-${sanitizedFileName}`;
+  }
+
+  return sanitizedFileName;
+}
+
+// Based on the node-sanitize-filename package: https://github.com/parshap/node-sanitize-filename/blob/master/index.js
+export function isValidPath(_path: string): boolean {
+  // Invalid characters excluding forward slash
+  // eslint-disable-next-line no-control-regex
+  const invalidChars = /[<>:"|?*\x00-\x1F]/;
+  const baseName = path.basename(_path);
+
+  if (invalidChars.test(baseName)) {
+    return false;
+  }
+
+  if (reservedNames.test(baseName)) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Description and Context
<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This PR moves/creates the functions `sanitizeFileName` and `isValidPath` to the hubspot-local-dev-lib library. I think this makes more sense, since these are reusable for any file or path. In particular, I decided to rename the `sanitizeFileName` function from `sanitizeProjectName` when moving it to `local-dev-lib`, because it makes it more readable and reusable in the future. We're basically treating the project name as a directory/file name.

There is a sister [PR](https://github.com/HubSpot/hubspot-cli/pull/1102) in cli-lib. 

To test, you'll need to follow the `yarn link` instructions in the README file to use a symlinked version of local-dev-lib. 

## Screenshots
<!-- Provide images of the before and after functionality -->

We sanitize the project name before inserting it in the default path, and we validate for invalid characters/reserved names for the location. 
<img width="2282" alt="Screenshot 2024-06-17 at 1 31 44 PM" src="https://github.com/HubSpot/hubspot-local-dev-lib/assets/25392256/edcaaec9-b830-44d3-8256-e25ecffc060c">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback

## Who to Notify
<!-- /cc those you wish to know about the PR -->

@mendel-at-hubspot @brandenrodgers @camden11 @joe-yeager 

