### PR TITLE
chore: Make error handlers accept unknown and clean up type assertions

### DIFF
--- a/config/configFile.ts
+++ b/config/configFile.ts
@@ -11,7 +11,6 @@ import {
 } from '../constants/config';
 import { getOrderedConfig } from './configUtils';
 import { CLIConfig_NEW } from '../types/Config';
-import { BaseError } from '../types/Error';
 import { i18n } from '../utils/lang';
 
 const i18nKey = 'config.configFile';
@@ -49,7 +48,7 @@ export function readConfigFile(configPath: string): string {
     source = fs.readFileSync(configPath).toString();
   } catch (err) {
     logger.debug(i18n(`${i18nKey}.errorReading`, { configPath }));
-    throwFileSystemError(err as BaseError, {
+    throwFileSystemError(err, {
       filepath: configPath,
       read: true,
     });
@@ -67,7 +66,7 @@ export function parseConfig(configSource: string): CLIConfig_NEW {
   try {
     parsed = yaml.load(configSource) as CLIConfig_NEW;
   } catch (err) {
-    throwErrorWithMessage(`${i18nKey}.errors.parsing`, {}, err as BaseError);
+    throwErrorWithMessage(`${i18nKey}.errors.parsing`, {}, err);
   }
 
   return parsed;
@@ -104,7 +103,7 @@ export function writeConfigToFile(config: CLIConfig_NEW): void {
       JSON.parse(JSON.stringify(getOrderedConfig(config), null, 2))
     );
   } catch (err) {
-    throwError(err as BaseError);
+    throwError(err);
   }
   const configPath = getConfigFilePath();
 
@@ -113,7 +112,7 @@ export function writeConfigToFile(config: CLIConfig_NEW): void {
     fs.writeFileSync(configPath, source);
     logger.debug(i18n(`${i18nKey}.writeSuccess`, { configPath }));
   } catch (err) {
-    throwFileSystemError(err as BaseError, {
+    throwFileSystemError(err, {
       filepath: configPath,
       write: true,
     });

--- a/errors/apiErrors.ts
+++ b/errors/apiErrors.ts
@@ -3,10 +3,7 @@ import { AxiosErrorContext, BaseError, ValidationError } from '../types/Error';
 import { HTTP_METHOD_VERBS, HTTP_METHOD_PREPOSITIONS } from '../constants/api';
 import { i18n } from '../utils/lang';
 import { throwError } from './standardErrors';
-import {
-  HubSpotAuthError,
-  isHubSpotAuthError,
-} from '../models/HubSpotAuthError';
+import { HubSpotAuthError } from '../models/HubSpotAuthError';
 import { HttpMethod } from '../types/Api';
 
 const i18nKey = 'errors.apiErrors';
@@ -77,9 +74,10 @@ export function isSpecifiedHubSpotAuthError(
   err: unknown,
   { status, category, subCategory }: Partial<HubSpotAuthError>
 ): err is HubSpotAuthError {
-  if (!isHubSpotAuthError(err)) {
+  if (!err || !(err instanceof HubSpotAuthError)) {
     return false;
   }
+
   const statusCodeErr = !status || err.status === status;
   const categoryErr = !category || err.category === category;
   const subCategoryErr = !subCategory || err.subCategory === subCategory;

--- a/errors/fileSystemErrors.ts
+++ b/errors/fileSystemErrors.ts
@@ -1,11 +1,11 @@
 import { i18n } from '../utils/lang';
 import { isSystemError } from './standardErrors';
-import { BaseError, FileSystemErrorContext } from '../types/Error';
+import { FileSystemErrorContext } from '../types/Error';
 
 const i18nKey = 'errors.fileSystemErrors';
 
 export function getFileSystemError(
-  error: BaseError,
+  error: unknown,
   context: FileSystemErrorContext
 ): Error {
   let fileAction = '';
@@ -36,7 +36,7 @@ export function getFileSystemError(
  * @throws
  */
 export function throwFileSystemError(
-  error: BaseError,
+  error: unknown,
   context: FileSystemErrorContext
 ) {
   throw getFileSystemError(error, context);

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -6,7 +6,6 @@ import extract from 'extract-zip';
 import { throwFileSystemError } from '../errors/fileSystemErrors';
 import { throwErrorWithMessage } from '../errors/standardErrors';
 import { logger } from './logger';
-import { BaseError } from '../types/Error';
 import { i18n } from '../utils/lang';
 
 const i18nKey = 'lib.archive';
@@ -39,16 +38,12 @@ async function extractZip(
     });
   } catch (err) {
     if (tmpZipPath || result.tmpDir) {
-      throwFileSystemError(err as BaseError, {
+      throwFileSystemError(err, {
         filepath: tmpZipPath || result.tmpDir,
         write: true,
       });
     } else {
-      throwErrorWithMessage(
-        `${i18nKey}.extractZip.errors.write`,
-        {},
-        err as BaseError
-      );
+      throwErrorWithMessage(`${i18nKey}.extractZip.errors.write`, {}, err);
     }
     return result;
   }
@@ -58,11 +53,7 @@ async function extractZip(
     await extract(tmpZipPath, { dir: tmpExtractPath });
     result.extractDir = tmpExtractPath;
   } catch (err) {
-    throwErrorWithMessage(
-      `${i18nKey}.extractZip.errors.extract`,
-      {},
-      err as BaseError
-    );
+    throwErrorWithMessage(`${i18nKey}.extractZip.errors.extract`, {}, err);
   }
   logger.debug(i18n(`${i18nKey}.extractZip.success`));
   return result;
@@ -113,7 +104,7 @@ async function copySourceToDest(
     return true;
   } catch (err) {
     logger.debug(i18n(`${i18nKey}.copySourceToDest.error`, { dest }));
-    throwFileSystemError(err as BaseError, {
+    throwFileSystemError(err, {
       filepath: dest,
       write: true,
     });

--- a/lib/cms/functions.ts
+++ b/lib/cms/functions.ts
@@ -6,7 +6,6 @@ import { downloadGithubRepoContents } from '../github';
 import { logger } from '../logger';
 import { throwErrorWithMessage } from '../../errors/standardErrors';
 import { throwFileSystemError } from '../../errors/fileSystemErrors';
-import { BaseError } from '../../types/Error';
 import { i18n } from '../../utils/lang';
 
 const i18nKey = 'lib.cms.functions';
@@ -79,7 +78,7 @@ function updateExistingConfig(
         configFilePath,
       })
     );
-    throwFileSystemError(err as BaseError, {
+    throwFileSystemError(err, {
       filepath: configFilePath,
       read: true,
     });
@@ -94,7 +93,7 @@ function updateExistingConfig(
         configFilePath,
       })
     );
-    throwFileSystemError(err as BaseError, {
+    throwFileSystemError(err, {
       filepath: configFilePath,
       read: true,
     });
@@ -134,7 +133,7 @@ function updateExistingConfig(
         configFilePath,
       })
     );
-    throwFileSystemError(err as BaseError, {
+    throwFileSystemError(err, {
       filepath: configFilePath,
       write: true,
     });
@@ -248,7 +247,7 @@ export async function createFunction(
           configFilePath,
         })
       );
-      throwFileSystemError(err as BaseError, {
+      throwFileSystemError(err, {
         filepath: configFilePath,
         write: true,
       });

--- a/lib/cms/handleFieldsJS.ts
+++ b/lib/cms/handleFieldsJS.ts
@@ -124,7 +124,7 @@ export class FieldsJs {
       throwErrorWithMessage(
         `${i18nKey}.saveOutput.errors.saveFailed`,
         { path: savePath },
-        err as BaseError
+        err
       );
     }
   }
@@ -177,7 +177,7 @@ export function createTmpDirSync(prefix: string): string {
     throwErrorWithMessage(
       `${i18nKey}.createTmpDirSync.errors.writeFailed`,
       {},
-      err as BaseError
+      err
     );
   }
   return tmpDir;
@@ -190,7 +190,7 @@ export function cleanupTmpDirSync(tmpDir: string): void {
       throwErrorWithMessage(
         `${i18nKey}.cleanupTmpDirSync.errors.deleteFailed`,
         {},
-        err as BaseError
+        err
       );
     }
   });

--- a/lib/customObjects.ts
+++ b/lib/customObjects.ts
@@ -1,7 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
 import prettier from 'prettier';
-import { AxiosError } from 'axios';
 import { getCwd } from '../lib/path';
 import { fetchObjectSchemas, fetchObjectSchema } from '../api/customObjects';
 import { FetchSchemasResponse, Schema } from '../types/Schemas';
@@ -32,7 +31,7 @@ export async function downloadSchemas(
   try {
     response = await fetchObjectSchemas(accountId);
   } catch (err) {
-    throwApiError(err as AxiosError);
+    throwApiError(err);
   }
 
   if (response.results.length) {
@@ -54,7 +53,7 @@ export async function downloadSchema(
   try {
     response = await fetchObjectSchema(accountId, schemaObjectType);
   } catch (err) {
-    throwApiError(err as AxiosError);
+    throwApiError(err);
   }
 
   await writeSchemaToDisk(response, dest);

--- a/lib/developerTestAccounts.ts
+++ b/lib/developerTestAccounts.ts
@@ -4,7 +4,6 @@ import {
   deleteDeveloperTestAccount as _deleteDeveloperTestAccount,
 } from '../api/developerTestAccounts';
 
-import { AxiosError } from 'axios';
 import { throwApiError } from '../errors/apiErrors';
 import {
   DeveloperTestAccount,
@@ -19,7 +18,7 @@ export async function createDeveloperTestAccount(
     const resp = await _createDeveloperTestAccount(accountId, accountName);
     return resp;
   } catch (err) {
-    throwApiError(err as AxiosError);
+    throwApiError(err);
   }
 }
 
@@ -31,7 +30,7 @@ export async function deleteDeveloperTestAccount(
     const resp = await _deleteDeveloperTestAccount(accountId, testAccountId);
     return resp;
   } catch (err) {
-    throwApiError(err as AxiosError);
+    throwApiError(err);
   }
 }
 
@@ -42,6 +41,6 @@ export async function fetchDeveloperTestAccounts(
     const resp = await _fetchDeveloperTestAccounts(accountId);
     return resp;
   } catch (err) {
-    throwApiError(err as AxiosError);
+    throwApiError(err);
   }
 }

--- a/lib/fileManager.ts
+++ b/lib/fileManager.ts
@@ -27,9 +27,8 @@ import {
   throwError,
 } from '../errors/standardErrors';
 import { throwFileSystemError } from '../errors/fileSystemErrors';
-import { BaseError, GenericError } from '../types/Error';
+import { GenericError } from '../types/Error';
 import { File, Folder } from '../types/FileManager';
-import { AxiosError } from 'axios';
 import { i18n } from '../utils/lang';
 
 type SimplifiedFolder = Partial<Folder> & Pick<Folder, 'id' | 'name'>;
@@ -62,9 +61,8 @@ export async function uploadFolder(
       await uploadFile(accountId, file, destPath);
       logger.log(i18n(`${i18nKey}.uploadSuccess`, { file, destPath }));
     } catch (err) {
-      const error = err as BaseError;
-      if (isFatalError(error)) {
-        throwError(error);
+      if (isFatalError(err)) {
+        throwError(err);
       }
       throwErrorWithMessage(`${i18nKey}.errors.uploadFailed`, {
         file,
@@ -148,7 +146,7 @@ async function fetchFolderContents(
   try {
     await fs.ensureDir(dest);
   } catch (err) {
-    throwFileSystemError(err as BaseError, {
+    throwFileSystemError(err, {
       dest,
       accountId,
       write: true,
@@ -299,7 +297,7 @@ export async function downloadFileOrFolder(
   } catch (err) {
     const error = err as GenericError;
     if (error.isAxiosError) {
-      throwApiError(err as AxiosError, {
+      throwApiError(err, {
         request: src,
         accountId,
       });

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -23,7 +23,6 @@ import {
 } from '../types/Files';
 import { throwFileSystemError } from '../errors/fileSystemErrors';
 import { isTimeoutError } from '../errors/apiErrors';
-import { BaseError } from '../types/Error';
 import { i18n } from '../utils/lang';
 
 const i18nKey = 'lib.fileMapper';
@@ -163,7 +162,7 @@ export async function writeUtimes(
     const mtime = node.updatedAt ? new Date(node.updatedAt) : now;
     await fs.utimes(filepath, atime, mtime);
   } catch (err) {
-    throwFileSystemError(err as BaseError, {
+    throwFileSystemError(err, {
       filepath,
       accountId,
       write: true,
@@ -210,7 +209,7 @@ async function fetchAndWriteFileStream(
       getFileMapperQueryValues(mode, options)
     );
   } catch (err) {
-    throwError(err as BaseError);
+    throwError(err);
   }
   await writeUtimes(accountId, filepath, node);
 }
@@ -255,7 +254,7 @@ async function writeFileMapperNode(
       })
     );
   } catch (err) {
-    throwFileSystemError(err as BaseError, {
+    throwFileSystemError(err, {
       filepath: localFilepath,
       accountId,
       write: true,
@@ -396,7 +395,7 @@ async function downloadFolder(
       throwErrorWithMessage(
         `${i18nKey}.errors.failedToFetchFolder`,
         { src, dest: destPath },
-        err as AxiosError
+        err
       );
     }
   }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -37,7 +37,7 @@ export async function fetchFileFromRepository(
     throwErrorWithMessage(
       `${i18nKey}.fetchFileFromRepository.errors.fetchFail`,
       {},
-      err as BaseError
+      err
     );
   }
 }
@@ -58,11 +58,10 @@ export async function fetchReleaseData(
     const { data } = await fetchRepoReleaseData(repoPath, tag);
     return data;
   } catch (err) {
-    const error = err as BaseError;
     throwErrorWithMessage(
       `${i18nKey}.fetchReleaseData.errors.fetchFail`,
       { tag: tag || 'latest' },
-      error
+      err
     );
   }
 }
@@ -106,7 +105,7 @@ async function downloadGithubRepoZip(
     throwErrorWithMessage(
       `${i18nKey}.downloadGithubRepoZip.errors.fetchFail`,
       {},
-      err as BaseError
+      err
     );
   }
 }

--- a/lib/gitignore.ts
+++ b/lib/gitignore.ts
@@ -8,7 +8,6 @@ import {
 } from '../utils/git';
 import { DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME } from '../constants/config';
 import { throwErrorWithMessage } from '../errors/standardErrors';
-import { BaseError } from '../types/Error';
 
 const i18nKey = 'lib.gitignore';
 
@@ -31,7 +30,7 @@ export function checkAndAddConfigToGitignore(configPath: string): void {
     const updatedContents = `${gitignoreContents.trim()}\n\n# HubSpot config file\n${DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME}\n`;
     writeFileSync(gitignoreFilePath, updatedContents);
   } catch (e) {
-    throwErrorWithMessage(`${i18nKey}.errors.configIgnore`, {}, e as BaseError);
+    throwErrorWithMessage(`${i18nKey}.errors.configIgnore`, {}, e);
   }
 }
 

--- a/lib/hubdb.ts
+++ b/lib/hubdb.ts
@@ -13,7 +13,6 @@ import {
 import { getCwd } from './path';
 import { FetchRowsResponse, Row, Table } from '../types/Hubdb';
 import { throwErrorWithMessage } from '../errors/standardErrors';
-import { BaseError } from '../types/Error';
 
 const i18nKey = 'lib.hubdb';
 
@@ -29,11 +28,7 @@ function validateJsonFile(src: string): void {
   try {
     stats = fs.statSync(src);
   } catch (err) {
-    throwErrorWithMessage(
-      `${i18nKey}.errors.invalidJsonFile`,
-      { src },
-      err as BaseError
-    );
+    throwErrorWithMessage(`${i18nKey}.errors.invalidJsonFile`, { src }, err);
   }
 
   if (!stats.isFile()) {

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -3,7 +3,6 @@ import moment from 'moment';
 import debounce from 'debounce';
 
 import { throwErrorWithMessage } from '../errors/standardErrors';
-import { BaseError } from '../types/Error';
 
 const i18nKey = 'utils.notify';
 
@@ -54,7 +53,7 @@ function notifyFilePath(filePathToNotify: string, outputToWrite: string): void {
       throwErrorWithMessage(
         `${i18nKey}.errors.filePath`,
         { filePath: filePathToNotify },
-        e as BaseError
+        e
       );
     }
   }

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -3,7 +3,6 @@ import { AUTH_METHODS } from '../constants/auth';
 import { FlatAccountFields } from '../types/Accounts';
 import { throwError } from '../errors/standardErrors';
 import { logger } from './logger';
-import { BaseError } from '../types/Error';
 import { getAccountIdentifier } from '../utils/getAccountIdentifier';
 import { updateAccountConfig, writeConfig } from '../config';
 import { i18n } from '../utils/lang';
@@ -48,6 +47,6 @@ export function addOauthToAccountConfig(oauth: OAuth2Manager) {
     writeConfig();
     logger.success(i18n(`${i18nKey}.addOauthToAccountConfig.success`));
   } catch (err) {
-    throwError(err as BaseError);
+    throwError(err);
   }
 }

--- a/lib/personalAccessKey.ts
+++ b/lib/personalAccessKey.ts
@@ -9,7 +9,6 @@ import {
 } from '../errors/standardErrors';
 import { fetchAccessToken } from '../api/localDevAuth';
 import { fetchSandboxHubData } from '../api/sandboxHubs';
-import { BaseError } from '../types/Error';
 import { CLIAccount, PersonalAccessKeyAccount } from '../types/Accounts';
 import { Environment } from '../types/Config';
 import {
@@ -61,7 +60,7 @@ export async function getAccessToken(
         error
       );
     } else {
-      throwError(e as BaseError);
+      throwError(e);
     }
   }
   return {

--- a/lib/sandboxes.ts
+++ b/lib/sandboxes.ts
@@ -16,7 +16,6 @@ import {
   TaskRequestData,
   Usage,
 } from '../types/Sandbox';
-import { AxiosError } from 'axios';
 import { throwApiError } from '../errors/apiErrors';
 
 export async function createSandbox(
@@ -35,7 +34,7 @@ export async function createSandbox(
       ...resp,
     };
   } catch (err) {
-    throwApiError(err as AxiosError);
+    throwApiError(err);
   }
 }
 
@@ -46,7 +45,7 @@ export async function deleteSandbox(
   try {
     await _deleteSandbox(parentAccountId, sandboxAccountId);
   } catch (err) {
-    throwApiError(err as AxiosError);
+    throwApiError(err);
   }
 
   return {
@@ -62,7 +61,7 @@ export async function getSandboxUsageLimits(
     const resp = await _getSandboxUsageLimits(parentAccountId);
     return resp && resp.usage;
   } catch (err) {
-    throwApiError(err as AxiosError);
+    throwApiError(err);
   }
 }
 
@@ -75,7 +74,7 @@ export async function initiateSync(
   try {
     return await _initiateSync(fromHubId, toHubId, tasks, sandboxHubId);
   } catch (err) {
-    throwApiError(err as AxiosError);
+    throwApiError(err);
   }
 }
 
@@ -86,7 +85,7 @@ export async function fetchTaskStatus(
   try {
     return await _fetchTaskStatus(accountId, taskId);
   } catch (err) {
-    throwApiError(err as AxiosError);
+    throwApiError(err);
   }
 }
 
@@ -98,6 +97,6 @@ export async function fetchTypes(
     const resp = await _fetchTypes(accountId, toHubId);
     return resp && resp.results;
   } catch (err) {
-    throwApiError(err as AxiosError);
+    throwApiError(err);
   }
 }

--- a/models/HubSpotAuthError.ts
+++ b/models/HubSpotAuthError.ts
@@ -23,7 +23,3 @@ export class HubSpotAuthError extends Error {
       undefined;
   }
 }
-
-export function isHubSpotAuthError(err: unknown): err is HubSpotAuthError {
-  return !!err && err instanceof HubSpotAuthError;
-}

--- a/models/HubSpotAuthError.ts
+++ b/models/HubSpotAuthError.ts
@@ -23,3 +23,7 @@ export class HubSpotAuthError extends Error {
       undefined;
   }
 }
+
+export function isHubSpotAuthError(err: unknown): err is HubSpotAuthError {
+  return !!err && err instanceof HubSpotAuthError;
+}

--- a/models/OAuth2Manager.ts
+++ b/models/OAuth2Manager.ts
@@ -12,7 +12,6 @@ import {
   throwErrorWithMessage,
   throwAuthErrorWithMessage,
 } from '../errors/standardErrors';
-import { BaseError } from '../types/Error';
 import { Environment } from '../types/Config';
 import { i18n } from '../utils/lang';
 
@@ -125,7 +124,7 @@ class OAuth2Manager {
       this.refreshTokenRequest = null;
     } catch (e) {
       this.refreshTokenRequest = null;
-      throwError(e as BaseError);
+      throwError(e);
     }
   }
 


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
**_This PR looks huge, but the big changes are localized to a couple of files that I tagged with comments, the rest are typescript changes, or updating tests._**

Updates functions that take errors as arguments to take type `unknown` and to type narrow the error to prevent the methods to require type assertions every time they are called.  

The reasoning behind this:
- The default type of the `error` in catch blocks is `unknown` and it is considered a bad practice to set it to anything other than `unknown`.  
- It required type assertions on every invocation and they are considered a bad practice because they are disabling the type system by us asserting we know the type with full certainty.  Because of this they give us a false sense of type security
 

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
- [ ] Integrate this with the CLI and test things are working as expected

## Who to Notify

<!-- /cc those you wish to know about the PR -->
@camden11 @brandenrodgers @kemmerle 