### PR TITLE
Allow different types of for Data for axios request config

### DIFF
--- a/types/Http.ts
+++ b/types/Http.ts
@@ -1,4 +1,5 @@
 import { ReadStream } from 'fs';
+import { Stream } from 'stream';
 
 export type Data = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -15,7 +16,14 @@ export type AxiosConfigOptions = {
   env?: string;
   localHostOverride?: boolean;
   params?: QueryParams;
-  data?: Data;
+  data?:
+    | Data
+    | string
+    | ArrayBuffer
+    | ArrayBufferView
+    | URLSearchParams
+    | Stream
+    | Buffer;
   resolveWithFullResponse?: boolean;
   timeout?: number;
   headers?: Data;


### PR DESCRIPTION
## Description and Context

Axios allows for more than just a plain JSON object for `data` in the config - see https://axios-http.com/docs/req_config. We have a need to pass a string here, and the PR just opens up the type based on the documentation.

