### PR TITLE
Add private app user token manger for use with local dev server

### DIFF
--- a/api/privateAppUserToken.ts
+++ b/api/privateAppUserToken.ts
@@ -25,13 +25,13 @@ export async function fetchPrivateAppUserToken(
 export async function createPrivateAppUserToken(
   accountId: number,
   appId: number,
-  scopeGroups: Array<string> = [],
+  scopeGroups?: Array<string>,
   expiresAt?: string
 ): Promise<PrivateAppUserTokenResponse> {
   return http.post(accountId, {
     url: `${LOCALDEVAUTH_API_PRIVATE_APP_USER_TOKEN_PATH}/${appId}`,
     data: {
-      ...(scopeGroups.length && { scopeGroups: scopeGroups }),
+      ...(scopeGroups && { scopeGroups: scopeGroups }),
       ...(expiresAt && { expiresAt: expiresAt }),
     },
   });
@@ -41,14 +41,14 @@ export async function updatePrivateAppUserToken(
   accountId: number,
   appId: number,
   userTokenKey: string,
-  scopeGroups: Array<string> = [],
+  scopeGroups?: Array<string>,
   expiresAt?: string
 ): Promise<PrivateAppUserTokenResponse> {
   return http.put(accountId, {
     url: `${LOCALDEVAUTH_API_PRIVATE_APP_USER_TOKEN_PATH}/${appId}`,
     data: {
       privateAppUserTokenKey: userTokenKey,
-      ...(scopeGroups.length && { scopeGroups: scopeGroups }),
+      ...(scopeGroups && { scopeGroups: scopeGroups }),
       ...(expiresAt && { expiresAt: expiresAt }),
     },
   });

--- a/api/privateAppUserToken.ts
+++ b/api/privateAppUserToken.ts
@@ -1,0 +1,55 @@
+import http from '../http';
+
+const LOCALDEVAUTH_API_PRIVATE_APP_USER_TOKEN_PATH =
+  'localdevauth/v1/private-app/user-token';
+
+export type PrivateAppUserTokenResponse = {
+  userId: number;
+  portalId: number;
+  appId: number;
+  scopeGroups: Array<string>;
+  userTokenKey: string;
+  expiresAt: string;
+  clientId: string;
+};
+
+export async function fetchPrivateAppUserToken(
+  accountId: number,
+  appId: number
+): Promise<PrivateAppUserTokenResponse> {
+  return http.get(accountId, {
+    url: `${LOCALDEVAUTH_API_PRIVATE_APP_USER_TOKEN_PATH}/${appId}`,
+  });
+}
+
+export async function createPrivateAppUserToken(
+  accountId: number,
+  appId: number,
+  scopeGroups: Array<string> = [],
+  expiresAt?: string
+): Promise<PrivateAppUserTokenResponse> {
+  return http.post(accountId, {
+    url: `${LOCALDEVAUTH_API_PRIVATE_APP_USER_TOKEN_PATH}/${appId}`,
+    data: {
+      ...(scopeGroups.length && { scopeGroups: scopeGroups }),
+      ...(expiresAt && { expiresAt: expiresAt }),
+    },
+  });
+}
+
+export async function updatePrivateAppUserToken(
+  accountId: number,
+  appId: number,
+  userTokenKey: string,
+  scopeGroups: Array<string> = [],
+  expiresAt?: string
+): Promise<PrivateAppUserTokenResponse> {
+  return http.put(accountId, {
+    url: `${LOCALDEVAUTH_API_PRIVATE_APP_USER_TOKEN_PATH}/${appId}`,
+    data: {
+      privateAppUserTokenKey: userTokenKey,
+      ...(scopeGroups.length && { scopeGroups: scopeGroups }),
+      ...(expiresAt && { expiresAt: expiresAt }),
+    },
+  });
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -238,7 +238,8 @@
       "refreshScheduled": "Scheduling refresh of token for appId~{{ appId }} expiring at {{ expiresAt }} to run at {{ refreshTime }} ",
       "errors": {
         "noScopes": "Unable to use private app user tokens for accountId~{{ accountId }}. Please regenerate the Personal Access Key.",
-        "apiError": "Unable to get or create private app user token for appId~{{ appId }} on accountId~{{ accountId }}. {{ messageDetail }} failed."
+        "apiError": "Unable to get or create private app user token for appId~{{ appId }} on accountId~{{ accountId }}. {{ messageDetail }} failed.",
+        "refreshFailed": "Unable to refresh private app user token for appId~{{ appId }} on accountId~{{ accountId }}."
       }
     }
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -230,16 +230,16 @@
       "standard": "standard"
     },
     "PrivateAppUserTokenManager": {
-      "enabled": "Private app user tokens is enabled for accountId~{{ accountId }}",
-      "disabled": "Private app user tokens is not enabled for accountId~{{ accountId }}, skipping call to fetch for appId~{{ appId }}",
-      "create": "Creating new private app user token for appId~{{ appId }}",
-      "cached": "Using cached private app user token for appId~{{ appId }}",
-      "refresh": "Updating or rereshing private app user token for appId~{{ appId }} ",
-      "refreshScheduled": "Scheduling refresh of token for appId~{{ appId }} expiring at {{ expiresAt }} to run at {{ refreshTime }} ",
+      "enabled": "Private app user tokens is enabled for accountId {{ accountId }}",
+      "disabled": "Private app user tokens is not enabled for accountId {{ accountId }}, skipping call to fetch for appId {{ appId }}",
+      "create": "Creating new private app user token for appId {{ appId }}",
+      "cached": "Using cached private app user token for appId {{ appId }}",
+      "refresh": "Updating or rereshing private app user token for appId {{ appId }} ",
+      "refreshScheduled": "Scheduling refresh of token for appId {{ appId }} expiring at {{ expiresAt }} to run at {{ refreshTime }} ",
       "errors": {
-        "noScopes": "Unable to use private app user tokens for accountId~{{ accountId }}. Please regenerate the Personal Access Key.",
-        "apiError": "Unable to get or create private app user token for appId~{{ appId }} on accountId~{{ accountId }}. {{ messageDetail }} failed.",
-        "refreshFailed": "Unable to refresh private app user token for appId~{{ appId }} on accountId~{{ accountId }}."
+        "noScopes": "Unable to use private app user token for appId {{ appId }} since updated App function scope is missing on accountId {{ accountId }}. To add App function scope to that account, deactivate the existing Personal Access Key, and generate a new one that includes the App functions scope. Then run hs auth and reauthenticate accountId {{ accountId }}.",
+        "apiError": "Unable to get or create private app user token for appId {{ appId }} on accountId {{ accountId }}. {{ messageDetail }}",
+        "refreshFailed": "Unable to refresh private app user token for appId {{ appId }} on accountId {{ accountId }}."
       }
     }
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -347,6 +347,15 @@
         "409": "Failed to assign port. Server with instanceId {{ instanceId }} is already running on port {{ port }}",
         "400": "Invalid port requested. Port must be between {{ minPort }} and {{ maxPort }}."
       }
+    },
+    "PrivateAppUserTokenManager": {
+      "disabled": "Private application user tokens is not enabled for accountId~{{ accountId }}, skipping call to fetch for appId~{{ appId }}",
+      "create": "Creating new private applications user token for appId~{{ appId }}",
+      "refresh": "Updating or rereshing private application user token for appId~{{ appId }} ",
+      "refreshScheduled": "Scheduling refresh of token for appId~{{ appId }} expiring at {{ expiresAt }} to run at {{ refreshTime }} ",
+      "errors": {
+        "noScopes": "Unable to use temporary Private Application User tokens for accountId~{{ accountId }}. Please regenerate the Personal Access Key."
+      }
     }
   },
   "http": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -228,6 +228,18 @@
       "developerTest": "test account",
       "appDeveloper": "dev account",
       "standard": "standard"
