### PR TITLE
Export getAxiosConfig from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "./api/*": "./api/*.js",
     "./errors/*": "./errors/*.js",
     "./http": "./http/index.js",
+    "./http/*": "./http/*.js",
     "./config": "./config/index.js",
     "./constants/*": "./constants/*.js",
     "./models/*": "./models/*.js"


### PR DESCRIPTION
## Description and Context
This exports `getAxiosConfig` from `local-dev-lib`. This will make it easier to make un-authed requests to HubSpot APIs, which is not currently supported by the `http` module.

More context: https://hubspot.slack.com/archives/C076QV345ME/p1721328218238189

## TODO
In the future, we should provide a way to make un-authed requests directly from the `http` module.

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
