### PR TITLE
Add API function to get public app install counts without delay

### DIFF
--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -1,6 +1,7 @@
 import http from '../http';
 import {
   PublicApp,
+  PublicApInstallCounts,
   PublicAppDeveloperTestAccountInstallData,
 } from '../types/Apps';
 
@@ -26,6 +27,15 @@ export function fetchPublicAppDeveloperTestAccountInstallData(
 ): Promise<PublicAppDeveloperTestAccountInstallData> {
   return http.get<PublicAppDeveloperTestAccountInstallData>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/test-portal-installs`,
+  });
+}
+
+export function fetchPublicAppProductionInstallCounts(
+  appId: number,
+  accountId: number
+): Promise<PublicApInstallCounts> {
+  return http.get<PublicApInstallCounts>(accountId, {
+    url: `${APPS_DEV_API_PATH}/${appId}/install-counts-without-test-portals`,
   });
 }
 

--- a/types/Apps.ts
+++ b/types/Apps.ts
@@ -15,6 +15,12 @@ export type PublicAppDeveloperTestAccountInstallData = {
   testPortalInstallCount: string;
 };
 
+export type PublicApInstallCounts = {
+  uniquePortalInstallCount: number;
+  uniqueUserInstallCount: number;
+  uniqueBusinessUnitInstallCount: number;
+};
+
 export type PublicApp = {
   id: number;
   name: string;
@@ -36,11 +42,7 @@ export type PublicApp = {
   supportPhone: string | null;
   extensionIconUrl: string | null;
   isAdvancedScopesSettingEnabled: boolean;
-  publicApplicationInstallCounts: {
-    uniquePortalInstallCount: number;
-    uniqueUserInstallCount: number;
-    uniqueBusinessUnitInstallCount: number;
-  };
+  publicApplicationInstallCounts: PublicApInstallCounts;
   redirectUrls: Array<string>;
   scopeGroupIds: Array<number>;
   requiredScopeInfo?: Array<{ id: number; name: string }>;


### PR DESCRIPTION
## Description and Context
This adds support for hitting the new `apps-dev/external/public/v3/{appId}/install-counts-without-test-portals` endpoint, which returns public app production installs without the 30 minute delay the endpoint we were previously using had. This will allow the CLI to give users more up to date info about whether or not their public apps have active installs

## Who to Notify

@brandenrodgers @kemmerle @joe-yeager 