+    },
+    "PrivateAppUserTokenManager": {
+      "enabled": "Private application user tokens is enabled for accountId~{{ accountId }}",
+      "disabled": "Private application user tokens is not enabled for accountId~{{ accountId }}, skipping call to fetch for appId~{{ appId }}",
+      "create": "Creating new private applications user token for appId~{{ appId }}",
+      "cached": "Using cached private applications user token for appId~{{ appId }}",
+      "refresh": "Updating or rereshing private application user token for appId~{{ appId }} ",
+      "refreshScheduled": "Scheduling refresh of token for appId~{{ appId }} expiring at {{ expiresAt }} to run at {{ refreshTime }} ",
+      "errors": {
+        "noScopes": "Unable to use temporary private application user tokens for accountId~{{ accountId }}. Please regenerate the Personal Access Key.",
+        "apiError": "Unable to get or create tempory Private application user token for appId~{{ appId }} on accountId~{{ accountId }}. {{ messageDetail }} failed."
+      }
     }
   },
   "config": {
@@ -346,16 +358,6 @@
         "404": "Could not find a server with instanceId {{ instanceId }}",
         "409": "Failed to assign port. Server with instanceId {{ instanceId }} is already running on port {{ port }}",
         "400": "Invalid port requested. Port must be between {{ minPort }} and {{ maxPort }}."
-      }
-    },
-    "PrivateAppUserTokenManager": {
-      "disabled": "Private application user tokens is not enabled for accountId~{{ accountId }}, skipping call to fetch for appId~{{ appId }}",
-      "create": "Creating new private applications user token for appId~{{ appId }}",
-      "refresh": "Updating or rereshing private application user token for appId~{{ appId }} ",
-      "refreshScheduled": "Scheduling refresh of token for appId~{{ appId }} expiring at {{ expiresAt }} to run at {{ refreshTime }} ",
-      "errors": {
-        "noScopes": "Unable to use temporary private application user tokens for accountId~{{ accountId }}. Please regenerate the Personal Access Key.",
-        "apiError": "Unable to get or create tempory Private application user token for appId~{{ appId }} on accountId~{{ accountId }}. {{ messageDetail }} failed."
       }
     }
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -354,7 +354,8 @@
       "refresh": "Updating or rereshing private application user token for appId~{{ appId }} ",
       "refreshScheduled": "Scheduling refresh of token for appId~{{ appId }} expiring at {{ expiresAt }} to run at {{ refreshTime }} ",
       "errors": {
-        "noScopes": "Unable to use temporary Private Application User tokens for accountId~{{ accountId }}. Please regenerate the Personal Access Key."
+        "noScopes": "Unable to use temporary private application user tokens for accountId~{{ accountId }}. Please regenerate the Personal Access Key.",
+        "apiError": "Unable to get or create tempory Private application user token for appId~{{ appId }} on accountId~{{ accountId }}. {{ messageDetail }} failed."
       }
     }
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -230,15 +230,15 @@
       "standard": "standard"
     },
     "PrivateAppUserTokenManager": {
-      "enabled": "Private application user tokens is enabled for accountId~{{ accountId }}",
-      "disabled": "Private application user tokens is not enabled for accountId~{{ accountId }}, skipping call to fetch for appId~{{ appId }}",
-      "create": "Creating new private applications user token for appId~{{ appId }}",
-      "cached": "Using cached private applications user token for appId~{{ appId }}",
-      "refresh": "Updating or rereshing private application user token for appId~{{ appId }} ",
+      "enabled": "Private app user tokens is enabled for accountId~{{ accountId }}",
+      "disabled": "Private app user tokens is not enabled for accountId~{{ accountId }}, skipping call to fetch for appId~{{ appId }}",
+      "create": "Creating new private app user token for appId~{{ appId }}",
+      "cached": "Using cached private app user token for appId~{{ appId }}",
+      "refresh": "Updating or rereshing private app user token for appId~{{ appId }} ",
       "refreshScheduled": "Scheduling refresh of token for appId~{{ appId }} expiring at {{ expiresAt }} to run at {{ refreshTime }} ",
       "errors": {
-        "noScopes": "Unable to use temporary private application user tokens for accountId~{{ accountId }}. Please regenerate the Personal Access Key.",
-        "apiError": "Unable to get or create tempory Private application user token for appId~{{ appId }} on accountId~{{ accountId }}. {{ messageDetail }} failed."
+        "noScopes": "Unable to use private app user tokens for accountId~{{ accountId }}. Please regenerate the Personal Access Key.",
+        "apiError": "Unable to get or create private app user token for appId~{{ appId }} on accountId~{{ accountId }}. {{ messageDetail }} failed."
       }
     }
   },

