### PR TITLE
Add endpoint to fetch single public app metadata (Sister PR in HubSpot CLI)

### DIFF
--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -28,3 +28,12 @@ export function fetchPublicAppDeveloperTestAccountInstallData(
     url: `${APPS_DEV_API_PATH}/${appId}/test-portal-installs`,
   });
 }
+
+export function fetchPublicAppMetadata(
+  appId: number,
+  accountId: number
+): Promise<PublicApp> {
+  return http.get<PublicApp>(accountId, {
+    url: `${APPS_DEV_API_PATH}/${appId}/full`,
+  });
+}

--- a/types/Apps.ts
+++ b/types/Apps.ts
@@ -43,9 +43,24 @@ export type PublicApp = {
   };
   redirectUrls: Array<string>;
   scopeGroupIds: Array<number>;
+  requiredScopeInfo?: Array<{ id: number; name: string }>;
   additionalScopeGroupIds: Array<number>;
+  additionalScopeInfo?: Array<{ id: number; name: string }>;
   optionalScopeGroupIds: Array<number>;
+  optionalScopeInfo?: Array<{ id: number; name: string }>;
   projectId: number | null;
   sourceId: string | null;
+  providerInfo?: {
+    domain: string;
+    isVerified: boolean;
+  };
+  listingInfo?: {
+    listingUrl: string;
+    isCertified: boolean;
+    isPublished: boolean;
+    hasDraft: boolean;
+    inReview: boolean;
+  };
   allowedExternalUrls: Array<string>;
+  preventProjectMigrations?: boolean;
 };


### PR DESCRIPTION
## Description and Context
Chris C. added an endpoint that returns metadata for a single public app. He also added a new property, preventProjectMigrations, a boolean that returns true when the app is a marketplace app that has not been added to the Ecosystem Quality review whitelist. This ties in disabling project migrations directly with the allow-list, which better future proofs this command.

This PR has a sister [PR](https://github.com/HubSpot/hubspot-cli/pull/1111) in the CLI. See that description for full context.

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address feedback

## Who to Notify

<!-- /cc those you wish to know about the PR -->
@brandenrodgers @joe-yeager 
