### PR TITLE
Export all TypeScript types

### DIFF
--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -3,13 +3,10 @@ import {
   PublicApp,
   PublicApInstallCounts,
   PublicAppDeveloperTestAccountInstallData,
+  FetchPublicAppsForPortalResponse,
 } from '../types/Apps';
 
 const APPS_DEV_API_PATH = 'apps-dev/external/public/v3';
-
-type FetchPublicAppsForPortalResponse = {
-  results: Array<PublicApp>;
-};
 
 export async function fetchPublicAppsForPortal(
   accountId: number

--- a/api/customObjects.ts
+++ b/api/customObjects.ts
@@ -1,22 +1,12 @@
 import http from '../http';
-import { FetchSchemasResponse, Schema } from '../types/Schemas';
+import {
+  FetchSchemasResponse,
+  Schema,
+  CreateObjectsResponse,
+} from '../types/Schemas';
 
 const CUSTOM_OBJECTS_API_PATH = 'crm/v3/objects';
 const SCHEMA_API_PATH = 'crm-object-schemas/v3/schemas';
-
-type CreateObjectsResponse = {
-  status: string;
-  startedAt: string;
-  completedAt: string;
-  results: Array<{
-    id: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    properties: Array<any>;
-    createdAt: string;
-    updatedAt: string;
-    archived: boolean;
-  }>;
-};
 
 export async function batchCreateObjects(
   accountId: number,

--- a/api/designManager.ts
+++ b/api/designManager.ts
@@ -1,15 +1,11 @@
 import http from '../http';
 import { QueryParams } from '../types/Http';
+import {
+  FetchThemesResponse,
+  FetchBuiltinMappingResponse,
+} from '../types/DesignManager';
 
 const DESIGN_MANAGER_API_PATH = 'designmanager/v1';
-
-type FetchThemesResponse = {
-  objects: Array<{
-    theme: {
-      path: string;
-    };
-  }>;
-};
 
 export async function fetchThemes(
   accountId: number,
@@ -20,10 +16,6 @@ export async function fetchThemes(
     params,
   });
 }
-
-type FetchBuiltinMappingResponse = {
-  [key: string]: string;
-};
 
 export async function fetchBuiltinMapping(
   accountId: number

--- a/api/github.ts
+++ b/api/github.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
 import { getDefaultUserAgentHeader } from '../http/getAxiosConfig';
-import { GithubReleaseData, GithubRepoFile } from '../types/Github';
+import { GithubReleaseData, GithubRepoFile, RepoPath } from '../types/Github';
 
 const GITHUB_REPOS_API = 'https://api.github.com/repos';
 const GITHUB_RAW_CONTENT_API_PATH = 'https://raw.githubusercontent.com';
@@ -9,8 +9,6 @@ declare global {
   // eslint-disable-next-line no-var
   var githubToken: string;
 }
-
-type RepoPath = `${string}/${string}`;
 
 const GITHUB_AUTH_HEADERS = {
   authorization:

--- a/api/localDevAuth.ts
+++ b/api/localDevAuth.ts
@@ -2,25 +2,11 @@ import { getAxiosConfig } from '../http/getAxiosConfig';
 import http from '../http';
 import { ENVIRONMENTS } from '../constants/environments';
 import { Environment } from '../types/Config';
-import { ScopeData } from '../types/Accounts';
+import { ScopeData, AccessTokenResponse } from '../types/Accounts';
 import axios from 'axios';
-import { HUBSPOT_ACCOUNT_TYPES } from '../constants/config';
-import { ValueOf } from '../types/Utils';
 import { PublicAppInstallationData } from '../types/Apps';
 
 const LOCALDEVAUTH_API_AUTH_PATH = 'localdevauth/v1/auth';
-
-type AccessTokenResponse = {
-  hubId: number;
-  userId: number;
-  oauthAccessToken: string;
-  expiresAtMillis: number;
-  enabledFeatures?: { [key: string]: number };
-  scopeGroups: Array<string>;
-  encodedOAuthRefreshToken: string;
-  hubName: string;
-  accountType: ValueOf<typeof HUBSPOT_ACCOUNT_TYPES>;
-};
 
 export async function fetchAccessToken(
   personalAccessKey: string,

--- a/api/projects.ts
+++ b/api/projects.ts
@@ -6,6 +6,7 @@ import {
   FetchProjectResponse,
   UploadProjectResponse,
   ProjectSettings,
+  FetchPlatformVersionResponse,
 } from '../types/Project';
 import { Build, FetchProjectBuildsResponse } from '../types/Build';
 import {
@@ -100,11 +101,6 @@ export async function deleteProject(
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
   });
 }
-
-type FetchPlatformVersionResponse = {
-  defaultPlatformVersion: string;
-  activePlatformVersions: Array<string>;
-};
 
 export async function fetchPlatformVersions(
   accountId: number

--- a/api/secrets.ts
+++ b/api/secrets.ts
@@ -1,10 +1,7 @@
 import http from '../http';
+import { FetchSecretsResponse } from '../types/Secrets';
 
 const SECRETS_API_PATH = 'cms/v3/functions/secrets';
-
-type FetchSecretsResponse = {
-  results: Array<string>;
-};
 
 export async function addSecret(
   accountId: number,

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -4,13 +4,16 @@ import {
   OAUTH_AUTH_METHOD,
   PERSONAL_ACCESS_KEY_AUTH_METHOD,
 } from '../constants/auth';
-import { CLIConfig_NEW, Environment } from '../types/Config';
+import { CLIConfig_NEW } from '../types/Config';
 import {
   AuthType,
   CLIAccount_NEW,
   APIKeyAccount_NEW,
   OAuthAccount_NEW,
   PersonalAccessKeyAccount_NEW,
+  PersonalAccessKeyOptions,
+  OAuthOptions,
+  APIKeyOptions,
 } from '../types/Accounts';
 import { i18n } from '../utils/lang';
 
@@ -52,12 +55,6 @@ export function getOrderedConfig(
   };
 }
 
-type PersonalAccessKeyOptions = {
-  accountId: number;
-  personalAccessKey: string;
-  env: Environment;
-};
-
 function generatePersonalAccessKeyAccountConfig({
   accountId,
   personalAccessKey,
@@ -70,15 +67,6 @@ function generatePersonalAccessKeyAccountConfig({
     env,
   };
 }
-
-type OAuthOptions = {
-  accountId: number;
-  clientId: string;
-  clientSecret: string;
-  refreshToken: string;
-  scopes: Array<string>;
-  env: Environment;
-};
 
 function generateOauthAccountConfig({
   accountId,
@@ -102,12 +90,6 @@ function generateOauthAccountConfig({
     env,
   };
 }
-
-type APIKeyOptions = {
-  accountId: number;
-  apiKey: string;
-  env: Environment;
-};
 
 function generateApiKeyAccountConfig({
   accountId,

--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -29,6 +29,7 @@ import {
   CLIAccount_DEPRECATED,
   FlatAccountFields_DEPRECATED,
   OAuthAccount_DEPRECATED,
+  UpdateAccountConfigOptions,
 } from '../types/Accounts';
 import { BaseError } from '../types/Error';
 import { Mode } from '../types/Files';

--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -475,10 +475,6 @@ export function removeSandboxAccountFromConfig(
   return promptDefaultAccount;
 }
 
-type UpdateAccountConfigOptions = Partial<FlatAccountFields_DEPRECATED> & {
-  environment?: Environment;
-};
-
 /**
  * @throws {Error}
  */

--- a/config/environment.ts
+++ b/config/environment.ts
@@ -1,4 +1,8 @@
-import { CLIConfig_NEW, Environment } from '../types/Config';
+import {
+  CLIConfig_NEW,
+  Environment,
+  EnvironmentConfigVariables,
+} from '../types/Config';
 import { logger } from '../lib/logger';
 import { ENVIRONMENT_VARIABLES } from '../constants/environments';
 import {
@@ -12,16 +16,6 @@ import { getValidEnv } from '../lib/environment';
 import { i18n } from '../utils/lang';
 
 const i18nKey = 'config.environment';
-
-type EnvironmentConfigVariables = {
-  apiKey?: string;
-  clientId?: string;
-  clientSecret?: string;
-  personalAccessKey?: string;
-  accountId?: number;
-  refreshToken?: string;
-  env?: Environment;
-};
 
 function getConfigVariablesFromEnv(): EnvironmentConfigVariables {
   const env = process.env;

--- a/errors/errors_DEPRECATED.ts
+++ b/errors/errors_DEPRECATED.ts
@@ -1,8 +1,8 @@
-import { BaseError, FileSystemErrorContext } from '../types/Error';
-
-type ErrorContext = {
-  accountId?: number;
-};
+import {
+  BaseError,
+  FileSystemErrorContext,
+  ErrorContext,
+} from '../types/Error';
 
 function isSystemError(err: BaseError) {
   return err.errno != null && err.code != null && err.syscall != null;

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -7,13 +7,9 @@ import { throwFileSystemError } from '../errors/fileSystemErrors';
 import { throwErrorWithMessage } from '../errors/standardErrors';
 import { logger } from './logger';
 import { i18n } from '../utils/lang';
+import { ZipData, CopySourceToDestOptions } from '../types/Archive';
 
 const i18nKey = 'lib.archive';
-
-type ZipData = {
-  extractDir: string;
-  tmpDir: string;
-};
 
 async function extractZip(
   name: string,
@@ -58,12 +54,6 @@ async function extractZip(
   logger.debug(i18n(`${i18nKey}.extractZip.success`));
   return result;
 }
-
-type CopySourceToDestOptions = {
-  sourceDir?: string;
-  includesRootDir?: boolean;
-  hideLogs?: boolean;
-};
 
 async function copySourceToDest(
   src: string,

--- a/lib/cms/functions.ts
+++ b/lib/cms/functions.ts
@@ -8,20 +8,13 @@ import { throwErrorWithMessage } from '../../errors/standardErrors';
 import { throwFileSystemError } from '../../errors/fileSystemErrors';
 import { i18n } from '../../utils/lang';
 
+import {
+  FunctionConfig,
+  FunctionConfigInfo,
+  FunctionInfo,
+  FunctionOptions,
+} from '../../types/Functions';
 const i18nKey = 'lib.cms.functions';
-
-type Config = {
-  runtime: string;
-  version: string;
-  environment: object;
-  secrets: Array<string>;
-  endpoints: {
-    [key: string]: {
-      method: string;
-      file: string;
-    };
-  };
-};
 
 function isObjectOrFunction(value: object): boolean {
   const type = typeof value;
@@ -38,17 +31,11 @@ function createEndpoint(
   };
 }
 
-type ConfigInfo = {
-  endpointPath: string;
-  endpointMethod: string;
-  functionFile: string;
-};
-
 function createConfig({
   endpointPath,
   endpointMethod,
   functionFile,
-}: ConfigInfo): Config {
+}: FunctionConfigInfo): FunctionConfig {
   return {
     runtime: 'nodejs18.x',
     version: '1.0',
@@ -60,14 +47,14 @@ function createConfig({
   };
 }
 
-function writeConfig(configFilePath: string, config: Config): void {
+function writeConfig(configFilePath: string, config: FunctionConfig): void {
   const configJson = JSON.stringify(config, null, '  ');
   fs.writeFileSync(configFilePath, configJson);
 }
 
 function updateExistingConfig(
   configFilePath: string,
-  { endpointPath, endpointMethod, functionFile }: ConfigInfo
+  { endpointPath, endpointMethod, functionFile }: FunctionConfigInfo
 ): void {
   let configString!: string;
   try {
@@ -84,9 +71,9 @@ function updateExistingConfig(
     });
   }
 
-  let config!: Config;
+  let config!: FunctionConfig;
   try {
-    config = JSON.parse(configString) as Config;
+    config = JSON.parse(configString) as FunctionConfig;
   } catch (err) {
     logger.debug(
       i18n(`${i18nKey}.updateExistingConfig.invalidJSON`, {
@@ -139,17 +126,6 @@ function updateExistingConfig(
     });
   }
 }
-
-type FunctionInfo = {
-  functionsFolder: string;
-  filename: string;
-  endpointPath: string;
-  endpointMethod: string;
-};
-
-type FunctionOptions = {
-  allowExistingFile?: boolean;
-};
 
 export async function createFunction(
   functionInfo: FunctionInfo,

--- a/lib/cms/modules.ts
+++ b/lib/cms/modules.ts
@@ -10,7 +10,11 @@ import {
   isModuleFolder,
   isModuleFolderChild,
 } from '../../utils/cms/modules';
-import { PathInput } from '../../types/Modules';
+import {
+  PathInput,
+  ValidationResult,
+  ModuleDefinition,
+} from '../../types/Modules';
 import { i18n } from '../../utils/lang';
 
 const i18nKey = 'lib.cms.modules';
@@ -22,11 +26,6 @@ export const ValidationIds = {
   MODULE_FOLDER_REQUIRED: 'MODULE_FOLDER_REQUIRED',
   MODULE_TO_MODULE_NESTING: 'MODULE_TO_MODULE_NESTING',
   MODULE_NESTING: 'MODULE_NESTING',
-};
-
-type ValidationResult = {
-  id: string;
-  message: string;
 };
 
 const getValidationResult = (
@@ -150,13 +149,6 @@ const updateFileContents = async (
       errorMessage: message,
     });
   }
-};
-
-type ModuleDefinition = {
-  contentTypes: Array<string>;
-  moduleLabel: string;
-  reactType: boolean;
-  global: boolean;
 };
 
 export async function createModule(

--- a/lib/cms/uploadFolder.ts
+++ b/lib/cms/uploadFolder.ts
@@ -18,7 +18,12 @@ import { throwApiUploadError } from '../../errors/apiErrors';
 import { FileMapperInputOptions } from '../../types/Files';
 import { logger } from '../logger';
 import { FILE_TYPES, FILE_UPLOAD_RESULT_TYPES } from '../../constants/files';
-import { FileType, UploadFolderResults } from '../../types/Files';
+import {
+  FileType,
+  UploadFolderResults,
+  CommandOptions,
+  FilePathsByType,
+} from '../../types/Files';
 import { Mode } from '../../types/Files';
 import { i18n } from '../../utils/lang';
 
@@ -27,30 +32,6 @@ const i18nKey = 'lib.cms.uploadFolder';
 const queue = new PQueue({
   concurrency: 10,
 });
-
-type CommandOptions = {
-  convertFields?: boolean;
-  fieldOptions?: string;
-  saveOutput?: boolean;
-  onAttemptCallback?: (file: string | undefined, destPath: string) => void;
-  onSuccessCallback?: (file: string | undefined, destPath: string) => void;
-  onFirstErrorCallback?: (
-    file: string,
-    destPath: string,
-    error: AxiosError
-  ) => void;
-  onRetryCallback?: (file: string, destPath: string) => void;
-  onFinalErrorCallback?: (
-    accountId: number,
-    file: string,
-    destPath: string,
-    error: AxiosError
-  ) => void;
-};
-
-type FilePathsByType = {
-  [key: string]: Array<string>;
-};
 
 function getFileType(filePath: string): FileType {
   const extension = getExt(filePath);

--- a/lib/cms/watch.ts
+++ b/lib/cms/watch.ts
@@ -15,7 +15,12 @@ import { convertToUnixPath, isAllowedExtension, getCwd } from '../path';
 import { triggerNotify } from '../notify';
 import { getThemePreviewUrl, getThemeJSONPath } from './themes';
 import { logger } from '../logger';
-import { FileMapperInputOptions, Mode } from '../../types/Files';
+import {
+  UploadFileOptions,
+  Mode,
+  WatchOptions,
+  WatchErrorHandler,
+} from '../../types/Files';
 import { UploadFolderResults } from '../../types/Files';
 import { i18n } from '../../utils/lang';
 
@@ -38,14 +43,6 @@ function _notifyOfThemePreview(filePath: string, accountId: number): void {
 }
 
 const notifyOfThemePreview = debounce(_notifyOfThemePreview, 1000);
-
-type UploadFileOptions = FileMapperInputOptions & {
-  src: string;
-  commandOptions: {
-    convertFields?: boolean;
-  };
-  fieldOptions?: string;
-};
 
 const defaultOnUploadFileError =
   (file: string, dest: string, accountId: number) => (error: AxiosError) => {
@@ -160,19 +157,6 @@ async function deleteRemoteFile(
   });
 }
 
-type WatchOptions = {
-  mode?: Mode;
-  remove?: boolean;
-  disableInitial?: boolean;
-  notify?: string;
-  commandOptions: {
-    convertFields?: boolean;
-  };
-  filePaths?: Array<string>;
-};
-
-type ErrorHandler = (error: AxiosError) => void;
-
 export function watch(
   accountId: number,
   src: string,
@@ -188,13 +172,13 @@ export function watch(
   postInitialUploadCallback:
     | ((result: Array<UploadFolderResults>) => void)
     | null = null,
-  onUploadFolderError?: ErrorHandler,
-  onQueueAddError?: ErrorHandler,
+  onUploadFolderError?: WatchErrorHandler,
+  onQueueAddError?: WatchErrorHandler,
   onUploadFileError?: (
     file: string,
     dest: string,
     accountId: number
-  ) => ErrorHandler
+  ) => WatchErrorHandler
 ) {
   const regex = new RegExp(`^${escapeRegExp(src)}`);
   if (notify) {

--- a/lib/cms/watch.ts
+++ b/lib/cms/watch.ts
@@ -68,7 +68,7 @@ async function uploadFile(
     file: string,
     dest: string,
     accountId: number
-  ) => ErrorHandler = defaultOnUploadFileError
+  ) => WatchErrorHandler = defaultOnUploadFileError
 ): Promise<void> {
   const src = options.src;
 

--- a/lib/fileManager.ts
+++ b/lib/fileManager.ts
@@ -28,10 +28,8 @@ import {
 } from '../errors/standardErrors';
 import { throwFileSystemError } from '../errors/fileSystemErrors';
 import { GenericError } from '../types/Error';
-import { File, Folder } from '../types/FileManager';
+import { File, SimplifiedFolder } from '../types/FileManager';
 import { i18n } from '../utils/lang';
-
-type SimplifiedFolder = Partial<Folder> & Pick<Folder, 'id' | 'name'>;
 
 const i18nKey = 'lib.fileManager';
 

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -21,6 +21,7 @@ import {
   FileMapperOptions,
   FileMapperInputOptions,
   PathTypeData,
+  RecursiveFileMapperCallback,
 } from '../types/Files';
 import { throwFileSystemError } from '../errors/fileSystemErrors';
 import { isTimeoutError } from '../errors/apiErrors';

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -20,6 +20,7 @@ import {
   Mode,
   FileMapperOptions,
   FileMapperInputOptions,
+  PathTypeData,
 } from '../types/Files';
 import { throwFileSystemError } from '../errors/fileSystemErrors';
 import { isTimeoutError } from '../errors/apiErrors';
@@ -98,14 +99,6 @@ function validateFileMapperNode(node: FileMapperNode): void {
   });
 }
 
-type PathTypeData = {
-  isModule: boolean;
-  isHubspot: boolean;
-  isFile: boolean;
-  isRoot: boolean;
-  isFolder: boolean;
-};
-
 export function getTypeDataFromPath(src: string): PathTypeData {
   const isModule = isPathToModule(src);
   const isHubspot = isPathToHubspot(src);
@@ -120,12 +113,6 @@ export function getTypeDataFromPath(src: string): PathTypeData {
     isFolder,
   };
 }
-
-type RecursiveFileMapperCallback = (
-  node: FileMapperNode,
-  filepath?: string,
-  depth?: number
-) => boolean;
 
 export function recurseFolder(
   node: FileMapperNode,

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -5,7 +5,13 @@ import { throwError, throwErrorWithMessage } from '../errors/standardErrors';
 import { extractZipArchive } from './archive';
 import { logger } from './logger';
 import { GenericError, BaseError } from '../types/Error';
-import { GithubReleaseData, GithubRepoFile } from '../types/Github';
+import {
+  GithubReleaseData,
+  GithubRepoFile,
+  RepoPath,
+  DownloadGithubRepoZipOptions,
+  CloneGithubRepoOptions,
+} from '../types/Github';
 import {
   fetchRepoFile,
   fetchRepoFileByDownloadUrl,
@@ -16,8 +22,6 @@ import {
 import { i18n } from '../utils/lang';
 
 const i18nKey = 'lib.github';
-
-type RepoPath = `${string}/${string}`;
 
 export async function fetchFileFromRepository(
   repoPath: RepoPath,
@@ -66,11 +70,6 @@ export async function fetchReleaseData(
   }
 }
 
-type DownloadGithubRepoZipOptions = {
-  branch?: string;
-  tag?: string;
-};
-
 async function downloadGithubRepoZip(
   repoPath: RepoPath,
   isRelease = false,
@@ -109,14 +108,6 @@ async function downloadGithubRepoZip(
     );
   }
 }
-
-type CloneGithubRepoOptions = {
-  isRelease?: boolean; // Download a repo release? (Default is to download the repo contents)
-  type?: string; // The type of asset being downloaded. Used for logging
-  branch?: string; // Repo branch
-  tag?: string; // Repo tag
-  sourceDir?: string; // The directory within the downloaded repo to write after extraction
-};
 
 export async function cloneGithubRepo(
   repoPath: RepoPath,

--- a/lib/gitignore.ts
+++ b/lib/gitignore.ts
@@ -8,6 +8,7 @@ import {
 } from '../utils/git';
 import { DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME } from '../constants/config';
 import { throwErrorWithMessage } from '../errors/standardErrors';
+import { GitInclusionResult } from '../types/Config';
 
 const i18nKey = 'lib.gitignore';
 
@@ -33,12 +34,6 @@ export function checkAndAddConfigToGitignore(configPath: string): void {
     throwErrorWithMessage(`${i18nKey}.errors.configIgnore`, {}, e);
   }
 }
-
-type GitInclusionResult = {
-  inGit: boolean;
-  configIgnored: boolean;
-  gitignoreFiles: Array<string>;
-};
 
 export function checkGitInclusion(configPath: string): GitInclusionResult {
   const result: GitInclusionResult = {

--- a/lib/personalAccessKey.ts
+++ b/lib/personalAccessKey.ts
@@ -22,7 +22,7 @@ import { HUBSPOT_ACCOUNT_TYPES } from '../constants/config';
 import { fetchDeveloperTestAccountData } from '../api/developerTestAccounts';
 import { logger } from './logger';
 import { getAxiosErrorWithContext } from '../errors/apiErrors';
-import { ValueOf } from '../types/Utils';
+import { AccessToken } from '../types/Accounts';
 
 const i18nKey = 'lib.personalAccessKey';
 
@@ -31,17 +31,6 @@ const refreshRequests = new Map();
 function getRefreshKey(personalAccessKey: string, expiration?: string): string {
   return `${personalAccessKey}-${expiration || 'fresh'}`;
 }
-
-type AccessToken = {
-  portalId: number;
-  accessToken: string;
-  expiresAt: string;
-  scopeGroups: Array<string>;
-  enabledFeatures?: { [key: string]: number };
-  encodedOAuthRefreshToken: string;
-  hubName: string;
-  accountType: ValueOf<typeof HUBSPOT_ACCOUNT_TYPES>;
-};
 
 export async function getAccessToken(
   personalAccessKey: string,

--- a/lib/portManager.ts
+++ b/lib/portManager.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import PortManagerServer from '../utils/PortManagerServer';
 import { detectPort } from '../utils/detectPort';
 import { PORT_MANAGER_SERVER_PORT } from '../constants/ports';
+import { RequestPortsData } from '../types/PortManager';
 
 export const BASE_URL = `http://localhost:${PORT_MANAGER_SERVER_PORT}`;
 
@@ -26,11 +27,6 @@ export async function stopPortManagerServer(): Promise<void> {
     await axios.post(`${BASE_URL}/close`);
   }
 }
-
-type RequestPortsData = {
-  instanceId: string;
-  port?: number;
-};
 
 export async function requestPorts(
   portData: Array<RequestPortsData>

--- a/models/OAuth2Manager.ts
+++ b/models/OAuth2Manager.ts
@@ -3,7 +3,13 @@ import moment from 'moment';
 
 import { getHubSpotApiOrigin } from '../lib/urls';
 import { getValidEnv } from '../lib/environment';
-import { FlatAccountFields, TokenInfo } from '../types/Accounts';
+import {
+  FlatAccountFields,
+  OAuth2ManagerAccountConfig,
+  WriteTokenInfoFunction,
+  RefreshTokenResponse,
+  ExchangeProof,
+} from '../types/Accounts';
 import { logger } from '../lib/logger';
 import { getAccountIdentifier } from '../utils/getAccountIdentifier';
 import { AUTH_METHODS } from '../constants/auth';
@@ -12,35 +18,7 @@ import {
   throwErrorWithMessage,
   throwAuthErrorWithMessage,
 } from '../errors/standardErrors';
-import { Environment } from '../types/Config';
 import { i18n } from '../utils/lang';
-
-type OAuth2ManagerAccountConfig = {
-  name?: string;
-  accountId?: number;
-  clientId?: string;
-  clientSecret?: string;
-  scopes?: Array<string>;
-  env?: Environment;
-  environment?: Environment;
-  tokenInfo?: TokenInfo;
-  authType?: 'oauth2';
-};
-
-type WriteTokenInfoFunction = (tokenInfo: TokenInfo) => void;
-
-type RefreshTokenResponse = {
-  refresh_token: string;
-  access_token: string;
-  expires_in: string;
-};
-
-type ExchangeProof = {
-  grant_type: string;
-  client_id?: string;
-  client_secret?: string;
-  refresh_token?: string;
-};
 
 const i18nKey = 'models.OAuth2Manager';
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "./http/*": "./http/*.js",
     "./config": "./config/index.js",
     "./constants/*": "./constants/*.js",
-    "./models/*": "./models/*.js"
+    "./models/*": "./models/*.js",
+    "./types/*": "./types/*.d.ts"
   },
   "dependencies": {
     "address": "^2.0.1",

--- a/types/Accounts.ts
+++ b/types/Accounts.ts
@@ -160,3 +160,14 @@ export type APIKeyOptions = {
   apiKey: string;
   env: Environment;
 };
+
+export type AccessToken = {
+  portalId: number;
+  accessToken: string;
+  expiresAt: string;
+  scopeGroups: Array<string>;
+  enabledFeatures?: { [key: string]: number };
+  encodedOAuthRefreshToken: string;
+  hubName: string;
+  accountType: ValueOf<typeof HUBSPOT_ACCOUNT_TYPES>;
+};

--- a/types/Accounts.ts
+++ b/types/Accounts.ts
@@ -139,3 +139,24 @@ export type UpdateAccountConfigOptions =
   Partial<FlatAccountFields_DEPRECATED> & {
     environment?: Environment;
   };
+
+export type PersonalAccessKeyOptions = {
+  accountId: number;
+  personalAccessKey: string;
+  env: Environment;
+};
+
+export type OAuthOptions = {
+  accountId: number;
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  scopes: Array<string>;
+  env: Environment;
+};
+
+export type APIKeyOptions = {
+  accountId: number;
+  apiKey: string;
+  env: Environment;
+};

--- a/types/Accounts.ts
+++ b/types/Accounts.ts
@@ -122,3 +122,20 @@ export type ScopeData = {
   portalScopesInGroup: Array<string>;
   userScopesInGroup: Array<string>;
 };
+
+export type AccessTokenResponse = {
+  hubId: number;
+  userId: number;
+  oauthAccessToken: string;
+  expiresAtMillis: number;
+  enabledFeatures?: { [key: string]: number };
+  scopeGroups: Array<string>;
+  encodedOAuthRefreshToken: string;
+  hubName: string;
+  accountType: ValueOf<typeof HUBSPOT_ACCOUNT_TYPES>;
+};
+
+export type UpdateAccountConfigOptions =
+  Partial<FlatAccountFields_DEPRECATED> & {
+    environment?: Environment;
+  };

--- a/types/Accounts.ts
+++ b/types/Accounts.ts
@@ -39,6 +39,11 @@ export interface CLIAccount_DEPRECATED {
 
 export type CLIAccount = CLIAccount_NEW | CLIAccount_DEPRECATED;
 
+export type GenericAccount = {
+  portalId?: number;
+  accountId?: number;
+};
+
 export type AccountType = ValueOf<typeof HUBSPOT_ACCOUNT_TYPES>;
 
 export type TokenInfo = {
@@ -170,4 +175,31 @@ export type AccessToken = {
   encodedOAuthRefreshToken: string;
   hubName: string;
   accountType: ValueOf<typeof HUBSPOT_ACCOUNT_TYPES>;
+};
+
+export type OAuth2ManagerAccountConfig = {
+  name?: string;
+  accountId?: number;
+  clientId?: string;
+  clientSecret?: string;
+  scopes?: Array<string>;
+  env?: Environment;
+  environment?: Environment;
+  tokenInfo?: TokenInfo;
+  authType?: 'oauth2';
+};
+
+export type WriteTokenInfoFunction = (tokenInfo: TokenInfo) => void;
+
+export type RefreshTokenResponse = {
+  refresh_token: string;
+  access_token: string;
+  expires_in: string;
+};
+
+export type ExchangeProof = {
+  grant_type: string;
+  client_id?: string;
+  client_secret?: string;
+  refresh_token?: string;
 };

--- a/types/Apps.ts
+++ b/types/Apps.ts
@@ -66,3 +66,7 @@ export type PublicApp = {
   allowedExternalUrls: Array<string>;
   preventProjectMigrations?: boolean;
 };
+
+export type FetchPublicAppsForPortalResponse = {
+  results: Array<PublicApp>;
+};

--- a/types/Archive.ts
+++ b/types/Archive.ts
@@ -1,0 +1,10 @@
+export type ZipData = {
+  extractDir: string;
+  tmpDir: string;
+};
+
+export type CopySourceToDestOptions = {
+  sourceDir?: string;
+  includesRootDir?: boolean;
+  hideLogs?: boolean;
+};

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -25,3 +25,13 @@ export interface CLIConfig_DEPRECATED {
 export type CLIConfig = CLIConfig_NEW | CLIConfig_DEPRECATED;
 
 export type Environment = ValueOf<typeof ENVIRONMENTS> | '';
+
+export type EnvironmentConfigVariables = {
+  apiKey?: string;
+  clientId?: string;
+  clientSecret?: string;
+  personalAccessKey?: string;
+  accountId?: number;
+  refreshToken?: string;
+  env?: Environment;
+};

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -35,3 +35,9 @@ export type EnvironmentConfigVariables = {
   refreshToken?: string;
   env?: Environment;
 };
+
+export type GitInclusionResult = {
+  inGit: boolean;
+  configIgnored: boolean;
+  gitignoreFiles: Array<string>;
+};

--- a/types/DesignManager.ts
+++ b/types/DesignManager.ts
@@ -1,0 +1,11 @@
+export type FetchThemesResponse = {
+  objects: Array<{
+    theme: {
+      path: string;
+    };
+  }>;
+};
+
+export type FetchBuiltinMappingResponse = {
+  [key: string]: string;
+};

--- a/types/Error.ts
+++ b/types/Error.ts
@@ -38,3 +38,7 @@ export type AxiosErrorContext = {
 };
 
 export type OptionalError = BaseError | null | undefined;
+
+export type ErrorContext = {
+  accountId?: number;
+};

--- a/types/FieldsJS.ts
+++ b/types/FieldsJS.ts
@@ -1,0 +1,1 @@
+export type FieldsArray<T> = Array<T | FieldsArray<T>>;

--- a/types/FileManager.ts
+++ b/types/FileManager.ts
@@ -73,3 +73,5 @@ export type FetchFolderResponse = {
   objects: Array<Folder>;
   total_count: number;
 };
+
+export type SimplifiedFolder = Partial<Folder> & Pick<Folder, 'id' | 'name'>;

--- a/types/Files.ts
+++ b/types/Files.ts
@@ -64,3 +64,48 @@ export type RecursiveFileMapperCallback = (
   filepath?: string,
   depth?: number
 ) => boolean;
+
+export type CommandOptions = {
+  convertFields?: boolean;
+  fieldOptions?: string;
+  saveOutput?: boolean;
+  onAttemptCallback?: (file: string | undefined, destPath: string) => void;
+  onSuccessCallback?: (file: string | undefined, destPath: string) => void;
+  onFirstErrorCallback?: (
+    file: string,
+    destPath: string,
+    error: AxiosError
+  ) => void;
+  onRetryCallback?: (file: string, destPath: string) => void;
+  onFinalErrorCallback?: (
+    accountId: number,
+    file: string,
+    destPath: string,
+    error: AxiosError
+  ) => void;
+};
+
+export type FilePathsByType = {
+  [key: string]: Array<string>;
+};
+
+export type UploadFileOptions = FileMapperInputOptions & {
+  src: string;
+  commandOptions: {
+    convertFields?: boolean;
+  };
+  fieldOptions?: string;
+};
+
+export type WatchOptions = {
+  mode?: Mode;
+  remove?: boolean;
+  disableInitial?: boolean;
+  notify?: string;
+  commandOptions: {
+    convertFields?: boolean;
+  };
+  filePaths?: Array<string>;
+};
+
+export type WatchErrorHandler = (error: AxiosError) => void;

--- a/types/Files.ts
+++ b/types/Files.ts
@@ -50,3 +50,17 @@ export type FileTree = {
   path: string;
   children: Array<FileTree>;
 };
+
+export type PathTypeData = {
+  isModule: boolean;
+  isHubspot: boolean;
+  isFile: boolean;
+  isRoot: boolean;
+  isFolder: boolean;
+};
+
+export type RecursiveFileMapperCallback = (
+  node: FileMapperNode,
+  filepath?: string,
+  depth?: number
+) => boolean;

--- a/types/Functions.ts
+++ b/types/Functions.ts
@@ -39,3 +39,33 @@ export type GetBuildStatusResponse = {
   userId: number;
   deployId: number;
 };
+
+export type FunctionConfig = {
+  runtime: string;
+  version: string;
+  environment: object;
+  secrets: Array<string>;
+  endpoints: {
+    [key: string]: {
+      method: string;
+      file: string;
+    };
+  };
+};
+
+export type FunctionConfigInfo = {
+  endpointPath: string;
+  endpointMethod: string;
+  functionFile: string;
+};
+
+export type FunctionInfo = {
+  functionsFolder: string;
+  filename: string;
+  endpointPath: string;
+  endpointMethod: string;
+};
+
+export type FunctionOptions = {
+  allowExistingFile?: boolean;
+};

--- a/types/Github.ts
+++ b/types/Github.ts
@@ -66,3 +66,16 @@ export interface GithubSourceData {
 }
 
 export type RepoPath = `${string}/${string}`;
+
+export type DownloadGithubRepoZipOptions = {
+  branch?: string;
+  tag?: string;
+};
+
+export type CloneGithubRepoOptions = {
+  isRelease?: boolean; // Download a repo release? (Default is to download the repo contents)
+  type?: string; // The type of asset being downloaded. Used for logging
+  branch?: string; // Repo branch
+  tag?: string; // Repo tag
+  sourceDir?: string; // The directory within the downloaded repo to write after extraction
+};

--- a/types/Github.ts
+++ b/types/Github.ts
@@ -64,3 +64,5 @@ export interface GithubSourceData {
   repositoryName: string;
   source: string;
 }
+
+export type RepoPath = `${string}/${string}`;

--- a/types/Modules.ts
+++ b/types/Modules.ts
@@ -3,3 +3,15 @@ export type PathInput = {
   isHubSpot?: boolean;
   path: string;
 };
+
+export type ValidationResult = {
+  id: string;
+  message: string;
+};
+
+export type ModuleDefinition = {
+  contentTypes: Array<string>;
+  moduleLabel: string;
+  reactType: boolean;
+  global: boolean;
+};

--- a/types/PortManager.ts
+++ b/types/PortManager.ts
@@ -2,3 +2,13 @@ export type RequestPortsData = {
   instanceId: string;
   port?: number;
 };
+
+export type NetError = Error & {
+  code: string;
+};
+
+export type ListenCallback = (error: NetError | null, port: number) => void;
+
+export type ServerPortMap = {
+  [instanceId: string]: number;
+};

--- a/types/Project.ts
+++ b/types/Project.ts
@@ -40,3 +40,8 @@ export type UploadProjectResponse = {
 export type ProjectSettings = {
   isAutoDeployEnabled: boolean;
 };
+
+export type FetchPlatformVersionResponse = {
+  defaultPlatformVersion: string;
+  activePlatformVersions: Array<string>;
+};

--- a/types/Schemas.ts
+++ b/types/Schemas.ts
@@ -26,3 +26,17 @@ export type Schema = {
 };
 
 export type FetchSchemasResponse = { results: Array<Schema> };
+
+export type CreateObjectsResponse = {
+  status: string;
+  startedAt: string;
+  completedAt: string;
+  results: Array<{
+    id: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    properties: Array<any>;
+    createdAt: string;
+    updatedAt: string;
+    archived: boolean;
+  }>;
+};

--- a/types/Secrets.ts
+++ b/types/Secrets.ts
@@ -1,0 +1,3 @@
+export type FetchSecretsResponse = {
+  results: Array<string>;
+};

--- a/utils/PortManagerServer.ts
+++ b/utils/PortManagerServer.ts
@@ -12,11 +12,7 @@ import { throwErrorWithMessage } from '../errors/standardErrors';
 import { logger } from '../lib/logger';
 import { i18n } from './lang';
 import { BaseError } from '../types/Error';
-import { RequestPortsData } from '../types/PortManager';
-
-type ServerPortMap = {
-  [instanceId: string]: number;
-};
+import { RequestPortsData, ServerPortMap } from '../types/PortManager';
 
 const i18nKey = 'utils.PortManagerServer';
 

--- a/utils/cms/fieldsJS.ts
+++ b/utils/cms/fieldsJS.ts
@@ -1,4 +1,4 @@
-type FieldsArray<T> = Array<T | FieldsArray<T>>;
+import { FieldsArray } from '../../types/FieldsJS';
 
 /*
  * Polyfill for `Array.flat(Infinity)` since the `flat` is only available for Node v11+

--- a/utils/detectPort.ts
+++ b/utils/detectPort.ts
@@ -26,14 +26,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 import net, { AddressInfo } from 'net';
 import { ip } from 'address';
 import { throwErrorWithMessage } from '../errors/standardErrors';
+import { NetError, ListenCallback } from '../types/PortManager';
 
 import { MIN_PORT_NUMBER, MAX_PORT_NUMBER } from '../constants/ports';
-
-type NetError = Error & {
-  code: string;
-};
-
-type ListenCallback = (error: NetError | null, port: number) => void;
 
 const i18nKey = 'utils.detectPort';
 

--- a/utils/getAccountIdentifier.ts
+++ b/utils/getAccountIdentifier.ts
@@ -1,17 +1,12 @@
-import { CLIAccount } from '../types/Accounts';
+import { CLIAccount, GenericAccount } from '../types/Accounts';
 import {
   CLIConfig,
   CLIConfig_DEPRECATED,
   CLIConfig_NEW,
 } from '../types/Config';
 
-type Account = {
-  portalId?: number;
-  accountId?: number;
-};
-
 export function getAccountIdentifier(
-  account?: Account | null
+  account?: GenericAccount | null
 ): number | undefined {
   if (!account) {
     return undefined;


### PR DESCRIPTION
## Description and Context
Throughout `local-dev-lib`, we generally followed the convention of not moving types to a type file and exporting them if they were only used in one file. This approach makes sense for most repos, but since this is a library, we should make all types available to other consuming packages. This moves all types to type files, and exports type declaration files via the package.json

## TODO
This unfortunately will likely cause some conflicts with `next`, especially with error related types

## Who to Notify

@brandenrodgers @kemmerle @joe-yeager 