--- a/lib/__tests__/PrivateAppUserTokenManager.ts
+++ b/lib/__tests__/PrivateAppUserTokenManager.ts
@@ -64,7 +64,7 @@ describe('lib/PrivateAppUserTokenManager', () => {
     });
   });
 
-  describe('getPrivateAppToken()', () => {
+  describe('getPrivateAppUserToken()', () => {
     const systemTime = new Date(Date.UTC(2024, 5, 1, 0, 0, 0));
 
     const token: PrivateAppUserTokenResponse = {
@@ -110,7 +110,7 @@ describe('lib/PrivateAppUserTokenManager', () => {
 
     it('should no opt if not initialized', async () => {
       manager = new PrivateAppUserTokenManager(accountId); // set to new instance not initialized
-      const result = await manager.getPrivateAppToken(accountId);
+      const result = await manager.getPrivateAppUserToken(accountId);
       expect(result).toBeUndefined();
     });
     it('should no opt if disabled', async () => {
@@ -121,25 +121,25 @@ describe('lib/PrivateAppUserTokenManager', () => {
       } catch (e) {
         expect(e).toBeDefined();
       }
-      const result = await manager.getPrivateAppToken(accountId);
+      const result = await manager.getPrivateAppUserToken(accountId);
       expect(result).toBeUndefined();
     });
     it('should fetch a existing valid Private App User Token', async () => {
       fetchPrivateAppUserToken.mockResolvedValue(token);
-      const result = await manager.getPrivateAppToken(token.appId);
+      const result = await manager.getPrivateAppUserToken(token.appId);
       expect(result).toEqual(token.userTokenKey);
     });
     it('should used cached Private App User Token', async () => {
       fetchPrivateAppUserToken.mockResolvedValue(token);
-      await manager.getPrivateAppToken(token.appId);
-      const result = await manager.getPrivateAppToken(token.appId);
+      await manager.getPrivateAppUserToken(token.appId);
+      const result = await manager.getPrivateAppUserToken(token.appId);
       expect(result).toEqual(token.userTokenKey);
       expect(fetchPrivateAppUserToken).toHaveBeenCalledTimes(1);
     });
     it('should refresh existing expired Private App User Token', async () => {
       fetchPrivateAppUserToken.mockResolvedValue(expiredToken);
       updatePrivateAppUserToken.mockResolvedValue(token);
-      const result = await manager.getPrivateAppToken(token.appId);
+      const result = await manager.getPrivateAppUserToken(token.appId);
       expect(result).toEqual(token.userTokenKey);
       expect(updatePrivateAppUserToken).toHaveBeenCalledTimes(1);
     });
@@ -148,14 +148,14 @@ describe('lib/PrivateAppUserTokenManager', () => {
         throw notFoundError;
       });
       createPrivateAppUserToken.mockResolvedValue(token);
-      const result = await manager.getPrivateAppToken(token.appId);
+      const result = await manager.getPrivateAppUserToken(token.appId);
       expect(result).toEqual(token.userTokenKey);
       expect(createPrivateAppUserToken).toHaveBeenCalledTimes(1);
     });
     it('should refresh cached token if it is about to expire', async () => {
       fetchPrivateAppUserToken.mockResolvedValue(token);
       updatePrivateAppUserToken.mockResolvedValue(refreshedToken);
-      const tokenKey = await manager.getPrivateAppToken(token.appId);
+      const tokenKey = await manager.getPrivateAppUserToken(token.appId);
       expect(tokenKey).toEqual(token.userTokenKey);
       jest.advanceTimersByTime(60 * 60 * 1000);
       expect(updatePrivateAppUserToken).toHaveBeenCalledTimes(1);
@@ -163,8 +163,8 @@ describe('lib/PrivateAppUserTokenManager', () => {
     it('should update token is missing scopes', async () => {
       fetchPrivateAppUserToken.mockResolvedValue(token);
       updatePrivateAppUserToken.mockResolvedValue(tokenWithMoreScopes);
-      await manager.getPrivateAppToken(token.appId);
-      const tokenKey = await manager.getPrivateAppToken(
+      await manager.getPrivateAppUserToken(token.appId);
+      const tokenKey = await manager.getPrivateAppUserToken(
         token.appId,
         tokenWithMoreScopes.scopeGroups
       );
@@ -174,7 +174,7 @@ describe('lib/PrivateAppUserTokenManager', () => {
     });
     it('should clear token refresh if cleanup is called', async () => {
       fetchPrivateAppUserToken.mockResolvedValue(token);
-      await manager.getPrivateAppToken(token.appId);
+      await manager.getPrivateAppUserToken(token.appId);
       manager.cleanup();
       jest.advanceTimersByTime(60 * 60 * 1000);
       expect(updatePrivateAppUserToken).not.toHaveBeenCalled();

--- a/lib/__tests__/PrivateAppUserTokenManager.ts
+++ b/lib/__tests__/PrivateAppUserTokenManager.ts
@@ -55,7 +55,11 @@ describe('lib/PrivateAppUserTokenManager', () => {
     });
     it('should not enable PrivateAppUserTokenManager if the personal access key does not contain scopes', async () => {
       scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenDisabled);
-      await manager.init();
+      try {
+        await manager.init();
+      } catch (e) {
+        expect(e).toBeDefined();
+      }
       expect(manager.isEnabled()).toBe(false);
     });
   });
@@ -112,7 +116,11 @@ describe('lib/PrivateAppUserTokenManager', () => {
     it('should no opt if disabled', async () => {
       scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenDisabled);
       manager = new PrivateAppUserTokenManager(accountId); // set to new instance not initialized
-      await manager.init();
+      try {
+        await manager.init();
+      } catch (e) {
+        expect(e).toBeDefined();
+      }
       const result = await manager.getPrivateAppToken(accountId);
       expect(result).toBeUndefined();
     });

--- a/lib/__tests__/PrivateAppUserTokenManager.ts
+++ b/lib/__tests__/PrivateAppUserTokenManager.ts
@@ -1,0 +1,169 @@
+import { scopeGroupsForPersonalAccessKey as __scopeGroupsForPersonalAccessKey } from '../personalAccessKey';
+import { PrivateAppUserTokenManager } from '../PrivateAppUserTokenManager';
+import {
+  fetchPrivateAppUserToken as __fetchPrivateAppUserToken,
+  createPrivateAppUserToken as __createPrivateAppUserToken,
+  updatePrivateAppUserToken as __updatePrivateAppUserToken,
+  PrivateAppUserTokenResponse,
+} from '../../api/privateAppUserToken';
+
+import { AxiosError, AxiosHeaders } from 'axios';
+import { setLogLevel, LOG_LEVEL } from '../logger';
+jest.mock('../personalAccessKey');
+jest.mock('../../api/privateAppUserToken');
+
+const scopeGroupsForPersonalAccessKey =
+  __scopeGroupsForPersonalAccessKey as jest.MockedFunction<
+    typeof __scopeGroupsForPersonalAccessKey
+  >;
+
+const fetchPrivateAppUserToken =
+  __fetchPrivateAppUserToken as jest.MockedFunction<
+    typeof __fetchPrivateAppUserToken
+  >;
+const createPrivateAppUserToken =
+  __createPrivateAppUserToken as jest.MockedFunction<
+    typeof __createPrivateAppUserToken
+  >;
+const updatePrivateAppUserToken =
+  __updatePrivateAppUserToken as jest.MockedFunction<
+    typeof __updatePrivateAppUserToken
+  >;
+
+jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2024, 5, 1, 0, 0, 0)));
+jest.spyOn(global, 'setInterval');
+setLogLevel(LOG_LEVEL.DEBUG);
+describe('lib/PrivateAppUserTokenManager', () => {
+  const accountId = 123;
+  const token: PrivateAppUserTokenResponse = {
+    userId: 111,
+    portalId: 123,
+    appId: 345,
+    scopeGroups: ['crm.objects.contacts.read'],
+    userTokenKey: 'pat-na1-u-FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF',
+    clientId: 'my-client-id',
+    expiresAt: '2024-06-01T01:00:00Z',
+  };
+  const tokenWithMoreScopes = {
+    ...token,
+    scopeGroups: ['crm.objects.contacts.read', 'crm.objects.contacts.write'],
+  };
+  const refreshedToken = { ...token, expiresAt: '2024-06-01T02:00:00Z' };
+  const expiredToken = { ...token, expiresAt: '2024-05-30T00:00:00Z' };
+  const pakScopesTokenEnabled = Promise.resolve([
+    'developer.private_app.temporary_token.read',
+    'developer.private_app.temporary_token.write',
+  ]);
+  const pakScopesTokenDisabled = Promise.resolve(['developer.projects.read']);
+  const headers = new AxiosHeaders();
+  const config = { url: 'https://api.hubspot.com', headers: headers };
+
+  const notFoundError = new AxiosError('msg', 'code', config, undefined, {
+    status: 404,
+    data: { message: 'Not Found' },
+    statusText: 'Not Found',
+    config,
+    headers,
+  });
+  it('should initialize the PrivateAppUserTokenManager', async () => {
+    scopeGroupsForPersonalAccessKey.mockReturnValue(pakScopesTokenEnabled);
+    const manager = new PrivateAppUserTokenManager(accountId);
+    await manager.init();
+    expect(manager.isEnabled()).toBe(true);
+    manager.cleanup();
+  });
+  it('should not initialize the PrivateAppUserTokenManager if the scopes are not enabled', async () => {
+    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenDisabled);
+    const manager = new PrivateAppUserTokenManager(accountId);
+    await manager.init();
+    expect(manager.isEnabled()).toBe(false);
+    manager.cleanup();
+  });
+  it('should fetch a existing valid Private App User Token', async () => {
+    fetchPrivateAppUserToken.mockResolvedValue(token);
+    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
+    const manager = new PrivateAppUserTokenManager(accountId);
+    await manager.init();
+    const result = await manager.getPrivateAppToken(token.appId);
+    expect(result).toEqual(token.userTokenKey);
+    manager.cleanup();
+  });
+  it('should used cached Private App User Token', async () => {
+    fetchPrivateAppUserToken.mockResolvedValue(token);
+    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
+    const manager = new PrivateAppUserTokenManager(accountId);
+    await manager.init();
+    await manager.getPrivateAppToken(token.appId);
+    const result = await manager.getPrivateAppToken(token.appId);
+    expect(result).toEqual(token.userTokenKey);
+    expect(fetchPrivateAppUserToken).toHaveBeenCalledTimes(1);
+    manager.cleanup();
+  });
+  it('should refresh existing expired Private App User Token', async () => {
+    fetchPrivateAppUserToken.mockResolvedValue(expiredToken);
+    updatePrivateAppUserToken.mockResolvedValue(token);
+    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
+    const manager = new PrivateAppUserTokenManager(accountId);
+    await manager.init();
+    const result = await manager.getPrivateAppToken(token.appId);
+    expect(result).toEqual(token.userTokenKey);
+    expect(updatePrivateAppUserToken).toHaveBeenCalledTimes(1);
+    manager.cleanup();
+  });
+  it('should create a new Private App User Token if none exist', async () => {
+    fetchPrivateAppUserToken.mockImplementation(() => {
+      throw notFoundError;
+    });
+    createPrivateAppUserToken.mockResolvedValue(token);
+    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
+    const manager = new PrivateAppUserTokenManager(accountId);
+    await manager.init();
+    const result = await manager.getPrivateAppToken(token.appId);
+    expect(result).toEqual(token.userTokenKey);
+    expect(createPrivateAppUserToken).toHaveBeenCalledTimes(1);
+    manager.cleanup();
+  });
+  it('should not no opt if not initialized', async () => {
+    const manager = new PrivateAppUserTokenManager(accountId);
+    const result = await manager.getPrivateAppToken(token.appId);
+    expect(result).toBeUndefined();
+  });
+  it('should refresh cached token if it is about to expire', async () => {
+    fetchPrivateAppUserToken.mockResolvedValue(token);
+    updatePrivateAppUserToken.mockResolvedValue(refreshedToken);
+    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
+    const manager = new PrivateAppUserTokenManager(accountId);
+    await manager.init();
+    const tokenKey = await manager.getPrivateAppToken(token.appId);
+    expect(tokenKey).toEqual(token.userTokenKey);
+    jest.advanceTimersByTime(60 * 60 * 1000);
+    expect(updatePrivateAppUserToken).toHaveBeenCalledTimes(1);
+    manager.cleanup();
+  });
+  it('should update token is missing scopes', async () => {
+    fetchPrivateAppUserToken.mockResolvedValue(token);
+    updatePrivateAppUserToken.mockResolvedValue(tokenWithMoreScopes);
+    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
+    const manager = new PrivateAppUserTokenManager(accountId);
+    await manager.init();
+    await manager.getPrivateAppToken(token.appId);
+    const tokenKey = await manager.getPrivateAppToken(
+      token.appId,
+      tokenWithMoreScopes.scopeGroups
+    );
+    expect(tokenKey).toEqual(token.userTokenKey);
+    expect(fetchPrivateAppUserToken).toHaveBeenCalledTimes(1);
+    expect(updatePrivateAppUserToken).toHaveBeenCalledTimes(1);
+    manager.cleanup();
+  });
+  it('should clear token refresh if cleanup is called', async () => {
+    fetchPrivateAppUserToken.mockResolvedValue(token);
+    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
+    const manager = new PrivateAppUserTokenManager(accountId);
+    await manager.init();
+    await manager.getPrivateAppToken(token.appId);
+    manager.cleanup();
+    jest.advanceTimersByTime(60 * 60 * 1000);
+    expect(updatePrivateAppUserToken).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/PrivateAppUserTokenManager.ts
+++ b/lib/__tests__/PrivateAppUserTokenManager.ts
@@ -6,9 +6,8 @@ import {
   updatePrivateAppUserToken as __updatePrivateAppUserToken,
   PrivateAppUserTokenResponse,
 } from '../../api/privateAppUserToken';
-
 import { AxiosError, AxiosHeaders } from 'axios';
-import { setLogLevel, LOG_LEVEL } from '../logger';
+
 jest.mock('../personalAccessKey');
 jest.mock('../../api/privateAppUserToken');
 
@@ -30,140 +29,147 @@ const updatePrivateAppUserToken =
     typeof __updatePrivateAppUserToken
   >;
 
-jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2024, 5, 1, 0, 0, 0)));
-jest.spyOn(global, 'setInterval');
-setLogLevel(LOG_LEVEL.DEBUG);
 describe('lib/PrivateAppUserTokenManager', () => {
   const accountId = 123;
-  const token: PrivateAppUserTokenResponse = {
-    userId: 111,
-    portalId: 123,
-    appId: 345,
-    scopeGroups: ['crm.objects.contacts.read'],
-    userTokenKey: 'pat-na1-u-FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF',
-    clientId: 'my-client-id',
-    expiresAt: '2024-06-01T01:00:00Z',
-  };
-  const tokenWithMoreScopes = {
-    ...token,
-    scopeGroups: ['crm.objects.contacts.read', 'crm.objects.contacts.write'],
-  };
-  const refreshedToken = { ...token, expiresAt: '2024-06-01T02:00:00Z' };
-  const expiredToken = { ...token, expiresAt: '2024-05-30T00:00:00Z' };
   const pakScopesTokenEnabled = Promise.resolve([
     'developer.private_app.temporary_token.read',
     'developer.private_app.temporary_token.write',
   ]);
   const pakScopesTokenDisabled = Promise.resolve(['developer.projects.read']);
-  const headers = new AxiosHeaders();
-  const config = { url: 'https://api.hubspot.com', headers: headers };
 
-  const notFoundError = new AxiosError('msg', 'code', config, undefined, {
-    status: 404,
-    data: { message: 'Not Found' },
-    statusText: 'Not Found',
-    config,
-    headers,
-  });
-  it('should initialize the PrivateAppUserTokenManager', async () => {
-    scopeGroupsForPersonalAccessKey.mockReturnValue(pakScopesTokenEnabled);
-    const manager = new PrivateAppUserTokenManager(accountId);
-    await manager.init();
-    expect(manager.isEnabled()).toBe(true);
-    manager.cleanup();
-  });
-  it('should not initialize the PrivateAppUserTokenManager if the scopes are not enabled', async () => {
-    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenDisabled);
-    const manager = new PrivateAppUserTokenManager(accountId);
-    await manager.init();
-    expect(manager.isEnabled()).toBe(false);
-    manager.cleanup();
-  });
-  it('should fetch a existing valid Private App User Token', async () => {
-    fetchPrivateAppUserToken.mockResolvedValue(token);
-    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
-    const manager = new PrivateAppUserTokenManager(accountId);
-    await manager.init();
-    const result = await manager.getPrivateAppToken(token.appId);
-    expect(result).toEqual(token.userTokenKey);
-    manager.cleanup();
-  });
-  it('should used cached Private App User Token', async () => {
-    fetchPrivateAppUserToken.mockResolvedValue(token);
-    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
-    const manager = new PrivateAppUserTokenManager(accountId);
-    await manager.init();
-    await manager.getPrivateAppToken(token.appId);
-    const result = await manager.getPrivateAppToken(token.appId);
-    expect(result).toEqual(token.userTokenKey);
-    expect(fetchPrivateAppUserToken).toHaveBeenCalledTimes(1);
-    manager.cleanup();
-  });
-  it('should refresh existing expired Private App User Token', async () => {
-    fetchPrivateAppUserToken.mockResolvedValue(expiredToken);
-    updatePrivateAppUserToken.mockResolvedValue(token);
-    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
-    const manager = new PrivateAppUserTokenManager(accountId);
-    await manager.init();
-    const result = await manager.getPrivateAppToken(token.appId);
-    expect(result).toEqual(token.userTokenKey);
-    expect(updatePrivateAppUserToken).toHaveBeenCalledTimes(1);
-    manager.cleanup();
-  });
-  it('should create a new Private App User Token if none exist', async () => {
-    fetchPrivateAppUserToken.mockImplementation(() => {
-      throw notFoundError;
+  let manager: PrivateAppUserTokenManager;
+
+  describe('init()', () => {
+    beforeEach(() => {
+      manager = new PrivateAppUserTokenManager(accountId);
     });
-    createPrivateAppUserToken.mockResolvedValue(token);
-    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
-    const manager = new PrivateAppUserTokenManager(accountId);
-    await manager.init();
-    const result = await manager.getPrivateAppToken(token.appId);
-    expect(result).toEqual(token.userTokenKey);
-    expect(createPrivateAppUserToken).toHaveBeenCalledTimes(1);
-    manager.cleanup();
+
+    afterEach(() => {
+      manager.cleanup();
+    });
+
+    it('should enable PrivateAppUserTokenManager when personal access key has all scopes', async () => {
+      scopeGroupsForPersonalAccessKey.mockReturnValue(pakScopesTokenEnabled);
+      await manager.init();
+      expect(manager.isEnabled()).toBe(true);
+    });
+    it('should not enable PrivateAppUserTokenManager if the personal access key does not contain scopes', async () => {
+      scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenDisabled);
+      await manager.init();
+      expect(manager.isEnabled()).toBe(false);
+    });
   });
-  it('should not no opt if not initialized', async () => {
-    const manager = new PrivateAppUserTokenManager(accountId);
-    const result = await manager.getPrivateAppToken(token.appId);
-    expect(result).toBeUndefined();
-  });
-  it('should refresh cached token if it is about to expire', async () => {
-    fetchPrivateAppUserToken.mockResolvedValue(token);
-    updatePrivateAppUserToken.mockResolvedValue(refreshedToken);
-    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
-    const manager = new PrivateAppUserTokenManager(accountId);
-    await manager.init();
-    const tokenKey = await manager.getPrivateAppToken(token.appId);
-    expect(tokenKey).toEqual(token.userTokenKey);
-    jest.advanceTimersByTime(60 * 60 * 1000);
-    expect(updatePrivateAppUserToken).toHaveBeenCalledTimes(1);
-    manager.cleanup();
-  });
-  it('should update token is missing scopes', async () => {
-    fetchPrivateAppUserToken.mockResolvedValue(token);
-    updatePrivateAppUserToken.mockResolvedValue(tokenWithMoreScopes);
-    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
-    const manager = new PrivateAppUserTokenManager(accountId);
-    await manager.init();
-    await manager.getPrivateAppToken(token.appId);
-    const tokenKey = await manager.getPrivateAppToken(
-      token.appId,
-      tokenWithMoreScopes.scopeGroups
-    );
-    expect(tokenKey).toEqual(token.userTokenKey);
-    expect(fetchPrivateAppUserToken).toHaveBeenCalledTimes(1);
-    expect(updatePrivateAppUserToken).toHaveBeenCalledTimes(1);
-    manager.cleanup();
-  });
-  it('should clear token refresh if cleanup is called', async () => {
-    fetchPrivateAppUserToken.mockResolvedValue(token);
-    scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
-    const manager = new PrivateAppUserTokenManager(accountId);
-    await manager.init();
-    await manager.getPrivateAppToken(token.appId);
-    manager.cleanup();
-    jest.advanceTimersByTime(60 * 60 * 1000);
-    expect(updatePrivateAppUserToken).not.toHaveBeenCalled();
+
+  describe('getPrivateAppToken()', () => {
+    const systemTime = new Date(Date.UTC(2024, 5, 1, 0, 0, 0));
+
+    const token: PrivateAppUserTokenResponse = {
+      userId: 111,
+      portalId: 123,
+      appId: 345,
+      scopeGroups: ['crm.objects.contacts.read'],
+      userTokenKey: 'pat-na1-u-FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF',
+      clientId: 'my-client-id',
+      expiresAt: '2024-06-01T01:00:00Z',
+    };
+    const tokenWithMoreScopes = {
+      ...token,
+      scopeGroups: ['crm.objects.contacts.read', 'crm.objects.contacts.write'],
+    };
+    const refreshedToken = { ...token, expiresAt: '2024-06-01T02:00:00Z' };
+    const expiredToken = { ...token, expiresAt: '2024-05-30T00:00:00Z' };
+    const headers = new AxiosHeaders();
+    const config = { url: 'https://api.hubspot.com', headers: headers };
+
+    const notFoundError = new AxiosError('msg', 'code', config, undefined, {
+      status: 404,
+      data: { message: 'Not Found' },
+      statusText: 'Not Found',
+      config,
+      headers,
+    });
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+      scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenEnabled);
+      jest.spyOn(global, 'setInterval');
+      jest.useFakeTimers();
+      jest.setSystemTime(systemTime);
+      manager = new PrivateAppUserTokenManager(accountId);
+      manager.init();
+    });
+
+    afterEach(() => {
+      manager.cleanup();
+      jest.clearAllTimers();
+    });
+
+    it('should no opt if not initialized', async () => {
+      manager = new PrivateAppUserTokenManager(accountId); // set to new instance not initialized
+      const result = await manager.getPrivateAppToken(accountId);
+      expect(result).toBeUndefined();
+    });
+    it('should no opt if disabled', async () => {
+      scopeGroupsForPersonalAccessKey.mockResolvedValue(pakScopesTokenDisabled);
+      manager = new PrivateAppUserTokenManager(accountId); // set to new instance not initialized
+      await manager.init();
+      const result = await manager.getPrivateAppToken(accountId);
+      expect(result).toBeUndefined();
+    });
+    it('should fetch a existing valid Private App User Token', async () => {
+      fetchPrivateAppUserToken.mockResolvedValue(token);
+      const result = await manager.getPrivateAppToken(token.appId);
+      expect(result).toEqual(token.userTokenKey);
+    });
+    it('should used cached Private App User Token', async () => {
+      fetchPrivateAppUserToken.mockResolvedValue(token);
+      await manager.getPrivateAppToken(token.appId);
+      const result = await manager.getPrivateAppToken(token.appId);
+      expect(result).toEqual(token.userTokenKey);
+      expect(fetchPrivateAppUserToken).toHaveBeenCalledTimes(1);
+    });
+    it('should refresh existing expired Private App User Token', async () => {
+      fetchPrivateAppUserToken.mockResolvedValue(expiredToken);
+      updatePrivateAppUserToken.mockResolvedValue(token);
+      const result = await manager.getPrivateAppToken(token.appId);
+      expect(result).toEqual(token.userTokenKey);
+      expect(updatePrivateAppUserToken).toHaveBeenCalledTimes(1);
+    });
+    it('should create a new Private App User Token if none exist', async () => {
+      fetchPrivateAppUserToken.mockImplementation(() => {
+        throw notFoundError;
+      });
+      createPrivateAppUserToken.mockResolvedValue(token);
+      const result = await manager.getPrivateAppToken(token.appId);
+      expect(result).toEqual(token.userTokenKey);
+      expect(createPrivateAppUserToken).toHaveBeenCalledTimes(1);
+    });
+    it('should refresh cached token if it is about to expire', async () => {
+      fetchPrivateAppUserToken.mockResolvedValue(token);
+      updatePrivateAppUserToken.mockResolvedValue(refreshedToken);
+      const tokenKey = await manager.getPrivateAppToken(token.appId);
+      expect(tokenKey).toEqual(token.userTokenKey);
+      jest.advanceTimersByTime(60 * 60 * 1000);
+      expect(updatePrivateAppUserToken).toHaveBeenCalledTimes(1);
+    });
+    it('should update token is missing scopes', async () => {
+      fetchPrivateAppUserToken.mockResolvedValue(token);
+      updatePrivateAppUserToken.mockResolvedValue(tokenWithMoreScopes);
+      await manager.getPrivateAppToken(token.appId);
+      const tokenKey = await manager.getPrivateAppToken(
+        token.appId,
+        tokenWithMoreScopes.scopeGroups
+      );
+      expect(tokenKey).toEqual(token.userTokenKey);
+      expect(fetchPrivateAppUserToken).toHaveBeenCalledTimes(2); // initial get, and then fetches again when scopes don't match in cached token
+      expect(updatePrivateAppUserToken).toHaveBeenCalledTimes(1);
+    });
+    it('should clear token refresh if cleanup is called', async () => {
+      fetchPrivateAppUserToken.mockResolvedValue(token);
+      await manager.getPrivateAppToken(token.appId);
+      manager.cleanup();
+      jest.advanceTimersByTime(60 * 60 * 1000);
+      expect(updatePrivateAppUserToken).not.toHaveBeenCalled();
+    });
   });
 });

--- a/lib/personalAccessKey.ts
+++ b/lib/personalAccessKey.ts
@@ -133,7 +133,9 @@ async function getNewAccessToken(
   return accessTokenResponse;
 }
 
-async function getAccessTokenResponse(accountId: number) {
+async function getNewAccessTokenByAccountId(
+  accountId: number
+): Promise<AccessToken> {
   const account = getAccountConfig(accountId) as PersonalAccessKeyAccount;
   if (!account) {
     throwErrorWithMessage(`${i18nKey}.errors.accountNotFound`, { accountId });
@@ -179,14 +181,14 @@ export async function accessTokenForPersonalAccessKey(
 export async function enabledFeaturesForPersonalAccessKey(
   accountId: number
 ): Promise<{ [key: string]: number } | undefined> {
-  const accessTokenResponse = await getAccessTokenResponse(accountId);
+  const accessTokenResponse = await getNewAccessTokenByAccountId(accountId);
   return accessTokenResponse?.enabledFeatures;
 }
 
 export async function scopeGroupsForPersonalAccessKey(
   accountId: number
 ): Promise<Array<string>> {
-  return (await getAccessTokenResponse(accountId)).scopeGroups;
+  return (await getNewAccessTokenByAccountId(accountId)).scopeGroups;
 }
 
 export async function updateConfigWithAccessToken(

--- a/lib/personalAccessKey.ts
+++ b/lib/personalAccessKey.ts
@@ -133,6 +133,23 @@ async function getNewAccessToken(
   return accessTokenResponse;
 }
 
+async function getAccessTokenResponse(accountId: number) {
+  const account = getAccountConfig(accountId) as PersonalAccessKeyAccount;
+  if (!account) {
+    throwErrorWithMessage(`${i18nKey}.errors.accountNotFound`, { accountId });
+  }
+  const { auth, personalAccessKey, env } = account;
+  const authTokenInfo = auth && auth.tokenInfo;
+
+  const accessTokenResponse = await getNewAccessToken(
+    accountId,
+    personalAccessKey,
+    authTokenInfo && authTokenInfo.expiresAt,
+    env
+  );
+  return accessTokenResponse;
+}
+
 export async function accessTokenForPersonalAccessKey(
   accountId: number
 ): Promise<string | undefined> {
@@ -162,20 +179,14 @@ export async function accessTokenForPersonalAccessKey(
 export async function enabledFeaturesForPersonalAccessKey(
   accountId: number
 ): Promise<{ [key: string]: number } | undefined> {
-  const account = getAccountConfig(accountId) as PersonalAccessKeyAccount;
-  if (!account) {
-    throwErrorWithMessage(`${i18nKey}.errors.accountNotFound`, { accountId });
-  }
-  const { auth, personalAccessKey, env } = account;
-  const authTokenInfo = auth && auth.tokenInfo;
-
-  const accessTokenResponse = await getNewAccessToken(
-    accountId,
-    personalAccessKey,
-    authTokenInfo && authTokenInfo.expiresAt,
-    env
-  );
+  const accessTokenResponse = await getAccessTokenResponse(accountId);
   return accessTokenResponse?.enabledFeatures;
+}
+
+export async function scopeGroupsForPersonalAccessKey(
+  accountId: number
+): Promise<Array<string>> {
+  return (await getAccessTokenResponse(accountId)).scopeGroups;
 }
 
 export async function updateConfigWithAccessToken(

--- a/utils/PrivateAppUserTokenManager.ts
+++ b/utils/PrivateAppUserTokenManager.ts
@@ -46,6 +46,14 @@ export class PrivateAppUserTokenManager {
     }
   }
 
+  stopRefreshes() {
+    this.tokenMapIntervalId.forEach((appId, timeoutId) =>
+      clearInterval(timeoutId)
+    );
+    this.tokenMapIntervalId.clear();
+    this.tokenMap.clear();
+  }
+
   async getToken(
     appId: number,
     scopeGroups: string[] = []

--- a/utils/PrivateAppUserTokenManager.ts
+++ b/utils/PrivateAppUserTokenManager.ts
@@ -1,0 +1,190 @@
+import {
+  fetchPrivateAppUserToken,
+  createPrivateAppUserToken,
+  updatePrivateAppUserToken,
+  PrivateAppUserTokenResponse,
+} from '../api/privateAppUserToken';
+import { scopeGroupsForPersonalAccessKey } from '../lib/personalAccessKey';
+import { logger } from '../lib/logger';
+import { i18n } from './lang';
+import moment from 'moment';
+import { AxiosError } from 'axios';
+import { getAxiosErrorWithContext } from '../errors/apiErrors';
+
+const USER_TOKEN_READ = 'developer.private_app.temporary_token.read';
+const USER_TOKEN_WRITE = 'developer.private_app.temporary_token.write';
+const i18nKey = 'utils.PrivateAppUserTokenManager';
+
+export class PrivateAppUserTokenManager {
+  accountId: number;
+  tokenMap: Map<number, PrivateAppUserTokenResponse>;
+  tokenMapIntervalId: Map<number, NodeJS.Timeout>;
+  enabled: boolean;
+
+  constructor(accountId: number) {
+    this.accountId = accountId;
+    this.tokenMap = new Map<number, PrivateAppUserTokenResponse>();
+    this.tokenMapIntervalId = new Map<number, NodeJS.Timeout>();
+    this.enabled = false;
+  }
+
+  async init(): Promise<void> {
+    const scopeGroups = new Set<string>(
+      await scopeGroupsForPersonalAccessKey(this.accountId)
+    );
+    if (
+      !scopeGroups.has(USER_TOKEN_READ) ||
+      !scopeGroups.has(USER_TOKEN_WRITE)
+    ) {
+      logger.warn(
+        i18n(`${i18nKey}.errors.noScopes`, {
+          accountId: this.accountId,
+        })
+      );
+    } else {
+      this.enabled = true;
+    }
+  }
+
+  async getToken(
+    appId: number,
+    scopeGroups: string[] = []
+  ): Promise<PrivateAppUserTokenResponse | undefined> {
+    if (!this.enabled) {
+      logger.debug(
+        i18n(`${i18nKey}.disabled`, {
+          accountId: this.accountId,
+          appId: appId,
+        })
+      );
+      return;
+    }
+
+    if (
+      this.tokenMap.has(appId) &&
+      PrivateAppUserTokenManager.doesTokenHaveAllScopes(
+        this.tokenMap.get(appId),
+        scopeGroups
+      )
+    ) {
+      return this.tokenMap.get(appId);
+    } else {
+      const token = await this.createOrGetActiveToken(appId, scopeGroups);
+      this.setCacheAndRefresh(appId, token, scopeGroups);
+      return token;
+    }
+  }
+
+  private setCacheAndRefresh(
+    appId: number,
+    token: PrivateAppUserTokenResponse,
+    scopeGroups: string[]
+  ) {
+    this.tokenMap.set(appId, token);
+    if (this.tokenMapIntervalId.has(appId)) {
+      clearInterval(this.tokenMapIntervalId.get(appId));
+    }
+    const now = moment.utc();
+    const refreshDelayMillis = Math.max(
+      moment
+        .utc(token.expiresAt)
+        .subtract(5, 'minutes')
+        .diff(now, 'milliseconds'),
+      0
+    );
+    this.tokenMapIntervalId.set(
+      appId,
+      setInterval(
+        () => this.refreshToken(appId, token.userTokenKey, scopeGroups),
+        refreshDelayMillis
+      )
+    );
+    logger.debug(
+      i18n(`${i18nKey}.refreshScheduled`, {
+        appId: appId,
+        expiresAt: token.expiresAt,
+        refreshTime: now.add(refreshDelayMillis, 'milliseconds').toISOString(),
+      })
+    );
+  }
+
+  private async createOrGetActiveToken(
+    appId: number,
+    scopeGroups: string[]
+  ): Promise<PrivateAppUserTokenResponse> {
+    const maybeToken = await this.getExistingToken(appId);
+    if (maybeToken === null) {
+      logger.debug(
+        i18n(`${i18nKey}.create`, {
+          appId: appId,
+        })
+      );
+      return createPrivateAppUserToken(this.accountId, appId, scopeGroups);
+    } else if (
+      moment().add(5, 'minutes').isAfter(moment.utc(maybeToken.expiresAt)) ||
+      !PrivateAppUserTokenManager.doesTokenHaveAllScopes(
+        maybeToken,
+        scopeGroups
+      )
+    ) {
+      logger.debug(
+        i18n(`${i18nKey}.refresh`, {
+          appId: appId,
+        })
+      );
+      return updatePrivateAppUserToken(
+        this.accountId,
+        appId,
+        maybeToken.userTokenKey,
+        scopeGroups
+      );
+    }
+    return maybeToken;
+  }
+
+  private static doesTokenHaveAllScopes(
+    token: PrivateAppUserTokenResponse | undefined,
+    requestedScopes: string[]
+  ): boolean {
+    if (token === undefined) {
+      return false;
+    }
+    return requestedScopes.every(scopeGroup =>
+      token.scopeGroups.includes(scopeGroup)
+    );
+  }
+
+  private async getExistingToken(
+    appId: number
+  ): Promise<PrivateAppUserTokenResponse | null> {
+    try {
+      return await fetchPrivateAppUserToken(this.accountId, appId);
+    } catch (err) {
+      const responseErr = err as AxiosError;
+      if (responseErr.status == 404) {
+        return null;
+      }
+      logger.debug(getAxiosErrorWithContext(err as AxiosError).message);
+      throw err;
+    }
+  }
+
+  private async refreshToken(
+    appId: number,
+    userTokenKey: string,
+    scopeGroups: string[]
+  ) {
+    logger.debug(
+      i18n(`${i18nKey}.refresh`, {
+        appId: appId,
+      })
+    );
+    const newToken = await updatePrivateAppUserToken(
+      this.accountId,
+      appId,
+      userTokenKey,
+      scopeGroups
+    );
+    this.setCacheAndRefresh(appId, newToken, scopeGroups);
+  }
+}


### PR DESCRIPTION
## Description and Context
Private app user tokens are temporary Private App tokens scoped to the portal and user of the Personal Access Key. Using this user can avoid grabbing the real Private app token that is used for in the serverless instances. 

Adds api calls to private app user token endpoints in localdevauth and creates a manager class to manage these token refreshes when they expire. 

## Screenshots

<img width="909" alt="Screenshot 2024-06-18 at 11 17 12 AM" src="https://github.com/HubSpot/hubspot-local-dev-lib/assets/159944531/2033a904-e021-45ac-aa63-100e575d759b">
local cli run with logs showing usage. 

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
