### PR TITLE
add support for react modules to enable lang translations internally

### DIFF
--- a/lib/cms/handleFieldsJS.ts
+++ b/lib/cms/handleFieldsJS.ts
@@ -116,7 +116,6 @@ export class FieldsJs {
 
   // Create a temporary file with the fields data
   private createTempFile(data: JSON): Promise<string> {
-    console.log(data);
     const tempDir = os.tmpdir();
     const tempFilePath = path.join(tempDir, `fields-${Date.now()}.json`);
 

--- a/lib/cms/handleFieldsJS.ts
+++ b/lib/cms/handleFieldsJS.ts
@@ -45,7 +45,6 @@ export class FieldsJs {
 
   async init(): Promise<this> {
     if (this.fields) {
-      console.log(this.fields);
       const tempFilePath = await this.createTempFile(this.fields);
       this.outputPath = tempFilePath;
     } else {


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Supports an internal use case where we need to translate lang keys for react modules. The changes in here support passing along JSON fields instead of a file path when it comes to react modules. 

## Screenshots

<!-- Provide images of the before and after functionality -->
These changes, along with some changes to an internal lib enable functionality like you will see below for generating lang keys on internal HS projects:
![translate-react-fields](https://github.com/HubSpot/hubspot-local-dev-lib/assets/22771842/b8321528-1f03-415d-80f4-0a24b19fe80b)