### PR TITLE
Expose axios response

### DIFF
--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -12,7 +12,7 @@ type FetchPublicAppsForPortalResponse = {
   results: Array<PublicApp>;
 };
 
-export async function fetchPublicAppsForPortal(
+export function fetchPublicAppsForPortal(
   accountId: number
 ): AxiosPromise<FetchPublicAppsForPortalResponse> {
   return http.get<FetchPublicAppsForPortalResponse>(accountId, {

--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import http from '../http';
 import {
   PublicApp,
@@ -13,18 +14,16 @@ type FetchPublicAppsForPortalResponse = {
 
 export async function fetchPublicAppsForPortal(
   accountId: number
-): Promise<Array<PublicApp>> {
-  const resp = await http.get<FetchPublicAppsForPortalResponse>(accountId, {
+): AxiosPromise<FetchPublicAppsForPortalResponse> {
+  return http.get<FetchPublicAppsForPortalResponse>(accountId, {
     url: `${APPS_DEV_API_PATH}/full/portal`,
   });
-
-  return resp ? resp.results : [];
 }
 
 export function fetchPublicAppDeveloperTestAccountInstallData(
   appId: number,
   accountId: number
-): Promise<PublicAppDeveloperTestAccountInstallData> {
+): AxiosPromise<PublicAppDeveloperTestAccountInstallData> {
   return http.get<PublicAppDeveloperTestAccountInstallData>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/test-portal-installs`,
   });
@@ -33,7 +32,7 @@ export function fetchPublicAppDeveloperTestAccountInstallData(
 export function fetchPublicAppProductionInstallCounts(
   appId: number,
   accountId: number
-): Promise<PublicApInstallCounts> {
+): AxiosPromise<PublicApInstallCounts> {
   return http.get<PublicApInstallCounts>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/install-counts-without-test-portals`,
   });
@@ -42,7 +41,7 @@ export function fetchPublicAppProductionInstallCounts(
 export function fetchPublicAppMetadata(
   appId: number,
   accountId: number
-): Promise<PublicApp> {
+): AxiosPromise<PublicApp> {
   return http.get<PublicApp>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/full`,
   });

--- a/api/customObjects.ts
+++ b/api/customObjects.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import http from '../http';
 import { FetchSchemasResponse, Schema } from '../types/Schemas';
 
@@ -22,7 +23,7 @@ export async function batchCreateObjects(
   accountId: number,
   objectTypeId: string,
   objects: JSON
-): Promise<CreateObjectsResponse> {
+): AxiosPromise<CreateObjectsResponse> {
   return http.post<CreateObjectsResponse>(accountId, {
     url: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}/batch/create`,
     data: objects,
@@ -32,8 +33,8 @@ export async function batchCreateObjects(
 export async function createObjectSchema(
   accountId: number,
   schema: JSON
-): Promise<Schema> {
-  return http.post(accountId, {
+): AxiosPromise<Schema> {
+  return http.post<Schema>(accountId, {
     url: SCHEMA_API_PATH,
     data: schema,
   });
@@ -43,8 +44,8 @@ export async function updateObjectSchema(
   accountId: number,
   schemaObjectType: string,
   schema: Schema
-): Promise<Schema> {
-  return http.patch(accountId, {
+): AxiosPromise<Schema> {
+  return http.patch<Schema>(accountId, {
     url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
     data: schema,
   });
@@ -53,16 +54,16 @@ export async function updateObjectSchema(
 export async function fetchObjectSchema(
   accountId: number,
   schemaObjectType: string
-): Promise<Schema> {
-  return http.get(accountId, {
+): AxiosPromise<Schema> {
+  return http.get<Schema>(accountId, {
     url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
   });
 }
 
 export async function fetchObjectSchemas(
   accountId: number
-): Promise<FetchSchemasResponse> {
-  return http.get(accountId, {
+): AxiosPromise<FetchSchemasResponse> {
+  return http.get<FetchSchemasResponse>(accountId, {
     url: SCHEMA_API_PATH,
   });
 }
@@ -70,7 +71,7 @@ export async function fetchObjectSchemas(
 export async function deleteObjectSchema(
   accountId: number,
   schemaObjectType: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.delete(accountId, {
     url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
   });

--- a/api/customObjects.ts
+++ b/api/customObjects.ts
@@ -19,7 +19,7 @@ type CreateObjectsResponse = {
   }>;
 };
 
-export async function batchCreateObjects(
+export function batchCreateObjects(
   accountId: number,
   objectTypeId: string,
   objects: JSON
@@ -30,7 +30,7 @@ export async function batchCreateObjects(
   });
 }
 
-export async function createObjectSchema(
+export function createObjectSchema(
   accountId: number,
   schema: JSON
 ): AxiosPromise<Schema> {
@@ -40,7 +40,7 @@ export async function createObjectSchema(
   });
 }
 
-export async function updateObjectSchema(
+export function updateObjectSchema(
   accountId: number,
   schemaObjectType: string,
   schema: Schema
@@ -51,7 +51,7 @@ export async function updateObjectSchema(
   });
 }
 
-export async function fetchObjectSchema(
+export function fetchObjectSchema(
   accountId: number,
   schemaObjectType: string
 ): AxiosPromise<Schema> {
@@ -60,7 +60,7 @@ export async function fetchObjectSchema(
   });
 }
 
-export async function fetchObjectSchemas(
+export function fetchObjectSchemas(
   accountId: number
 ): AxiosPromise<FetchSchemasResponse> {
   return http.get<FetchSchemasResponse>(accountId, {
@@ -68,7 +68,7 @@ export async function fetchObjectSchemas(
   });
 }
 
-export async function deleteObjectSchema(
+export function deleteObjectSchema(
   accountId: number,
   schemaObjectType: string
 ): AxiosPromise<void> {

--- a/api/designManager.ts
+++ b/api/designManager.ts
@@ -12,7 +12,7 @@ type FetchThemesResponse = {
   }>;
 };
 
-export async function fetchThemes(
+export function fetchThemes(
   accountId: number,
   params: QueryParams = {}
 ): AxiosPromise<FetchThemesResponse> {
@@ -26,7 +26,7 @@ type FetchBuiltinMappingResponse = {
   [key: string]: string;
 };
 
-export async function fetchBuiltinMapping(
+export function fetchBuiltinMapping(
   accountId: number
 ): AxiosPromise<FetchBuiltinMappingResponse> {
   return http.get<FetchBuiltinMappingResponse>(accountId, {

--- a/api/designManager.ts
+++ b/api/designManager.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import http from '../http';
 import { QueryParams } from '../types/Http';
 
@@ -14,7 +15,7 @@ type FetchThemesResponse = {
 export async function fetchThemes(
   accountId: number,
   params: QueryParams = {}
-): Promise<FetchThemesResponse> {
+): AxiosPromise<FetchThemesResponse> {
   return http.get<FetchThemesResponse>(accountId, {
     url: `${DESIGN_MANAGER_API_PATH}/themes/combined`,
     params,
@@ -27,7 +28,7 @@ type FetchBuiltinMappingResponse = {
 
 export async function fetchBuiltinMapping(
   accountId: number
-): Promise<FetchBuiltinMappingResponse> {
+): AxiosPromise<FetchBuiltinMappingResponse> {
   return http.get<FetchBuiltinMappingResponse>(accountId, {
     url: `${DESIGN_MANAGER_API_PATH}/widgets/builtin-mapping`,
   });

--- a/api/developerTestAccounts.ts
+++ b/api/developerTestAccounts.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosPromise } from 'axios';
 import http from '../http';
 import { getAxiosConfig } from '../http/getAxiosConfig';
 import { ENVIRONMENTS } from '../constants/environments';
@@ -13,8 +13,8 @@ const TEST_ACCOUNTS_API_PATH = 'integrators/test-portals/v2';
 
 export async function fetchDeveloperTestAccounts(
   accountId: number
-): Promise<FetchDeveloperTestAccountsResponse> {
-  return http.get(accountId, {
+): AxiosPromise<FetchDeveloperTestAccountsResponse> {
+  return http.get<FetchDeveloperTestAccountsResponse>(accountId, {
     url: TEST_ACCOUNTS_API_PATH,
   });
 }
@@ -22,8 +22,8 @@ export async function fetchDeveloperTestAccounts(
 export async function createDeveloperTestAccount(
   accountId: number,
   accountName: string
-): Promise<DeveloperTestAccount> {
-  return http.post(accountId, {
+): AxiosPromise<DeveloperTestAccount> {
+  return http.post<DeveloperTestAccount>(accountId, {
     url: TEST_ACCOUNTS_API_PATH,
     data: { accountName, generatePersonalAccessKey: true }, // For CLI, generatePersonalAccessKey will always be true since we'll be saving the entry to the config
     timeout: SANDBOX_TIMEOUT,
@@ -33,7 +33,7 @@ export async function createDeveloperTestAccount(
 export async function deleteDeveloperTestAccount(
   accountId: number,
   testAccountId: number
-): Promise<void> {
+): AxiosPromise<void> {
   return http.delete(accountId, {
     url: `${TEST_ACCOUNTS_API_PATH}/${testAccountId}`,
   });
@@ -43,7 +43,7 @@ export async function fetchDeveloperTestAccountData(
   accessToken: string,
   accountId: number,
   env: Environment = ENVIRONMENTS.PROD
-): Promise<DeveloperTestAccount> {
+): AxiosPromise<DeveloperTestAccount> {
   const axiosConfig = getAxiosConfig({
     env,
     url: `${TEST_ACCOUNTS_API_PATH}/self`,
@@ -57,7 +57,5 @@ export async function fetchDeveloperTestAccountData(
     },
   };
 
-  const { data } = await axios<DeveloperTestAccount>(reqWithToken);
-
-  return data;
+  return axios<DeveloperTestAccount>(reqWithToken);
 }

--- a/api/developerTestAccounts.ts
+++ b/api/developerTestAccounts.ts
@@ -11,7 +11,7 @@ import { Environment } from '../types/Config';
 
 const TEST_ACCOUNTS_API_PATH = 'integrators/test-portals/v2';
 
-export async function fetchDeveloperTestAccounts(
+export function fetchDeveloperTestAccounts(
   accountId: number
 ): AxiosPromise<FetchDeveloperTestAccountsResponse> {
   return http.get<FetchDeveloperTestAccountsResponse>(accountId, {
@@ -19,7 +19,7 @@ export async function fetchDeveloperTestAccounts(
   });
 }
 
-export async function createDeveloperTestAccount(
+export function createDeveloperTestAccount(
   accountId: number,
   accountName: string
 ): AxiosPromise<DeveloperTestAccount> {
@@ -30,7 +30,7 @@ export async function createDeveloperTestAccount(
   });
 }
 
-export async function deleteDeveloperTestAccount(
+export function deleteDeveloperTestAccount(
   accountId: number,
   testAccountId: number
 ): AxiosPromise<void> {
@@ -39,7 +39,7 @@ export async function deleteDeveloperTestAccount(
   });
 }
 
-export async function fetchDeveloperTestAccountData(
+export function fetchDeveloperTestAccountData(
   accessToken: string,
   accountId: number,
   env: Environment = ENVIRONMENTS.PROD

--- a/api/fileManager.ts
+++ b/api/fileManager.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import fs from 'fs';
 import path from 'path';
 import http from '../http';
@@ -12,11 +13,11 @@ import {
 const FILE_MANAGER_V2_API_PATH = 'filemanager/api/v2';
 const FILE_MANAGER_V3_API_PATH = 'filemanager/api/v3';
 
-export async function uploadFile(
+export function uploadFile(
   accountId: number,
   src: string,
   dest: string
-): Promise<UploadResponse> {
+): AxiosPromise<UploadResponse> {
   const directory = path.dirname(dest);
   const filename = path.basename(dest);
   const formData: FormData = {
@@ -34,29 +35,29 @@ export async function uploadFile(
     formData.folderPath = '/';
   }
 
-  return http.post(accountId, {
+  return http.post<UploadResponse>(accountId, {
     url: `${FILE_MANAGER_V3_API_PATH}/files/upload`,
     data: formData,
     headers: { 'Content-Type': 'multipart/form-data' },
   });
 }
 
-export async function fetchStat(
+export function fetchStat(
   accountId: number,
   src: string
-): Promise<FetchStatResponse> {
-  return http.get(accountId, {
+): AxiosPromise<FetchStatResponse> {
+  return http.get<FetchStatResponse>(accountId, {
     url: `${FILE_MANAGER_V2_API_PATH}/files/stat/${src}`,
   });
 }
 
-export async function fetchFiles(
+export function fetchFiles(
   accountId: number,
   folderId: number | 'None',
   offset: number,
   archived?: boolean
-): Promise<FetchFilesResponse> {
-  return http.get(accountId, {
+): AxiosPromise<FetchFilesResponse> {
+  return http.get<FetchFilesResponse>(accountId, {
     url: `${FILE_MANAGER_V2_API_PATH}/files/`,
     params: {
       hidden: 0,
@@ -67,11 +68,11 @@ export async function fetchFiles(
   });
 }
 
-export async function fetchFolders(
+export function fetchFolders(
   accountId: number,
   folderId: number | 'None'
-): Promise<FetchFolderResponse> {
-  return http.get(accountId, {
+): AxiosPromise<FetchFolderResponse> {
+  return http.get<FetchFolderResponse>(accountId, {
     url: `${FILE_MANAGER_V2_API_PATH}/folders/`,
     params: {
       hidden: 0,

--- a/api/fileMapper.ts
+++ b/api/fileMapper.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import contentDisposition from 'content-disposition';
-import { AxiosResponse } from 'axios';
+import { AxiosResponse, AxiosPromise } from 'axios';
 import http from '../http';
 import { getCwd } from '../lib/path';
 import { FileMapperNode, FileMapperOptions, FileTree } from '../types/Files';
@@ -41,12 +41,12 @@ export function createFileMapperNodeFromStreamResponse(
   };
 }
 
-export async function upload(
+export function upload(
   accountId: number,
   src: string,
   dest: string,
   options: FileMapperOptions = {}
-): Promise<void> {
+): AxiosPromise<void> {
   return http.post<void>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/upload/${encodeURIComponent(dest)}`,
     data: {
@@ -58,11 +58,11 @@ export async function upload(
 }
 
 // Fetch a module by moduleId
-export async function fetchModule(
+export function fetchModule(
   accountId: number,
   moduleId: number,
   options: FileMapperOptions = {}
-): Promise<FileTree> {
+): AxiosPromise<FileTree> {
   return http.get<FileTree>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/modules/${moduleId}`,
     ...options,
@@ -88,11 +88,11 @@ export async function fetchFileStream(
 }
 
 // Fetch a folder or file node by path.
-export async function download(
+export function download(
   accountId: number,
   filepath: string,
   options: FileMapperOptions = {}
-): Promise<FileMapperNode> {
+): AxiosPromise<FileMapperNode> {
   return http.get<FileMapperNode>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/download/${encodeURIComponent(filepath)}`,
     ...options,
@@ -100,11 +100,11 @@ export async function download(
 }
 
 // Fetch a folder or file node by path.
-export async function downloadDefault(
+export function downloadDefault(
   accountId: number,
   filepath: string,
   options: FileMapperOptions = {}
-): Promise<FileMapperNode> {
+): AxiosPromise<FileMapperNode> {
   return http.get<FileMapperNode>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/download-default/${filepath}`,
     ...options,
@@ -112,21 +112,21 @@ export async function downloadDefault(
 }
 
 // Delete a file or folder by path
-export async function deleteFile(
+export function deleteFile(
   accountId: number,
   filePath: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.delete(accountId, {
     url: `${FILE_MAPPER_API_PATH}/delete/${encodeURIComponent(filePath)}`,
   });
 }
 
 // Moves file from srcPath to destPath
-export async function moveFile(
+export function moveFile(
   accountId: number,
   srcPath: string,
   destPath: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.put(accountId, {
     url: `${FILE_MAPPER_API_PATH}/rename/${srcPath}?path=${destPath}`,
     headers: { 'Content-Type': 'application/json' },
@@ -134,10 +134,10 @@ export async function moveFile(
 }
 
 // Get directory contents
-export async function getDirectoryContentsByPath(
+export function getDirectoryContentsByPath(
   accountId: number,
   path: string
-): Promise<FileMapperNode> {
+): AxiosPromise<FileMapperNode> {
   return http.get(accountId, {
     url: `${FILE_MAPPER_API_PATH}/meta/${path}`,
   });

--- a/api/fileTransport.ts
+++ b/api/fileTransport.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import fs from 'fs';
 import path from 'path';
 import { getCwd } from '../lib/path';
@@ -5,10 +6,10 @@ import http from '../http';
 
 const HUBFILES_API_PATH = '/file-transport/v1/hubfiles';
 
-export async function createSchemaFromHubFile(
+export function createSchemaFromHubFile(
   accountId: number,
   filepath: string
-) {
+): AxiosPromise {
   const file = fs.createReadStream(path.resolve(getCwd(), filepath));
   return http.post(accountId, {
     url: `${HUBFILES_API_PATH}/object-schemas`,
@@ -22,7 +23,7 @@ export async function createSchemaFromHubFile(
 export async function updateSchemaFromHubFile(
   accountId: number,
   filepath: string
-) {
+): AxiosPromise {
   const file = fs.createReadStream(path.resolve(getCwd(), filepath));
   return http.put(accountId, {
     url: `${HUBFILES_API_PATH}/object-schemas`,
@@ -37,7 +38,7 @@ export async function fetchHubFileSchema(
   accountId: number,
   objectName: string,
   path: string
-) {
+): AxiosPromise {
   return http.getOctetStream(
     accountId,
     {

--- a/api/functions.ts
+++ b/api/functions.ts
@@ -1,20 +1,21 @@
+import { AxiosPromise } from 'axios';
 import http from '../http';
 import { QueryParams } from '../types/Http';
 import { GetBuildStatusResponse, GetRoutesResponse } from '../types/Functions';
 
 const FUNCTION_API_PATH = 'cms/v3/functions';
 
-export async function getRoutes(accountId: number): Promise<GetRoutesResponse> {
+export function getRoutes(accountId: number): AxiosPromise<GetRoutesResponse> {
   return http.get(accountId, {
     url: `${FUNCTION_API_PATH}/routes`,
   });
 }
 
-export async function getFunctionLogs(
+export function getFunctionLogs(
   accountId: number,
   route: string,
   params: QueryParams = {}
-) {
+): AxiosPromise {
   const { limit = 5 } = params;
 
   return http.get(accountId, {
@@ -23,7 +24,10 @@ export async function getFunctionLogs(
   });
 }
 
-export async function getLatestFunctionLog(accountId: number, route: string) {
+export function getLatestFunctionLog(
+  accountId: number,
+  route: string
+): AxiosPromise {
   return http.get(accountId, {
     url: `${FUNCTION_API_PATH}/results/by-route/${encodeURIComponent(
       route
@@ -31,10 +35,10 @@ export async function getLatestFunctionLog(accountId: number, route: string) {
   });
 }
 
-export async function buildPackage(
+export function buildPackage(
   accountId: number,
   folderPath: string
-): Promise<string> {
+): AxiosPromise<string> {
   return http.post(accountId, {
     url: `${FUNCTION_API_PATH}/build/async`,
     headers: {
@@ -46,10 +50,10 @@ export async function buildPackage(
   });
 }
 
-export async function getBuildStatus(
+export function getBuildStatus(
   accountId: number,
   buildId: number
-): Promise<GetBuildStatusResponse> {
+): AxiosPromise<GetBuildStatusResponse> {
   return http.get(accountId, {
     url: `${FUNCTION_API_PATH}/build/${buildId}/poll`,
   });

--- a/api/github.ts
+++ b/api/github.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from 'axios';
+import axios, { AxiosPromise } from 'axios';
 import { getDefaultUserAgentHeader } from '../http/getAxiosConfig';
 import { GithubReleaseData, GithubRepoFile } from '../types/Github';
 
@@ -22,7 +22,7 @@ const GITHUB_AUTH_HEADERS = {
 export async function fetchRepoReleaseData(
   repoPath: RepoPath,
   tag = ''
-): Promise<AxiosResponse<GithubReleaseData>> {
+): AxiosPromise<GithubReleaseData> {
   const URL = `${GITHUB_REPOS_API}/${repoPath}/releases`;
 
   return axios.get<GithubReleaseData>(
@@ -35,9 +35,7 @@ export async function fetchRepoReleaseData(
 
 // Returns the entire repo content as a zip, using the zipball_url from fetchRepoReleaseData()
 // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#download-a-repository-archive-zip
-export async function fetchRepoAsZip(
-  zipUrl: string
-): Promise<AxiosResponse<Buffer>> {
+export async function fetchRepoAsZip(zipUrl: string): AxiosPromise<Buffer> {
   return axios.get<Buffer>(zipUrl, {
     responseType: 'arraybuffer',
     headers: { ...getDefaultUserAgentHeader(), ...GITHUB_AUTH_HEADERS },
@@ -49,7 +47,7 @@ export async function fetchRepoFile(
   repoPath: RepoPath,
   filePath: string,
   ref: string
-): Promise<AxiosResponse<Buffer>> {
+): AxiosPromise<Buffer> {
   return axios.get<Buffer>(
     `${GITHUB_RAW_CONTENT_API_PATH}/${repoPath}/${ref}/${filePath}`,
     {
@@ -61,7 +59,7 @@ export async function fetchRepoFile(
 // Returns the raw file contents via the raw.githubusercontent endpoint
 export async function fetchRepoFileByDownloadUrl(
   downloadUrl: string
-): Promise<AxiosResponse<Buffer>> {
+): AxiosPromise<Buffer> {
   return axios.get<Buffer>(downloadUrl, {
     headers: { ...getDefaultUserAgentHeader(), ...GITHUB_AUTH_HEADERS },
     responseType: 'arraybuffer',
@@ -74,7 +72,7 @@ export async function fetchRepoContents(
   repoPath: RepoPath,
   path: string,
   ref?: string
-): Promise<AxiosResponse<Array<GithubRepoFile>>> {
+): AxiosPromise<Array<GithubRepoFile>> {
   const refQuery = ref ? `?ref=${ref}` : '';
 
   return axios.get<Array<GithubRepoFile>>(

--- a/api/github.ts
+++ b/api/github.ts
@@ -19,7 +19,7 @@ const GITHUB_AUTH_HEADERS = {
 
 // Returns information about the repo's releases. Defaults to "latest" if no tag is provided
 // https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release-by-tag-name
-export async function fetchRepoReleaseData(
+export function fetchRepoReleaseData(
   repoPath: RepoPath,
   tag = ''
 ): AxiosPromise<GithubReleaseData> {
@@ -35,7 +35,7 @@ export async function fetchRepoReleaseData(
 
 // Returns the entire repo content as a zip, using the zipball_url from fetchRepoReleaseData()
 // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#download-a-repository-archive-zip
-export async function fetchRepoAsZip(zipUrl: string): AxiosPromise<Buffer> {
+export function fetchRepoAsZip(zipUrl: string): AxiosPromise<Buffer> {
   return axios.get<Buffer>(zipUrl, {
     responseType: 'arraybuffer',
     headers: { ...getDefaultUserAgentHeader(), ...GITHUB_AUTH_HEADERS },
@@ -43,7 +43,7 @@ export async function fetchRepoAsZip(zipUrl: string): AxiosPromise<Buffer> {
 }
 
 // Returns the raw file contents via the raw.githubusercontent endpoint
-export async function fetchRepoFile(
+export function fetchRepoFile(
   repoPath: RepoPath,
   filePath: string,
   ref: string
@@ -57,7 +57,7 @@ export async function fetchRepoFile(
 }
 
 // Returns the raw file contents via the raw.githubusercontent endpoint
-export async function fetchRepoFileByDownloadUrl(
+export function fetchRepoFileByDownloadUrl(
   downloadUrl: string
 ): AxiosPromise<Buffer> {
   return axios.get<Buffer>(downloadUrl, {
@@ -68,7 +68,7 @@ export async function fetchRepoFileByDownloadUrl(
 
 // Returns the contents of a file or directory in a repository by path
 // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content
-export async function fetchRepoContents(
+export function fetchRepoContents(
   repoPath: RepoPath,
   path: string,
   ref?: string

--- a/api/hubdb.ts
+++ b/api/hubdb.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import http from '../http';
 import { QueryParams } from '../types/Http';
 import {
@@ -10,41 +11,41 @@ import {
 
 const HUBDB_API_PATH = 'cms/v3/hubdb';
 
-export async function fetchTable(
+export function fetchTable(
   accountId: number,
   tableId: string
-): Promise<Table> {
-  return http.get(accountId, {
+): AxiosPromise<Table> {
+  return http.get<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}`,
   });
 }
 
-export async function createTable(
+export function createTable(
   accountId: number,
   schema: Schema
-): Promise<Table> {
-  return http.post(accountId, {
+): AxiosPromise<Table> {
+  return http.post<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables`,
     data: schema,
   });
 }
 
-export async function updateTable(
+export function updateTable(
   accountId: number,
   tableId: string,
   schema: Schema
-) {
-  return http.patch(accountId, {
+): AxiosPromise<Table> {
+  return http.patch<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/draft`,
     data: schema,
   });
 }
 
-export async function publishTable(
+export function publishTable(
   accountId: number,
   tableId: string
-): Promise<Table> {
-  return http.post(accountId, {
+): AxiosPromise<Table> {
+  return http.post<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/draft/publish`,
     headers: {
       'Content-Type': 'application/json',
@@ -52,42 +53,42 @@ export async function publishTable(
   });
 }
 
-export async function deleteTable(
+export function deleteTable(
   accountId: number,
   tableId: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.delete(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}`,
   });
 }
 
-export async function createRows(
+export function createRows(
   accountId: number,
   tableId: string,
   rows: Array<Row>
-): Promise<CreateRowsResponse> {
-  return http.post(accountId, {
+): AxiosPromise<CreateRowsResponse> {
+  return http.post<CreateRowsResponse>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/create`,
     data: { inputs: rows },
   });
 }
 
-export async function fetchRows(
+export function fetchRows(
   accountId: number,
   tableId: string,
   params: QueryParams = {}
-): Promise<FetchRowsResponse> {
-  return http.get(accountId, {
+): AxiosPromise<FetchRowsResponse> {
+  return http.get<FetchRowsResponse>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft`,
     params,
   });
 }
 
-export async function deleteRows(
+export function deleteRows(
   accountId: number,
   tableId: string,
   rowIds: Array<string>
-): Promise<void> {
+): AxiosPromise<void> {
   return http.post(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/purge`,
     data: { inputs: rowIds },

--- a/api/lighthouseScore.ts
+++ b/api/lighthouseScore.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import http from '../http';
 import { Data, QueryParams } from '../types/Http';
 import {
@@ -7,31 +8,31 @@ import {
 
 const LIGHTHOUSE_SCORE_API_BASE = 'quality-engine/v1/lighthouse';
 
-export async function requestLighthouseScore(
+export function requestLighthouseScore(
   accountId: number,
   data: Data = {}
-): Promise<RequestLighthouseScoreResponse> {
-  return http.post(accountId, {
+): AxiosPromise<RequestLighthouseScoreResponse> {
+  return http.post<RequestLighthouseScoreResponse>(accountId, {
     url: `${LIGHTHOUSE_SCORE_API_BASE}/request`,
     data,
   });
 }
 
-export async function getLighthouseScoreStatus(
+export function getLighthouseScoreStatus(
   accountId: number,
   params: QueryParams = {}
-): Promise<string> {
-  return http.get(accountId, {
+): AxiosPromise<string> {
+  return http.get<string>(accountId, {
     url: `${LIGHTHOUSE_SCORE_API_BASE}/status`,
     params,
   });
 }
 
-export async function getLighthouseScore(
+export function getLighthouseScore(
   accountId: number,
   params: QueryParams = {}
-): Promise<GetLighthouseScoreResponse> {
-  return http.get(accountId, {
+): AxiosPromise<GetLighthouseScoreResponse> {
+  return http.get<GetLighthouseScoreResponse>(accountId, {
     url: `${LIGHTHOUSE_SCORE_API_BASE}/scores`,
     params,
   });

--- a/api/localDevAuth.ts
+++ b/api/localDevAuth.ts
@@ -23,7 +23,7 @@ type AccessTokenResponse = {
   accountType: ValueOf<typeof HUBSPOT_ACCOUNT_TYPES>;
 };
 
-export async function fetchAccessToken(
+export function fetchAccessToken(
   personalAccessKey: string,
   env: Environment = ENVIRONMENTS.PROD,
   portalId?: number
@@ -44,7 +44,7 @@ export async function fetchAccessToken(
   });
 }
 
-export async function fetchScopeData(
+export function fetchScopeData(
   accountId: number,
   scopeGroup: string
 ): AxiosPromise<ScopeData> {
@@ -54,7 +54,7 @@ export async function fetchScopeData(
   });
 }
 
-export async function fetchAppInstallationData(
+export function fetchAppInstallationData(
   portalId: number,
   projectId: number,
   appUid: string,

--- a/api/localDevAuth.ts
+++ b/api/localDevAuth.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import { getAxiosConfig } from '../http/getAxiosConfig';
 import http from '../http';
 import { ENVIRONMENTS } from '../constants/environments';
@@ -26,7 +27,7 @@ export async function fetchAccessToken(
   personalAccessKey: string,
   env: Environment = ENVIRONMENTS.PROD,
   portalId?: number
-): Promise<AccessTokenResponse> {
+): AxiosPromise<AccessTokenResponse> {
   const axiosConfig = getAxiosConfig({
     env,
     localHostOverride: true,
@@ -37,18 +38,16 @@ export async function fetchAccessToken(
     params: portalId ? { portalId } : {},
   });
 
-  const { data } = await axios<AccessTokenResponse>({
+  return axios<AccessTokenResponse>({
     ...axiosConfig,
     method: 'post',
   });
-
-  return data;
 }
 
 export async function fetchScopeData(
   accountId: number,
   scopeGroup: string
-): Promise<ScopeData> {
+): AxiosPromise<ScopeData> {
   return http.get<ScopeData>(accountId, {
     url: `${LOCALDEVAUTH_API_AUTH_PATH}/check-scopes`,
     params: { scopeGroup },
@@ -61,7 +60,7 @@ export async function fetchAppInstallationData(
   appUid: string,
   requiredScopeGroups: Array<string>,
   optionalScopeGroups: Array<string> = []
-): Promise<PublicAppInstallationData> {
+): AxiosPromise<PublicAppInstallationData> {
   return http.post<PublicAppInstallationData>(portalId, {
     url: `${LOCALDEVAUTH_API_AUTH_PATH}/install-info`,
     data: {

--- a/api/marketplaceValidation.ts
+++ b/api/marketplaceValidation.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import http from '../http';
 import { Data, QueryParams } from '../types/Http';
 import { GetValidationResultsResponse } from '../types/MarketplaceValidation';
@@ -7,8 +8,8 @@ const VALIDATION_API_BASE = 'quality-engine/v1/validation';
 export function requestValidation(
   accountId: number,
   data: Data = {}
-): Promise<number> {
-  return http.post(accountId, {
+): AxiosPromise<number> {
+  return http.post<number>(accountId, {
     url: `${VALIDATION_API_BASE}/request`,
     data,
   });
@@ -17,8 +18,8 @@ export function requestValidation(
 export function getValidationStatus(
   accountId: number,
   params: QueryParams = {}
-): Promise<string> {
-  return http.get(accountId, {
+): AxiosPromise<string> {
+  return http.get<string>(accountId, {
     url: `${VALIDATION_API_BASE}/status`,
     params,
   });
@@ -27,8 +28,8 @@ export function getValidationStatus(
 export function getValidationResults(
   accountId: number,
   params: QueryParams = {}
-): Promise<GetValidationResultsResponse> {
-  return http.get(accountId, {
+): AxiosPromise<GetValidationResultsResponse> {
+  return http.get<GetValidationResultsResponse>(accountId, {
     url: `${VALIDATION_API_BASE}/results`,
     params,
   });

--- a/api/projects.ts
+++ b/api/projects.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import http from '../http';
 import fs from 'fs';
 import { FormData, QueryParams } from '../types/Http';
@@ -26,19 +27,19 @@ const PROJECTS_LOGS_API_PATH = 'dfs/logging/v1';
 const DEVELOPER_PROJECTS_API_PATH = 'developer/projects/v1';
 const MIGRATIONS_API_PATH = 'dfs/migrations/v1';
 
-export async function fetchProjects(
+export function fetchProjects(
   accountId: number
-): Promise<FetchProjectResponse> {
-  return http.get(accountId, {
+): AxiosPromise<FetchProjectResponse> {
+  return http.get<FetchProjectResponse>(accountId, {
     url: PROJECTS_API_PATH,
   });
 }
 
-export async function createProject(
+export function createProject(
   accountId: number,
   name: string
-): Promise<Project> {
-  return http.post(accountId, {
+): AxiosPromise<Project> {
+  return http.post<Project>(accountId, {
     url: PROJECTS_API_PATH,
     data: {
       name,
@@ -46,13 +47,13 @@ export async function createProject(
   });
 }
 
-export async function uploadProject(
+export function uploadProject(
   accountId: number,
   projectName: string,
   projectFile: string,
   uploadMessage: string,
   platformVersion?: string
-): Promise<UploadProjectResponse> {
+): AxiosPromise<UploadProjectResponse> {
   const formData: FormData = {
     file: fs.createReadStream(projectFile),
     uploadMessage,
@@ -61,7 +62,7 @@ export async function uploadProject(
     formData.platformVersion = platformVersion;
   }
 
-  return http.post(accountId, {
+  return http.post<UploadProjectResponse>(accountId, {
     url: `${PROJECTS_API_PATH}/upload/${encodeURIComponent(projectName)}`,
     timeout: 60000,
     data: formData,
@@ -69,21 +70,21 @@ export async function uploadProject(
   });
 }
 
-export async function fetchProject(
+export function fetchProject(
   accountId: number,
   projectName: string
-): Promise<Project> {
-  return http.get(accountId, {
+): AxiosPromise<Project> {
+  return http.get<Project>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
   });
 }
 
-export async function downloadProject(
+export function downloadProject(
   accountId: number,
   projectName: string,
   buildId: number
-): Promise<Buffer> {
-  return http.get(accountId, {
+): AxiosPromise<Buffer> {
+  return http.get<Buffer>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
     )}/builds/${buildId}/archive-full`,
@@ -92,10 +93,10 @@ export async function downloadProject(
   });
 }
 
-export async function deleteProject(
+export function deleteProject(
   accountId: number,
   projectName: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.delete(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
   });
@@ -106,55 +107,55 @@ type FetchPlatformVersionResponse = {
   activePlatformVersions: Array<string>;
 };
 
-export async function fetchPlatformVersions(
+export function fetchPlatformVersions(
   accountId: number
-): Promise<FetchPlatformVersionResponse> {
-  return http.get(accountId, {
+): AxiosPromise<FetchPlatformVersionResponse> {
+  return http.get<FetchPlatformVersionResponse>(accountId, {
     url: `${DEVELOPER_PROJECTS_API_PATH}/platformVersion`,
   });
 }
 
-export async function fetchProjectBuilds(
+export function fetchProjectBuilds(
   accountId: number,
   projectName: string,
   params: QueryParams = {}
-): Promise<FetchProjectBuildsResponse> {
-  return http.get(accountId, {
+): AxiosPromise<FetchProjectBuildsResponse> {
+  return http.get<FetchProjectBuildsResponse>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/builds`,
     params,
   });
 }
 
-export async function getBuildStatus(
+export function getBuildStatus(
   accountId: number,
   projectName: string,
   buildId: number
-): Promise<Build> {
-  return http.get(accountId, {
+): AxiosPromise<Build> {
+  return http.get<Build>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
     )}/builds/${buildId}/status`,
   });
 }
 
-export async function getBuildStructure(
+export function getBuildStructure(
   accountId: number,
   projectName: string,
   buildId: number
-): Promise<ComponentStructureResponse> {
-  return http.get(accountId, {
+): AxiosPromise<ComponentStructureResponse> {
+  return http.get<ComponentStructureResponse>(accountId, {
     url: `dfs/v1/builds/by-project-name/${encodeURIComponent(
       projectName
     )}/builds/${buildId}/structure`,
   });
 }
 
-export async function deployProject(
+export function deployProject(
   accountId: number,
   projectName: string,
   buildId: number
-): Promise<ProjectDeployResponse> {
-  return http.post(accountId, {
+): AxiosPromise<ProjectDeployResponse> {
+  return http.post<ProjectDeployResponse>(accountId, {
     url: `${PROJECTS_DEPLOY_API_PATH}/deploys/queue/async`,
     data: {
       projectName,
@@ -163,54 +164,54 @@ export async function deployProject(
   });
 }
 
-export async function getDeployStatus(
+export function getDeployStatus(
   accountId: number,
   projectName: string,
   deployId: number
-): Promise<Deploy> {
-  return http.get(accountId, {
+): AxiosPromise<Deploy> {
+  return http.get<Deploy>(accountId, {
     url: `${PROJECTS_DEPLOY_API_PATH}/deploy-status/projects/${encodeURIComponent(
       projectName
     )}/deploys/${deployId}`,
   });
 }
 
-export async function getDeployStructure(
+export function getDeployStructure(
   accountId: number,
   projectName: string,
   deployId: number
-): Promise<ComponentStructureResponse> {
-  return http.get(accountId, {
+): AxiosPromise<ComponentStructureResponse> {
+  return http.get<ComponentStructureResponse>(accountId, {
     url: `${PROJECTS_DEPLOY_API_PATH}/deploys/by-project-name/${encodeURIComponent(
       projectName
     )}/deploys/${deployId}/structure`,
   });
 }
 
-export async function fetchProjectSettings(
+export function fetchProjectSettings(
   accountId: number,
   projectName: string
-): Promise<ProjectSettings> {
-  return http.get(accountId, {
+): AxiosPromise<ProjectSettings> {
+  return http.get<ProjectSettings>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/settings`,
   });
 }
 
-export async function fetchDeployComponentsMetadata(
+export function fetchDeployComponentsMetadata(
   accountId: number,
   projectId: number
-): Promise<ComponentMetadataResponse> {
-  return http.get(accountId, {
+): AxiosPromise<ComponentMetadataResponse> {
+  return http.get<ComponentMetadataResponse>(accountId, {
     url: `${PROJECTS_API_PATH}/by-id/${projectId}/deploy-components-metadata`,
   });
 }
 
-export async function provisionBuild(
+export function provisionBuild(
   accountId: number,
   projectName: string,
   platformVersion?: string
-): Promise<Build> {
-  return http.post(accountId, {
+): AxiosPromise<Build> {
+  return http.post<Build>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
     )}/builds/staged/provision`,
@@ -220,11 +221,11 @@ export async function provisionBuild(
   });
 }
 
-export async function queueBuild(
+export function queueBuild(
   accountId: number,
   projectName: string,
   platformVersion?: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.post(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -234,12 +235,12 @@ export async function queueBuild(
   });
 }
 
-export async function uploadFileToBuild(
+export function uploadFileToBuild(
   accountId: number,
   projectName: string,
   filePath: string,
   path: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.put(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -251,11 +252,11 @@ export async function uploadFileToBuild(
   });
 }
 
-export async function deleteFileFromBuild(
+export function deleteFileFromBuild(
   accountId: number,
   projectName: string,
   path: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.delete(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -263,10 +264,10 @@ export async function deleteFileFromBuild(
   });
 }
 
-export async function cancelStagedBuild(
+export function cancelStagedBuild(
   accountId: number,
   projectName: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.post(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -275,36 +276,40 @@ export async function cancelStagedBuild(
   });
 }
 
-export async function fetchBuildWarnLogs(
+type WarnLogsResponse = {
+  logs: Array<ProjectLog>;
+};
+
+export function fetchBuildWarnLogs(
   accountId: number,
   projectName: string,
   buildId: number
-): Promise<{ logs: Array<ProjectLog> }> {
-  return http.get(accountId, {
+): AxiosPromise<WarnLogsResponse> {
+  return http.get<WarnLogsResponse>(accountId, {
     url: `${PROJECTS_LOGS_API_PATH}/logs/projects/${encodeURIComponent(
       projectName
     )}/builds/${buildId}/combined/warn`,
   });
 }
 
-export async function fetchDeployWarnLogs(
+export function fetchDeployWarnLogs(
   accountId: number,
   projectName: string,
   deployId: number
-): Promise<{ logs: Array<ProjectLog> }> {
-  return http.get(accountId, {
+): AxiosPromise<WarnLogsResponse> {
+  return http.get<WarnLogsResponse>(accountId, {
     url: `${PROJECTS_LOGS_API_PATH}/logs/projects/${encodeURIComponent(
       projectName
     )}/deploys/${deployId}/combined/warn`,
   });
 }
 
-export async function migrateApp(
+export function migrateApp(
   accountId: number,
   appId: number,
   projectName: string
-): Promise<MigrateAppResponse> {
-  return http.post(accountId, {
+): AxiosPromise<MigrateAppResponse> {
+  return http.post<MigrateAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/migrations`,
     data: {
       componentId: appId,
@@ -314,20 +319,20 @@ export async function migrateApp(
   });
 }
 
-export async function checkMigrationStatus(
+export function checkMigrationStatus(
   accountId: number,
   id: number
-): Promise<PollAppResponse> {
-  return http.get(accountId, {
+): AxiosPromise<PollAppResponse> {
+  return http.get<PollAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/migrations/${id}`,
   });
 }
 
-export async function cloneApp(
+export function cloneApp(
   accountId: number,
   appId: number
-): Promise<CloneAppResponse> {
-  return http.post(accountId, {
+): AxiosPromise<CloneAppResponse> {
+  return http.post<CloneAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/exports`,
     data: {
       componentId: appId,
@@ -336,20 +341,20 @@ export async function cloneApp(
   });
 }
 
-export async function checkCloneStatus(
+export function checkCloneStatus(
   accountId: number,
   exportId: number
-): Promise<CloneAppResponse> {
-  return http.get(accountId, {
+): AxiosPromise<CloneAppResponse> {
+  return http.get<CloneAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/exports/${exportId}/status`,
   });
 }
 
-export async function downloadClonedProject(
+export function downloadClonedProject(
   accountId: number,
   exportId: number
-): Promise<Buffer> {
-  return http.get(accountId, {
+): AxiosPromise<Buffer> {
+  return http.get<Buffer>(accountId, {
     url: `${MIGRATIONS_API_PATH}/exports/${exportId}/download-as-clone`,
     responseType: 'arraybuffer',
   });

--- a/api/sandboxHubs.ts
+++ b/api/sandboxHubs.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosPromise } from 'axios';
 import http from '../http';
 import { getAxiosConfig } from '../http/getAxiosConfig';
 import { ENVIRONMENTS } from '../constants/environments';
@@ -13,40 +13,40 @@ import {
 const SANDBOX_API_PATH = 'sandbox-hubs/v1';
 const SANDBOX_API_PATH_V2 = 'sandbox-hubs/v2';
 
-export async function createSandbox(
+export function createSandbox(
   accountId: number,
   name: string,
   type: 1 | 2
-): Promise<SandboxResponse> {
-  return http.post(accountId, {
+): AxiosPromise<SandboxResponse> {
+  return http.post<SandboxResponse>(accountId, {
     data: { name, type, generatePersonalAccessKey: true }, // For CLI, generatePersonalAccessKey will always be true since we'll be saving the entry to the config
     timeout: SANDBOX_TIMEOUT,
     url: SANDBOX_API_PATH_V2, // Create uses v2 for sandbox type and PAK generation support
   });
 }
 
-export async function deleteSandbox(
+export function deleteSandbox(
   parentAccountId: number,
   sandboxAccountId: number
-): Promise<void> {
+): AxiosPromise<void> {
   return http.delete(parentAccountId, {
     url: `${SANDBOX_API_PATH}/${sandboxAccountId}`,
   });
 }
 
-export async function getSandboxUsageLimits(
+export function getSandboxUsageLimits(
   parentAccountId: number
-): Promise<SandboxUsageLimitsResponse> {
-  return http.get(parentAccountId, {
+): AxiosPromise<SandboxUsageLimitsResponse> {
+  return http.get<SandboxUsageLimitsResponse>(parentAccountId, {
     url: `${SANDBOX_API_PATH}/parent/${parentAccountId}/usage`,
   });
 }
 
-export async function fetchSandboxHubData(
+export function fetchSandboxHubData(
   accessToken: string,
   accountId: number,
   env: Environment = ENVIRONMENTS.PROD
-): Promise<SandboxHubData> {
+): AxiosPromise<SandboxHubData> {
   const axiosConfig = getAxiosConfig({
     env,
     url: `${SANDBOX_API_PATH}/self`,
@@ -60,7 +60,5 @@ export async function fetchSandboxHubData(
     },
   };
 
-  const { data } = await axios<SandboxHubData>(reqWithToken);
-
-  return data;
+  return axios<SandboxHubData>(reqWithToken);
 }

--- a/api/sandboxSync.ts
+++ b/api/sandboxSync.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import http from '../http';
 import {
   InitiateSyncResponse,
@@ -8,13 +9,13 @@ import {
 import { SANDBOX_TIMEOUT } from '../constants/api';
 const SANDBOXES_SYNC_API_PATH = 'sandboxes-sync/v1';
 
-export async function initiateSync(
+export function initiateSync(
   fromHubId: number,
   toHubId: number,
   tasks: Array<TaskRequestData>,
   sandboxHubId: number
-): Promise<InitiateSyncResponse> {
-  return http.post(fromHubId, {
+): AxiosPromise<InitiateSyncResponse> {
+  return http.post<InitiateSyncResponse>(fromHubId, {
     data: {
       command: 'SYNC',
       fromHubId,
@@ -27,20 +28,20 @@ export async function initiateSync(
   });
 }
 
-export async function fetchTaskStatus(
+export function fetchTaskStatus(
   accountId: number,
   taskId: number
-): Promise<SyncTaskStatusType> {
-  return http.get(accountId, {
+): AxiosPromise<SyncTaskStatusType> {
+  return http.get<SyncTaskStatusType>(accountId, {
     url: `${SANDBOXES_SYNC_API_PATH}/tasks/${taskId}/status`,
   });
 }
 
-export async function fetchTypes(
+export function fetchTypes(
   accountId: number,
   toHubId: number
-): Promise<FetchTypesResponse> {
-  return http.get(accountId, {
+): AxiosPromise<FetchTypesResponse> {
+  return http.get<FetchTypesResponse>(accountId, {
     url: `${SANDBOXES_SYNC_API_PATH}/types${
       toHubId ? `?toHubId=${toHubId}` : ''
     }`,

--- a/api/secrets.ts
+++ b/api/secrets.ts
@@ -1,3 +1,4 @@
+import { AxiosPromise } from 'axios';
 import http from '../http';
 
 const SECRETS_API_PATH = 'cms/v3/functions/secrets';
@@ -6,11 +7,11 @@ type FetchSecretsResponse = {
   results: Array<string>;
 };
 
-export async function addSecret(
+export function addSecret(
   accountId: number,
   key: string,
   value: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.post(accountId, {
     url: SECRETS_API_PATH,
     data: {
@@ -20,11 +21,11 @@ export async function addSecret(
   });
 }
 
-export async function updateSecret(
+export function updateSecret(
   accountId: number,
   key: string,
   value: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.put(accountId, {
     url: SECRETS_API_PATH,
     data: {
@@ -34,19 +35,19 @@ export async function updateSecret(
   });
 }
 
-export async function deleteSecret(
+export function deleteSecret(
   accountId: number,
   key: string
-): Promise<void> {
+): AxiosPromise<void> {
   return http.delete(accountId, {
     url: `${SECRETS_API_PATH}/${key}`,
   });
 }
 
-export async function fetchSecrets(
+export function fetchSecrets(
   accountId: number
-): Promise<FetchSecretsResponse> {
-  return http.get(accountId, {
+): AxiosPromise<FetchSecretsResponse> {
+  return http.get<FetchSecretsResponse>(accountId, {
     url: `${SECRETS_API_PATH}`,
   });
 }

--- a/api/validateHubl.ts
+++ b/api/validateHubl.ts
@@ -1,14 +1,15 @@
+import { AxiosPromise } from 'axios';
 import http from '../http';
 import { Validation, HublValidationOptions } from '../types/HublValidation';
 
 const HUBL_VALIDATE_API_PATH = 'cos-rendering/v1/internal/validate';
 
-export async function validateHubl(
+export function validateHubl(
   accountId: number,
   sourceCode: string,
   hublValidationOptions?: HublValidationOptions
-): Promise<Validation> {
-  return http.post(accountId, {
+): AxiosPromise<Validation> {
+  return http.post<Validation>(accountId, {
     url: HUBL_VALIDATE_API_PATH,
     data: {
       template_source: sourceCode,

--- a/http/index.ts
+++ b/http/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs-extra';
 import contentDisposition from 'content-disposition';
-import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosRequestConfig, AxiosResponse, AxiosPromise } from 'axios';
 
 import { getAccountConfig } from '../config';
 import { USER_AGENTS, getAxiosConfig } from './getAxiosConfig';
@@ -122,125 +122,45 @@ function addQueryParams(
 async function getRequest<T>(
   accountId: number,
   options: HttpOptions
-): Promise<T>;
-async function getRequest<T>(
-  accountId: number,
-  options: HttpOptions,
-  withFullResponse: true
-): Promise<AxiosResponse<T>>;
-async function getRequest<T>(
-  accountId: number,
-  options: HttpOptions,
-  withFullResponse?: true
-) {
+): AxiosPromise<T> {
   const { params, ...rest } = options;
   const axiosConfig = addQueryParams(rest, params);
   const configWithAuth = await withAuth(accountId, axiosConfig);
 
-  const response = await axios<T>(configWithAuth);
-
-  if (withFullResponse) {
-    return response;
-  }
-
-  return response.data;
+  return axios<T>(configWithAuth);
 }
 
 async function postRequest<T>(
   accountId: number,
   options: HttpOptions
-): Promise<T>;
-async function postRequest<T>(
-  accountId: number,
-  options: HttpOptions,
-  withFullResponse: true
-): Promise<AxiosResponse<T>>;
-async function postRequest(
-  accountId: number,
-  options: HttpOptions,
-  withFullResponse?: true
-) {
+): AxiosPromise<T> {
   const configWithAuth = await withAuth(accountId, options);
 
-  const response = await axios({ ...configWithAuth, method: 'post' });
-
-  if (withFullResponse) {
-    return response;
-  }
-
-  return response.data;
+  return axios({ ...configWithAuth, method: 'post' });
 }
 
 async function putRequest<T>(
   accountId: number,
   options: HttpOptions
-): Promise<T>;
-async function putRequest<T>(
-  accountId: number,
-  options: HttpOptions,
-  withFullResponse: true
-): Promise<AxiosResponse<T>>;
-async function putRequest(
-  accountId: number,
-  options: HttpOptions,
-  withFullResponse?: true
-) {
+): AxiosPromise<T> {
   const configWithAuth = await withAuth(accountId, options);
-  const response = await axios({ ...configWithAuth, method: 'put' });
-
-  if (withFullResponse) {
-    return response;
-  }
-
-  return response.data;
+  return axios({ ...configWithAuth, method: 'put' });
 }
 
 async function patchRequest<T>(
   accountId: number,
   options: HttpOptions
-): Promise<T>;
-async function patchRequest<T>(
-  accountId: number,
-  options: HttpOptions,
-  withFullResponse: true
-): Promise<AxiosResponse<T>>;
-async function patchRequest(
-  accountId: number,
-  options: HttpOptions,
-  withFullResponse?: true
-) {
+): Promise<T> {
   const configWithAuth = await withAuth(accountId, options);
-  const response = await axios({ ...configWithAuth, method: 'patch' });
-
-  if (withFullResponse) {
-    return response;
-  }
-
-  return response.data;
+  return axios({ ...configWithAuth, method: 'patch' });
 }
 
 async function deleteRequest<T>(
   accountId: number,
   options: HttpOptions
-): Promise<T>;
-async function deleteRequest<T>(
-  accountId: number,
-  options: HttpOptions,
-  withFullResponse: true
-): Promise<AxiosResponse<T>>;
-async function deleteRequest(
-  accountId: number,
-  options: HttpOptions,
-  withFullResponse = false
-) {
+): AxiosPromise<T> {
   const configWithAuth = await withAuth(accountId, options);
-  const response = await axios({ ...configWithAuth, method: 'delete' });
-
-  if (withFullResponse) {
-    return response;
-  }
-
-  return response.data;
+  return axios({ ...configWithAuth, method: 'delete' });
 }
 
 function createGetRequestStream(contentType: string) {
@@ -248,7 +168,7 @@ function createGetRequestStream(contentType: string) {
     accountId: number,
     options: HttpOptions,
     destPath: string
-  ): Promise<AxiosResponse> => {
+  ): AxiosPromise => {
     const { params, ...rest } = options;
     const axiosConfig = addQueryParams(rest, params);
 

--- a/http/index.ts
+++ b/http/index.ts
@@ -150,7 +150,7 @@ async function putRequest<T>(
 async function patchRequest<T>(
   accountId: number,
   options: HttpOptions
-): Promise<T> {
+): AxiosPromise<T> {
   const configWithAuth = await withAuth(accountId, options);
   return axios({ ...configWithAuth, method: 'patch' });
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,6 @@ module.exports = {
   },
   setupFiles: ['./setupTests.ts'],
   transformIgnorePatterns: ['node_modules/(?!variables/.*)'],
-  modulePathIgnorePatterns: ['<rootDir>/dist/'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/', '/__utils__/'],
   clearMocks: true,
 };

--- a/lib/__tests__/__utils__/mockAxiosResponse.ts
+++ b/lib/__tests__/__utils__/mockAxiosResponse.ts
@@ -1,0 +1,14 @@
+import { AxiosResponse, AxiosHeaders } from 'axios';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function mockAxiosResponse(data?: any): AxiosResponse {
+  return {
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {
+      headers: new AxiosHeaders(),
+    },
+  };
+}

--- a/lib/__tests__/customObjects.ts
+++ b/lib/__tests__/customObjects.ts
@@ -11,6 +11,7 @@ import {
 import basicSchema from './fixtures/customObjects/basicSchema.json';
 import fullSchema from './fixtures/customObjects/fullSchema.json';
 import multipleSchemas from './fixtures/customObjects/multipleSchemas.json';
+import { mockAxiosResponse } from './__utils__/mockAxiosResponse';
 
 jest.mock('fs-extra');
 jest.mock('../../api/customObjects');
@@ -38,7 +39,7 @@ describe('lib/customObjects', () => {
 
   describe('downloadSchema()', () => {
     it('downloads a schema and writes it to disk', async () => {
-      fetchObjectSchema.mockResolvedValue(fullSchema);
+      fetchObjectSchema.mockResolvedValue(mockAxiosResponse(fullSchema));
 
       const result = await downloadSchema(123, '');
       const outputFileArgs = outputFileSyncSpy.mock.lastCall;
@@ -70,7 +71,9 @@ describe('lib/customObjects', () => {
 
   describe('downloadSchemas()', () => {
     it('downloads schemas and writes them to disk', async () => {
-      fetchObjectSchemas.mockResolvedValue({ results: multipleSchemas });
+      fetchObjectSchemas.mockResolvedValue(
+        mockAxiosResponse({ results: multipleSchemas })
+      );
 
       const result = await downloadSchemas(123);
       expect(result).toEqual(expect.objectContaining(multipleSchemas));

--- a/lib/__tests__/fileManager.ts
+++ b/lib/__tests__/fileManager.ts
@@ -2,6 +2,7 @@ import { uploadFolder } from '../fileManager';
 import { uploadFile } from '../../api/fileManager';
 import { walk } from '../fs';
 import { createIgnoreFilter } from '../ignoreRules';
+import { mockAxiosResponse } from './__utils__/mockAxiosResponse';
 
 jest.mock('../fs');
 jest.mock('../../api/fileManager');
@@ -23,7 +24,7 @@ describe('lib/fileManager', () => {
 
       mockedWalk.mockResolvedValue(files);
       mockedUploadFile.mockImplementation(() =>
-        Promise.resolve({ objects: [] })
+        Promise.resolve(mockAxiosResponse({ objects: [] }))
       );
       mockedCreateIgnoreFilter.mockImplementation(() => () => true);
 

--- a/lib/__tests__/fileMapper.ts
+++ b/lib/__tests__/fileMapper.ts
@@ -207,6 +207,7 @@ describe('lib/fileMapper', () => {
 
     it('folder: should execute the download client per the request input', async () => {
       const src = '1234';
+      download.mockResolvedValueOnce(mockAxiosResponse());
 
       await fetchFolderFromApi(accountId, src);
       const queryParams = {
@@ -220,6 +221,7 @@ describe('lib/fileMapper', () => {
     });
     it('module: should execute the download client per the request input', async () => {
       const src = 'cms-theme-boilerplate/modules/Card section.module';
+      download.mockResolvedValueOnce(mockAxiosResponse());
 
       await fetchFolderFromApi(accountId, src);
       const queryParams = {
@@ -233,6 +235,7 @@ describe('lib/fileMapper', () => {
     });
     it('fetch all: should execute the download client per the request input', async () => {
       const src = '/';
+      download.mockResolvedValueOnce(mockAxiosResponse());
 
       await fetchFolderFromApi(accountId, src);
       const queryParams = {

--- a/lib/__tests__/fileMapper.ts
+++ b/lib/__tests__/fileMapper.ts
@@ -14,6 +14,7 @@ import {
   fetchFileStream as __fetchFileStream,
 } from '../../api/fileMapper';
 import folderWithoutSources from './fixtures/fileMapper/folderWithoutSources.json';
+import { mockAxiosResponse } from './__utils__/mockAxiosResponse';
 
 jest.mock('../../api/fileMapper');
 const utimesSpy = jest.spyOn(fs, 'utimes');
@@ -270,15 +271,17 @@ describe('lib/fileMapper', () => {
     });
     it('should execute downloadFolder', async () => {
       pathExistsSpy.mockImplementationOnce(() => false);
-      download.mockResolvedValueOnce({
-        name: '',
-        createdAt: 1,
-        updatedAt: 1,
-        source: null,
-        path: '',
-        folder: true,
-        children: [],
-      });
+      download.mockResolvedValueOnce(
+        mockAxiosResponse({
+          name: '',
+          createdAt: 1,
+          updatedAt: 1,
+          source: null,
+          path: '',
+          folder: true,
+          children: [],
+        })
+      );
       await downloadFileOrFolder(accountId, '/a/b/c', './');
       expect(ensureDirSpy).toHaveBeenCalled();
     });

--- a/lib/__tests__/hubdb.ts
+++ b/lib/__tests__/hubdb.ts
@@ -17,6 +17,7 @@ import hubdbFetchRowsResponseWithPaging from './fixtures/hubdb/fetchRowsResponse
 import hubdbTableResponse from './fixtures/hubdb/tableResponse.json';
 import hubdbCreateRowsResponse from './fixtures/hubdb/createRowsResponse.json';
 import { Table } from '../../types/Hubdb';
+import { mockAxiosResponse } from './__utils__/mockAxiosResponse';
 
 jest.mock('fs-extra');
 jest.mock('../path');
@@ -41,8 +42,8 @@ describe('lib/hubdb', () => {
 
     beforeEach(() => {
       getCwd.mockReturnValue(projectCwd);
-      fetchRows.mockResolvedValue(hubdbFetchRowResponse);
-      fetchTable.mockResolvedValue(hubdbTableResponse);
+      fetchRows.mockResolvedValue(mockAxiosResponse(hubdbFetchRowResponse));
+      fetchTable.mockResolvedValue(mockAxiosResponse(hubdbTableResponse));
     });
 
     it('fetches all results', async () => {
@@ -67,7 +68,9 @@ describe('lib/hubdb', () => {
     });
 
     it('fetches all results with paging', async () => {
-      fetchRows.mockResolvedValueOnce(hubdbFetchRowsResponseWithPaging);
+      fetchRows.mockResolvedValueOnce(
+        mockAxiosResponse(hubdbFetchRowsResponseWithPaging)
+      );
       await downloadHubDbTable(accountId, tableId, destPath);
       const outputFile = JSON.parse(
         mockedFS.outputFile.mock.calls[0][1] as string
@@ -92,9 +95,9 @@ describe('lib/hubdb', () => {
       mockedFS.statSync.mockReturnValue({ isFile: () => true } as fs.Stats);
       mockedFS.readJsonSync.mockReturnValue(hubdbTableResponse);
 
-      createTable.mockResolvedValue(hubdbTableResponse);
-      createRows.mockResolvedValue(hubdbCreateRowsResponse);
-      publishTable.mockResolvedValue(hubdbTableResponse);
+      createTable.mockResolvedValue(mockAxiosResponse(hubdbTableResponse));
+      createRows.mockResolvedValue(mockAxiosResponse(hubdbCreateRowsResponse));
+      publishTable.mockResolvedValue(mockAxiosResponse(hubdbTableResponse));
 
       const table = await createHubDbTable(
         accountId,
@@ -109,7 +112,7 @@ describe('lib/hubdb', () => {
 
   describe('clearHubDbTableRows()', () => {
     it('clears all of the hubdb table rows', async () => {
-      fetchRows.mockResolvedValue(hubdbFetchRowResponse);
+      fetchRows.mockResolvedValue(mockAxiosResponse(hubdbFetchRowResponse));
       const result = await clearHubDbTableRows(123, '456');
 
       expect(result.deletedRowCount).toBe(3);

--- a/lib/__tests__/personalAccessKey.ts
+++ b/lib/__tests__/personalAccessKey.ts
@@ -15,6 +15,7 @@ import {
   updateConfigWithAccessToken,
 } from '../personalAccessKey';
 import { AuthType } from '../../types/Accounts';
+import { mockAxiosResponse } from './__utils__/mockAxiosResponse';
 
 jest.mock('../../config');
 jest.mock('../logger');
@@ -59,16 +60,18 @@ describe('lib/personalAccessKey', () => {
       getAccountConfig.mockReturnValue(account);
 
       const freshAccessToken = 'fresh-token';
-      fetchAccessToken.mockResolvedValue({
-        oauthAccessToken: freshAccessToken,
-        expiresAtMillis: moment().add(1, 'hours').valueOf(),
-        encodedOAuthRefreshToken: 'let-me-in',
-        scopeGroups: ['content'],
-        hubId: accountId,
-        userId: 456,
-        hubName: 'test-hub',
-        accountType: HUBSPOT_ACCOUNT_TYPES.STANDARD,
-      });
+      fetchAccessToken.mockResolvedValue(
+        mockAxiosResponse({
+          oauthAccessToken: freshAccessToken,
+          expiresAtMillis: moment().add(1, 'hours').valueOf(),
+          encodedOAuthRefreshToken: 'let-me-in',
+          scopeGroups: ['content'],
+          hubId: accountId,
+          userId: 456,
+          hubName: 'test-hub',
+          accountType: HUBSPOT_ACCOUNT_TYPES.STANDARD,
+        })
+      );
       const accessToken = await accessTokenForPersonalAccessKey(accountId);
       expect(accessToken).toEqual(freshAccessToken);
     });
@@ -112,16 +115,18 @@ describe('lib/personalAccessKey', () => {
       getAccountConfig.mockReturnValue(account);
 
       const freshAccessToken = 'fresh-token';
-      fetchAccessToken.mockResolvedValue({
-        oauthAccessToken: freshAccessToken,
-        expiresAtMillis: moment().add(1, 'hours').valueOf(),
-        encodedOAuthRefreshToken: 'let-me-in-3',
-        scopeGroups: ['content'],
-        hubId: accountId,
-        userId: 456,
-        hubName: 'test-hub',
-        accountType: HUBSPOT_ACCOUNT_TYPES.STANDARD,
-      });
+      fetchAccessToken.mockResolvedValue(
+        mockAxiosResponse({
+          oauthAccessToken: freshAccessToken,
+          expiresAtMillis: moment().add(1, 'hours').valueOf(),
+          encodedOAuthRefreshToken: 'let-me-in-3',
+          scopeGroups: ['content'],
+          hubId: accountId,
+          userId: 456,
+          hubName: 'test-hub',
+          accountType: HUBSPOT_ACCOUNT_TYPES.STANDARD,
+        })
+      );
       const accessToken = await accessTokenForPersonalAccessKey(accountId);
       expect(accessToken).toEqual(freshAccessToken);
     });
@@ -153,16 +158,18 @@ describe('lib/personalAccessKey', () => {
       const firstAccessToken = 'fresh-token';
       const expiresAtMillis = moment().subtract(1, 'hours').valueOf();
 
-      fetchAccessToken.mockResolvedValue({
-        oauthAccessToken: firstAccessToken,
-        expiresAtMillis,
-        encodedOAuthRefreshToken: accessKey,
-        scopeGroups: ['content'],
-        hubId: accountId,
-        userId,
-        hubName: 'test-hub',
-        accountType: HUBSPOT_ACCOUNT_TYPES.STANDARD,
-      });
+      fetchAccessToken.mockResolvedValue(
+        mockAxiosResponse({
+          oauthAccessToken: firstAccessToken,
+          expiresAtMillis,
+          encodedOAuthRefreshToken: accessKey,
+          scopeGroups: ['content'],
+          hubId: accountId,
+          userId,
+          hubName: 'test-hub',
+          accountType: HUBSPOT_ACCOUNT_TYPES.STANDARD,
+        })
+      );
       const firstRefreshedAccessToken =
         await accessTokenForPersonalAccessKey(accountId);
       expect(firstRefreshedAccessToken).toEqual(firstAccessToken);
@@ -176,16 +183,18 @@ describe('lib/personalAccessKey', () => {
       getAccountConfig.mockReturnValueOnce(updatedAccountConfig);
 
       const secondAccessToken = 'another-fresh-token';
-      fetchAccessToken.mockResolvedValue({
-        oauthAccessToken: secondAccessToken,
-        expiresAtMillis,
-        encodedOAuthRefreshToken: accessKey,
-        scopeGroups: ['content'],
-        hubId: accountId,
-        userId,
-        hubName: 'test-hub',
-        accountType: HUBSPOT_ACCOUNT_TYPES.STANDARD,
-      });
+      fetchAccessToken.mockResolvedValue(
+        mockAxiosResponse({
+          oauthAccessToken: secondAccessToken,
+          expiresAtMillis,
+          encodedOAuthRefreshToken: accessKey,
+          scopeGroups: ['content'],
+          hubId: accountId,
+          userId,
+          hubName: 'test-hub',
+          accountType: HUBSPOT_ACCOUNT_TYPES.STANDARD,
+        })
+      );
 
       const secondRefreshedAccessToken =
         await accessTokenForPersonalAccessKey(accountId);
@@ -196,16 +205,18 @@ describe('lib/personalAccessKey', () => {
   describe('updateConfigWithPersonalAccessKey()', () => {
     it('updates the config with the new account', async () => {
       const freshAccessToken = 'fresh-token';
-      fetchAccessToken.mockResolvedValue({
-        oauthAccessToken: freshAccessToken,
-        expiresAtMillis: moment().add(1, 'hours').valueOf(),
-        encodedOAuthRefreshToken: 'let-me-in-5',
-        scopeGroups: ['content'],
-        hubId: 123,
-        userId: 456,
-        hubName: 'test-hub',
-        accountType: HUBSPOT_ACCOUNT_TYPES.STANDARD,
-      });
+      fetchAccessToken.mockResolvedValue(
+        mockAxiosResponse({
+          oauthAccessToken: freshAccessToken,
+          expiresAtMillis: moment().add(1, 'hours').valueOf(),
+          encodedOAuthRefreshToken: 'let-me-in-5',
+          scopeGroups: ['content'],
+          hubId: 123,
+          userId: 456,
+          hubName: 'test-hub',
+          accountType: HUBSPOT_ACCOUNT_TYPES.STANDARD,
+        })
+      );
 
       const token = await getAccessToken('pak_123', ENVIRONMENTS.QA, 123);
 
@@ -228,22 +239,26 @@ describe('lib/personalAccessKey', () => {
     });
 
     it('updates the config with the new account for sandbox accounts', async () => {
-      fetchSandboxHubData.mockResolvedValue({
-        type: 'DEVELOPER',
-        parentHubId: 789,
-      });
+      fetchSandboxHubData.mockResolvedValue(
+        mockAxiosResponse({
+          type: 'DEVELOPER',
+          parentHubId: 789,
+        })
+      );
 
       const freshAccessToken = 'fresh-token';
-      fetchAccessToken.mockResolvedValue({
-        oauthAccessToken: freshAccessToken,
-        expiresAtMillis: moment().add(1, 'hours').valueOf(),
-        encodedOAuthRefreshToken: 'let-me-in-5',
-        scopeGroups: ['content'],
-        hubId: 123,
-        userId: 456,
-        hubName: 'test-hub',
-        accountType: HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX,
-      });
+      fetchAccessToken.mockResolvedValue(
+        mockAxiosResponse({
+          oauthAccessToken: freshAccessToken,
+          expiresAtMillis: moment().add(1, 'hours').valueOf(),
+          encodedOAuthRefreshToken: 'let-me-in-5',
+          scopeGroups: ['content'],
+          hubId: 123,
+          userId: 456,
+          hubName: 'test-hub',
+          accountType: HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX,
+        })
+      );
 
       const token = await getAccessToken('pak_123', ENVIRONMENTS.QA, 123);
 
@@ -268,26 +283,30 @@ describe('lib/personalAccessKey', () => {
 
     it('updates the config with the new account for developer test accounts', async () => {
       fetchSandboxHubData.mockRejectedValue(new Error('Not a sandbox'));
-      fetchDeveloperTestAccountData.mockResolvedValue({
-        parentPortalId: 999,
-        testPortalId: 123,
-        accountName: 'Dev test portal',
-        createdAt: '123',
-        updatedAt: '123',
-        status: 'ACTIVE',
-      });
+      fetchDeveloperTestAccountData.mockResolvedValue(
+        mockAxiosResponse({
+          parentPortalId: 999,
+          testPortalId: 123,
+          accountName: 'Dev test portal',
+          createdAt: '123',
+          updatedAt: '123',
+          status: 'ACTIVE',
+        })
+      );
 
       const freshAccessToken = 'fresh-token';
-      fetchAccessToken.mockResolvedValue({
-        oauthAccessToken: freshAccessToken,
-        expiresAtMillis: moment().add(1, 'hours').valueOf(),
-        encodedOAuthRefreshToken: 'let-me-in-5',
-        scopeGroups: ['content'],
-        hubId: 123,
-        userId: 456,
-        hubName: 'test-hub',
-        accountType: HUBSPOT_ACCOUNT_TYPES.DEVELOPER_TEST,
-      });
+      fetchAccessToken.mockResolvedValue(
+        mockAxiosResponse({
+          oauthAccessToken: freshAccessToken,
+          expiresAtMillis: moment().add(1, 'hours').valueOf(),
+          encodedOAuthRefreshToken: 'let-me-in-5',
+          scopeGroups: ['content'],
+          hubId: 123,
+          userId: 456,
+          hubName: 'test-hub',
+          accountType: HUBSPOT_ACCOUNT_TYPES.DEVELOPER_TEST,
+        })
+      );
 
       const token = await getAccessToken('pak_123', ENVIRONMENTS.QA, 123);
 

--- a/lib/__tests__/sandboxes.ts
+++ b/lib/__tests__/sandboxes.ts
@@ -18,6 +18,7 @@ import {
   fetchTaskStatus,
 } from '../sandboxes';
 import { AxiosError } from 'axios';
+import { mockAxiosResponse } from './__utils__/mockAxiosResponse';
 
 jest.mock('../../api/sandboxHubs');
 jest.mock('../../api/sandboxSync');
@@ -91,10 +92,12 @@ describe('lib/sandboxes', () => {
   describe('createSandbox', () => {
     const personalAccessKey = 'pak-test-123';
     it('should create a sandbox', async () => {
-      createSandboxMock.mockResolvedValue({
-        sandbox: MOCK_SANDBOX_ACCOUNT,
-        personalAccessKey,
-      });
+      createSandboxMock.mockResolvedValue(
+        mockAxiosResponse({
+          sandbox: MOCK_SANDBOX_ACCOUNT,
+          personalAccessKey,
+        })
+      );
 
       const response = await createSandbox(accountId, sandboxName, 1);
       expect(createSandboxMock).toHaveBeenCalledWith(accountId, sandboxName, 1);
@@ -135,9 +138,11 @@ describe('lib/sandboxes', () => {
 
   describe('getSandboxUsageLimits', () => {
     it('should get usage limit', async () => {
-      getSandboxUsageLimitsMock.mockResolvedValue({
-        usage: MOCK_USAGE_DATA,
-      });
+      getSandboxUsageLimitsMock.mockResolvedValue(
+        mockAxiosResponse({
+          usage: MOCK_USAGE_DATA,
+        })
+      );
 
       const response = await getSandboxUsageLimits(accountId);
       expect(response).toStrictEqual(MOCK_USAGE_DATA);
@@ -166,7 +171,7 @@ describe('lib/sandboxes', () => {
         } as SyncTask, // This object is huge, I don't want to add all of it
         id: 'this-is-an-id',
       };
-      initiateSyncMock.mockResolvedValue(sync);
+      initiateSyncMock.mockResolvedValue(mockAxiosResponse(sync));
 
       const response = await initiateSync(
         accountId,
@@ -200,7 +205,7 @@ describe('lib/sandboxes', () => {
         status: 'please hold',
         tasks: [],
       };
-      fetchTaskStatusMock.mockResolvedValue(status);
+      fetchTaskStatusMock.mockResolvedValue(mockAxiosResponse(status));
 
       const response = await fetchTaskStatus(accountId, taskId);
       expect(fetchTaskStatusMock).toHaveBeenCalledWith(accountId, taskId);
@@ -219,9 +224,11 @@ describe('lib/sandboxes', () => {
 
   describe('fetchTypes', () => {
     it('should fetch types', async () => {
-      fetchTypesMock.mockResolvedValue({
-        results: MOCK_TYPES,
-      });
+      fetchTypesMock.mockResolvedValue(
+        mockAxiosResponse({
+          results: MOCK_TYPES,
+        })
+      );
 
       const response = await fetchTypes(accountId, sandboxHubId);
       expect(response).toStrictEqual(MOCK_TYPES);

--- a/lib/__tests__/uploadFolder.ts
+++ b/lib/__tests__/uploadFolder.ts
@@ -11,6 +11,7 @@ import {
   cleanupTmpDirSync as __cleanupTmpDirSync,
   createTmpDirSync as __createTmpDirSync,
 } from '../cms/handleFieldsJS';
+import { mockAxiosResponse } from './__utils__/mockAxiosResponse';
 
 jest.mock('../fs');
 jest.mock('../../api/fileMapper');
@@ -93,7 +94,7 @@ describe('lib/cms/uploadFolder', () => {
     it('uploads files in the correct order', async () => {
       listFilesInDir.mockReturnValue(['fields.json']);
       walk.mockResolvedValue(filesProto);
-      upload.mockResolvedValue();
+      upload.mockResolvedValue(mockAxiosResponse());
 
       const uploadedFilesInOrder = [
         'folder/images/image.png',
@@ -129,7 +130,7 @@ describe('lib/cms/uploadFolder', () => {
     it('creates a temp directory if --convertFields is true', async () => {
       const tmpDirSpy = createTmpDirSync.mockImplementation(() => '');
 
-      upload.mockResolvedValue();
+      upload.mockResolvedValue(mockAxiosResponse());
 
       await uploadFolder(
         123,
@@ -147,7 +148,7 @@ describe('lib/cms/uploadFolder', () => {
       const saveOutputSpy = jest.spyOn(FieldsJs.prototype, 'saveOutput');
 
       createTmpDirSync.mockReturnValue('folder');
-      upload.mockResolvedValue();
+      upload.mockResolvedValue(mockAxiosResponse());
 
       await uploadFolder(
         123,
@@ -166,7 +167,7 @@ describe('lib/cms/uploadFolder', () => {
       createTmpDirSync.mockReturnValue('folder');
       const deleteDirSpy = cleanupTmpDirSync.mockImplementation(() => '');
 
-      upload.mockResolvedValue();
+      upload.mockResolvedValue(mockAxiosResponse());
 
       await uploadFolder(
         123,

--- a/lib/cms/validate.ts
+++ b/lib/cms/validate.ts
@@ -27,7 +27,7 @@ export async function lint(
           }
           return result;
         }
-        const validation = await validateHubl(accountId, source);
+        const { data: validation } = await validateHubl(accountId, source);
         const result = {
           file,
           validation,

--- a/lib/customObjects.ts
+++ b/lib/customObjects.ts
@@ -29,7 +29,8 @@ export async function downloadSchemas(
   let response: FetchSchemasResponse;
 
   try {
-    response = await fetchObjectSchemas(accountId);
+    const axiosResponse = await fetchObjectSchemas(accountId);
+    response = axiosResponse.data;
   } catch (err) {
     throwApiError(err);
   }
@@ -51,7 +52,8 @@ export async function downloadSchema(
   let response: Schema;
 
   try {
-    response = await fetchObjectSchema(accountId, schemaObjectType);
+    const axiosResponse = await fetchObjectSchema(accountId, schemaObjectType);
+    response = axiosResponse.data;
   } catch (err) {
     throwApiError(err);
   }

--- a/lib/developerTestAccounts.ts
+++ b/lib/developerTestAccounts.ts
@@ -15,8 +15,8 @@ export async function createDeveloperTestAccount(
   accountName: string
 ): Promise<DeveloperTestAccount> {
   try {
-    const resp = await _createDeveloperTestAccount(accountId, accountName);
-    return resp;
+    const { data } = await _createDeveloperTestAccount(accountId, accountName);
+    return data;
   } catch (err) {
     throwApiError(err);
   }
@@ -27,8 +27,11 @@ export async function deleteDeveloperTestAccount(
   testAccountId: number
 ): Promise<void> {
   try {
-    const resp = await _deleteDeveloperTestAccount(accountId, testAccountId);
-    return resp;
+    const { data } = await _deleteDeveloperTestAccount(
+      accountId,
+      testAccountId
+    );
+    return data;
   } catch (err) {
     throwApiError(err);
   }
@@ -38,8 +41,8 @@ export async function fetchDeveloperTestAccounts(
   accountId: number
 ): Promise<FetchDeveloperTestAccountsResponse> {
   try {
-    const resp = await _fetchDeveloperTestAccounts(accountId);
-    return resp;
+    const { data } = await _fetchDeveloperTestAccounts(accountId);
+    return data;
   } catch (err) {
     throwApiError(err);
   }

--- a/lib/fileManager.ts
+++ b/lib/fileManager.ts
@@ -118,7 +118,7 @@ async function fetchAllPagedFiles(
   let count = 0;
   let offset = 0;
   while (totalFiles === null || count < totalFiles) {
-    const response = await fetchFiles(
+    const { data: response } = await fetchFiles(
       accountId,
       folderId,
       offset,
@@ -165,7 +165,9 @@ async function fetchFolderContents(
     await downloadFile(accountId, file, dest, overwrite);
   }
 
-  const { objects: folders } = await fetchFolders(accountId, folder.id);
+  const {
+    data: { objects: folders },
+  } = await fetchFolders(accountId, folder.id);
   for (const folder of folders) {
     const nestedFolder = path.join(dest, folder.name);
     await fetchFolderContents(
@@ -273,7 +275,9 @@ export async function downloadFileOrFolder(
         includeArchived
       );
     } else {
-      const { file, folder } = await fetchStat(accountId, src);
+      const {
+        data: { file, folder },
+      } = await fetchStat(accountId, src);
       if (file) {
         await downloadSingleFile(
           accountId,

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -330,7 +330,7 @@ export async function fetchFolderFromApi(
   }
   const srcPath = isRoot ? '@root' : src;
   const queryValues = getFileMapperQueryValues(mode, options);
-  const node = isHubspot
+  const { data: node } = isHubspot
     ? await downloadDefault(accountId, srcPath, queryValues)
     : await download(accountId, srcPath, queryValues);
   logger.log(i18n(`${i18nKey}.folderFetch`, { src, accountId }));

--- a/lib/hubdb.ts
+++ b/lib/hubdb.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs-extra';
 import prettier from 'prettier';
+import { AxiosResponse } from 'axios';
 import {
   createTable,
   updateTable,
@@ -58,7 +59,9 @@ export async function addRowsToHubDbTable(
     await createRows(accountId, tableId, rowsToUpdate);
   }
 
-  const { rowCount } = await publishTable(accountId, tableId);
+  const {
+    data: { rowCount },
+  } = await publishTable(accountId, tableId);
 
   return {
     tableId,
@@ -74,7 +77,9 @@ export async function createHubDbTable(
 
   const table: Table = fs.readJsonSync(src);
   const { rows, ...schema } = table;
-  const { id } = await createTable(accountId, schema);
+  const {
+    data: { id },
+  } = await createTable(accountId, schema);
 
   return addRowsToHubDbTable(accountId, id, rows);
 }
@@ -147,13 +152,13 @@ async function fetchAllRows(
   let rows: Array<Row> = [];
   let after: string | null = null;
   do {
-    const response: FetchRowsResponse = await fetchRows(
+    const axiosResponse: AxiosResponse<FetchRowsResponse> = await fetchRows(
       accountId,
       tableId,
       after ? { after } : undefined
     );
 
-    const { paging, results } = response;
+    const { paging, results } = axiosResponse.data;
 
     rows = rows.concat(results);
     after = paging && paging.next ? paging.next.after : null;
@@ -167,7 +172,7 @@ export async function downloadHubDbTable(
   tableId: string,
   dest: string
 ): Promise<{ filePath: string }> {
-  const table = await fetchTable(accountId, tableId);
+  const { data: table } = await fetchTable(accountId, tableId);
 
   dest = path.resolve(getCwd(), dest || `${table.name}.hubdb.json`) as string;
 

--- a/lib/personalAccessKey.ts
+++ b/lib/personalAccessKey.ts
@@ -50,7 +50,12 @@ export async function getAccessToken(
 ): Promise<AccessToken> {
   let response;
   try {
-    response = await fetchAccessToken(personalAccessKey, env, accountId);
+    const axiosResponse = await fetchAccessToken(
+      personalAccessKey,
+      env,
+      accountId
+    );
+    response = axiosResponse.data;
   } catch (e) {
     const error = e as AxiosError<{ message?: string }>;
     if (error.response) {
@@ -112,7 +117,7 @@ async function getNewAccessToken(
   if (refreshRequests.has(key)) {
     return refreshRequests.get(key);
   }
-  let accessTokenResponse;
+  let accessTokenResponse: AccessToken;
   try {
     const refreshAccessPromise = refreshAccessToken(
       personalAccessKey,
@@ -193,7 +198,7 @@ export async function updateConfigWithAccessToken(
       accountType === HUBSPOT_ACCOUNT_TYPES.STANDARD_SANDBOX ||
       accountType === HUBSPOT_ACCOUNT_TYPES.DEVELOPMENT_SANDBOX
     ) {
-      const sandboxDataResponse = await fetchSandboxHubData(
+      const { data: sandboxDataResponse } = await fetchSandboxHubData(
         accessToken,
         portalId,
         accountEnv
@@ -209,11 +214,8 @@ export async function updateConfigWithAccessToken(
 
   try {
     if (accountType === HUBSPOT_ACCOUNT_TYPES.DEVELOPER_TEST) {
-      const developerTestAccountResponse = await fetchDeveloperTestAccountData(
-        accessToken,
-        portalId,
-        accountEnv
-      );
+      const { data: developerTestAccountResponse } =
+        await fetchDeveloperTestAccountData(accessToken, portalId, accountEnv);
       if (developerTestAccountResponse) {
         parentAccountId = developerTestAccountResponse.parentPortalId;
       }

--- a/lib/sandboxes.ts
+++ b/lib/sandboxes.ts
@@ -28,10 +28,10 @@ export async function createSandbox(
   personalAccessKey: string;
 }> {
   try {
-    const resp = await _createSandbox(accountId, name, type);
+    const { data } = await _createSandbox(accountId, name, type);
     return {
       name,
-      ...resp,
+      ...data,
     };
   } catch (err) {
     throwApiError(err);
@@ -58,8 +58,8 @@ export async function getSandboxUsageLimits(
   parentAccountId: number
 ): Promise<Usage | void> {
   try {
-    const resp = await _getSandboxUsageLimits(parentAccountId);
-    return resp && resp.usage;
+    const { data } = await _getSandboxUsageLimits(parentAccountId);
+    return data && data.usage;
   } catch (err) {
     throwApiError(err);
   }
@@ -72,7 +72,13 @@ export async function initiateSync(
   sandboxHubId: number
 ): Promise<InitiateSyncResponse> {
   try {
-    return await _initiateSync(fromHubId, toHubId, tasks, sandboxHubId);
+    const { data } = await _initiateSync(
+      fromHubId,
+      toHubId,
+      tasks,
+      sandboxHubId
+    );
+    return data;
   } catch (err) {
     throwApiError(err);
   }
@@ -83,7 +89,8 @@ export async function fetchTaskStatus(
   taskId: number
 ): Promise<SyncTaskStatusType> {
   try {
-    return await _fetchTaskStatus(accountId, taskId);
+    const { data } = await _fetchTaskStatus(accountId, taskId);
+    return data;
   } catch (err) {
     throwApiError(err);
   }
@@ -94,8 +101,8 @@ export async function fetchTypes(
   toHubId: number
 ): Promise<Array<SandboxType> | void> {
   try {
-    const resp = await _fetchTypes(accountId, toHubId);
-    return resp && resp.results;
+    const { data } = await _fetchTypes(accountId, toHubId);
+    return data && data.results;
   } catch (err) {
     throwApiError(err);
   }

--- a/lib/trackUsage.ts
+++ b/lib/trackUsage.ts
@@ -44,7 +44,7 @@ export async function trackUsage(
 
   if (accountConfig && accountConfig.authType === 'personalaccesskey') {
     logger.debug(i18n(`${i18nKey}.sendingEventAuthenticated`));
-    return http.post(accountId, {
+    http.post(accountId, {
       url: `${path}/authenticated`,
       data: usageEvent,
       resolveWithFullResponse: true,

--- a/lib/trackUsage.ts
+++ b/lib/trackUsage.ts
@@ -44,20 +44,20 @@ export async function trackUsage(
 
   if (accountConfig && accountConfig.authType === 'personalaccesskey') {
     logger.debug(i18n(`${i18nKey}.sendingEventAuthenticated`));
-    http.post(accountId, {
+    await http.post(accountId, {
       url: `${path}/authenticated`,
       data: usageEvent,
       resolveWithFullResponse: true,
     });
+  } else {
+    const env = getEnv(accountId);
+    const axiosConfig = getAxiosConfig({
+      env,
+      url: path,
+      data: usageEvent,
+      resolveWithFullResponse: true,
+    });
+    logger.debug(i18n(`${i18nKey}.sendingEventUnauthenticated`));
+    axios({ ...axiosConfig, method: 'post' });
   }
-
-  const env = getEnv(accountId);
-  const axiosConfig = getAxiosConfig({
-    env,
-    url: path,
-    data: usageEvent,
-    resolveWithFullResponse: true,
-  });
-  logger.debug(i18n(`${i18nKey}.sendingEventUnauthenticated`));
-  axios({ ...axiosConfig, method: 'post' });
 }


### PR DESCRIPTION
## Description and Context
This updates the `http` module to return full Axios response objects, which will make debugging easier for libraries that consume locla-dev-lib. All API modules will also now return the full response object (they've been updated to use the `AxiosPromise` return type that `axios` includes. Their previous return values will now be within the `data` field on the response object.

A Few other things...
* Uses this as an opportunity to clean up the API modules a bit. Added some return types and removed a lot of unneeded `async`s.
* Added a testing util to create Axios responses in `__utils__/mockAxiosResponse`. This lets tests easily create type accurate axios responses and use them for mocked return values. There _might_ be a better way to do this, but figured this would get the job done for now.

## TODO
Need to be very careful to make update all uses of API modules in the CLI to make sure nothing breaks. May also be helpful to PR other HubSpot repos that use local-dev-lib, if needed

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
