### PR TITLE
Unauthed http option

### DIFF
--- a/http/__tests__/index.ts
+++ b/http/__tests__/index.ts
@@ -255,5 +255,71 @@ describe('http/index', () => {
         },
       });
     });
+
+    it('supports making unauthed requests with config present', async () => {
+      getAndLoadConfigIfNeeded.mockReturnValue({
+        httpTimeout: 1000,
+        accounts: [
+          {
+            accountId: 123,
+            apiKey: 'abc',
+            env: ENVIRONMENTS.PROD,
+          },
+        ],
+      });
+      getAccountConfig.mockReturnValue({
+        accountId: 123,
+        apiKey: 'abc',
+        env: ENVIRONMENTS.PROD,
+      });
+
+      await http.get(123, { url: 'some/endpoint/path', unauthed: true });
+
+      expect(mockedAxios).toHaveBeenCalledWith({
+        baseURL: `https://api.hubapi.com`,
+        url: 'some/endpoint/path',
+        headers: {
+          'User-Agent': `HubSpot Local Dev Lib/${version}`,
+        },
+        timeout: 1000,
+        params: {},
+        transitional: {
+          clarifyTimeoutError: true,
+        },
+        httpAgent: {
+          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+        },
+        httpsAgent: {
+          options: { keepAlive: true, maxSockets: 6, maxTotalSockets: 26 },
+        },
+      });
+    });
+
+    it('supports making unauthed requests without config present', async () => {
+      await http.get(123, {
+        url: 'some/endpoint/path',
+        unauthed: true,
+        env: 'qa',
+      });
+
+      expect(mockedAxios).toHaveBeenCalledWith({
+        baseURL: `https://api.hubapiqa.com`,
+        url: 'some/endpoint/path',
+        headers: {
+          'User-Agent': `HubSpot Local Dev Lib/${version}`,
+        },
+        timeout: 15000,
+        params: {},
+        transitional: {
+          clarifyTimeoutError: true,
+        },
+        httpAgent: {
+          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+        },
+        httpsAgent: {
+          options: { keepAlive: true, maxSockets: 6, maxTotalSockets: 26 },
+        },
+      });
+    });
   });
 });

--- a/http/__tests__/index.ts
+++ b/http/__tests__/index.ts
@@ -255,31 +255,5 @@ describe('http/index', () => {
         },
       });
     });
-
-    it('supports making unauthed requests', async () => {
-      await http.getUnauthed({
-        url: 'some/endpoint/path',
-        env: 'qa',
-      });
-
-      expect(mockedAxios).toHaveBeenCalledWith({
-        baseURL: `https://api.hubapiqa.com`,
-        url: 'some/endpoint/path',
-        headers: {
-          'User-Agent': `HubSpot Local Dev Lib/${version}`,
-        },
-        timeout: 15000,
-        params: {},
-        transitional: {
-          clarifyTimeoutError: true,
-        },
-        httpAgent: {
-          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
-        },
-        httpsAgent: {
-          options: { keepAlive: true, maxSockets: 6, maxTotalSockets: 26 },
-        },
-      });
-    });
   });
 });

--- a/http/__tests__/index.ts
+++ b/http/__tests__/index.ts
@@ -256,49 +256,9 @@ describe('http/index', () => {
       });
     });
 
-    it('supports making unauthed requests with config present', async () => {
-      getAndLoadConfigIfNeeded.mockReturnValue({
-        httpTimeout: 1000,
-        accounts: [
-          {
-            accountId: 123,
-            apiKey: 'abc',
-            env: ENVIRONMENTS.PROD,
-          },
-        ],
-      });
-      getAccountConfig.mockReturnValue({
-        accountId: 123,
-        apiKey: 'abc',
-        env: ENVIRONMENTS.PROD,
-      });
-
-      await http.get(123, { url: 'some/endpoint/path', unauthed: true });
-
-      expect(mockedAxios).toHaveBeenCalledWith({
-        baseURL: `https://api.hubapi.com`,
+    it('supports making unauthed requests', async () => {
+      await http.getUnauthed({
         url: 'some/endpoint/path',
-        headers: {
-          'User-Agent': `HubSpot Local Dev Lib/${version}`,
-        },
-        timeout: 1000,
-        params: {},
-        transitional: {
-          clarifyTimeoutError: true,
-        },
-        httpAgent: {
-          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
-        },
-        httpsAgent: {
-          options: { keepAlive: true, maxSockets: 6, maxTotalSockets: 26 },
-        },
-      });
-    });
-
-    it('supports making unauthed requests without config present', async () => {
-      await http.get(123, {
-        url: 'some/endpoint/path',
-        unauthed: true,
         env: 'qa',
       });
 

--- a/http/__tests__/unauthed.ts
+++ b/http/__tests__/unauthed.ts
@@ -1,0 +1,49 @@
+import axios from 'axios';
+import { http } from '../unauthed';
+import { version } from '../../package.json';
+
+jest.mock('axios');
+
+jest.mock('http', () => ({
+  Agent: jest.fn().mockReturnValue({
+    options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+  }),
+}));
+
+jest.mock('https', () => ({
+  Agent: jest.fn().mockReturnValue({
+    options: { keepAlive: true, maxSockets: 6, maxTotalSockets: 26 },
+  }),
+}));
+
+const mockedAxios = jest.mocked(axios);
+
+describe('http/index', () => {
+  describe('http.get()', () => {
+    it('supports making unauthed requests', async () => {
+      await http.get({
+        url: 'some/endpoint/path',
+        env: 'qa',
+      });
+
+      expect(mockedAxios).toHaveBeenCalledWith({
+        baseURL: `https://api.hubapiqa.com`,
+        url: 'some/endpoint/path',
+        headers: {
+          'User-Agent': `HubSpot Local Dev Lib/${version}`,
+        },
+        timeout: 15000,
+        params: {},
+        transitional: {
+          clarifyTimeoutError: true,
+        },
+        httpAgent: {
+          options: { keepAlive: true, maxSockets: 5, maxTotalSockets: 25 },
+        },
+        httpsAgent: {
+          options: { keepAlive: true, maxSockets: 6, maxTotalSockets: 26 },
+        },
+      });
+    });
+  });
+});

--- a/http/addQueryParams.ts
+++ b/http/addQueryParams.ts
@@ -1,0 +1,15 @@
+import { HttpOptions, QueryParams } from '../types/Http';
+
+export function addQueryParams(
+  configOptions: HttpOptions,
+  queryParams: QueryParams = {}
+): HttpOptions {
+  const { params } = configOptions;
+  return {
+    ...configOptions,
+    params: {
+      ...queryParams,
+      ...params,
+    },
+  };
+}

--- a/http/getAxiosConfig.ts
+++ b/http/getAxiosConfig.ts
@@ -2,7 +2,6 @@ import { version } from '../package.json';
 import { getAndLoadConfigIfNeeded } from '../config';
 import { getHubSpotApiOrigin } from '../lib/urls';
 import { HttpOptions } from '../types/Http';
-import { CLIConfig } from '../types/Config';
 import { AxiosRequestConfig } from 'axios';
 import https from 'https';
 import http from 'http';
@@ -49,8 +48,19 @@ const DEFAULT_TRANSITIONAL = {
 
 export function getAxiosConfig(options: HttpOptions): AxiosRequestConfig {
   const { env, localHostOverride, headers, ...rest } = options;
-  const { httpTimeout, httpUseLocalhost } =
-    getAndLoadConfigIfNeeded() as CLIConfig;
+  const config = getAndLoadConfigIfNeeded();
+
+  let httpTimeout = 15000;
+  let httpUseLocalhost = false;
+
+  if (config && config.httpTimeout) {
+    httpTimeout = config.httpTimeout;
+  }
+
+  if (config && config.httpUseLocalhost) {
+    httpUseLocalhost = config.httpUseLocalhost;
+  }
+
   return {
     baseURL: getHubSpotApiOrigin(
       env,

--- a/http/getAxiosConfig.ts
+++ b/http/getAxiosConfig.ts
@@ -70,7 +70,7 @@ export function getAxiosConfig(options: HttpOptions): AxiosRequestConfig {
       ...getDefaultUserAgentHeader(),
       ...(headers || {}),
     },
-    timeout: httpTimeout || 15000,
+    timeout: httpTimeout,
     transitional: DEFAULT_TRANSITIONAL,
     httpAgent,
     httpsAgent,

--- a/http/getAxiosConfig.ts
+++ b/http/getAxiosConfig.ts
@@ -1,7 +1,7 @@
 import { version } from '../package.json';
 import { getAndLoadConfigIfNeeded } from '../config';
 import { getHubSpotApiOrigin } from '../lib/urls';
-import { AxiosConfigOptions } from '../types/Http';
+import { HttpOptions } from '../types/Http';
 import { CLIConfig } from '../types/Config';
 import { AxiosRequestConfig } from 'axios';
 import https from 'https';
@@ -47,9 +47,7 @@ const DEFAULT_TRANSITIONAL = {
   clarifyTimeoutError: true,
 };
 
-export function getAxiosConfig(
-  options: AxiosConfigOptions
-): AxiosRequestConfig {
+export function getAxiosConfig(options: HttpOptions): AxiosRequestConfig {
   const { env, localHostOverride, headers, ...rest } = options;
   const { httpTimeout, httpUseLocalhost } =
     getAndLoadConfigIfNeeded() as CLIConfig;

--- a/http/index.ts
+++ b/http/index.ts
@@ -8,7 +8,7 @@ import { USER_AGENTS, getAxiosConfig } from './getAxiosConfig';
 import { accessTokenForPersonalAccessKey } from '../lib/personalAccessKey';
 import { getOauthManager } from '../lib/oauth';
 import { FlatAccountFields } from '../types/Accounts';
-import { AxiosConfigOptions, HttpOptions, QueryParams } from '../types/Http';
+import { HttpOptions, QueryParams } from '../types/Http';
 import { logger } from '../lib/logger';
 import { i18n } from '../utils/lang';
 import { HubSpotHttpError } from '../models/HubSpotHttpError';
@@ -79,7 +79,7 @@ function withPortalId(
 
 async function withAuth(
   accountId: number,
-  options: AxiosConfigOptions
+  options: HttpOptions
 ): Promise<AxiosRequestConfig> {
   const accountConfig = getAccountConfig(accountId);
 
@@ -112,9 +112,9 @@ async function withAuth(
 }
 
 function addQueryParams(
-  configOptions: AxiosConfigOptions,
+  configOptions: HttpOptions,
   queryParams: QueryParams = {}
-): AxiosConfigOptions {
+): HttpOptions {
   const { params } = configOptions;
   return {
     ...configOptions,
@@ -125,11 +125,16 @@ function addQueryParams(
   };
 }
 
+// async function getAxiosRequestConfigFromOptions(
+//   accountId: number,
+//   options: HttpOptions
+// ): Promise<AxiosRequestConfig> {}
+
 async function getRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
-  const { params, ...rest } = options;
+  const { params, unauthed, ...rest } = options;
   const axiosConfig = addQueryParams(rest, params);
   const configWithAuth = await withAuth(accountId, axiosConfig);
 

--- a/http/index.ts
+++ b/http/index.ts
@@ -125,53 +125,75 @@ function addQueryParams(
   };
 }
 
-// async function getAxiosRequestConfigFromOptions(
-//   accountId: number,
-//   options: HttpOptions
-// ): Promise<AxiosRequestConfig> {}
+async function getAxiosRequestConfigFromOptions(
+  accountId: number,
+  options: HttpOptions
+): Promise<AxiosRequestConfig> {
+  if (options.unauthed) {
+    const accountConfig = getAccountConfig(accountId);
+    return getAxiosConfig({ env: accountConfig?.env, ...options });
+  } else {
+    return withAuth(accountId, options);
+  }
+}
 
 async function getRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
-  const { params, unauthed, ...rest } = options;
-  const axiosConfig = addQueryParams(rest, params);
-  const configWithAuth = await withAuth(accountId, axiosConfig);
+  const { params, ...rest } = options;
+  const optionsWithParams = addQueryParams(rest, params);
+  const requestConfig = await getAxiosRequestConfigFromOptions(
+    accountId,
+    optionsWithParams
+  );
 
-  return axios<T>(configWithAuth);
+  return axios<T>(requestConfig);
 }
 
 async function postRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
-  const configWithAuth = await withAuth(accountId, options);
+  const requestConfig = await getAxiosRequestConfigFromOptions(
+    accountId,
+    options
+  );
 
-  return axios({ ...configWithAuth, method: 'post' });
+  return axios({ ...requestConfig, method: 'post' });
 }
 
 async function putRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
-  const configWithAuth = await withAuth(accountId, options);
-  return axios({ ...configWithAuth, method: 'put' });
+  const requestConfig = await getAxiosRequestConfigFromOptions(
+    accountId,
+    options
+  );
+  return axios({ ...requestConfig, method: 'put' });
 }
 
 async function patchRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
-  const configWithAuth = await withAuth(accountId, options);
-  return axios({ ...configWithAuth, method: 'patch' });
+  const requestConfig = await getAxiosRequestConfigFromOptions(
+    accountId,
+    options
+  );
+  return axios({ ...requestConfig, method: 'patch' });
 }
 
 async function deleteRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
-  const configWithAuth = await withAuth(accountId, options);
-  return axios({ ...configWithAuth, method: 'delete' });
+  const requestConfig = await getAxiosRequestConfigFromOptions(
+    accountId,
+    options
+  );
+  return axios({ ...requestConfig, method: 'delete' });
 }
 
 function createGetRequestStream(contentType: string) {

--- a/http/index.ts
+++ b/http/index.ts
@@ -128,7 +128,7 @@ async function postRequest<T>(
   options: HttpOptions
 ): AxiosPromise<T> {
   const requestConfig = await withAuth(accountId, options);
-  return axios({ ...requestConfig, method: 'post' });
+  return axios<T>({ ...requestConfig, method: 'post' });
 }
 
 async function putRequest<T>(
@@ -136,7 +136,7 @@ async function putRequest<T>(
   options: HttpOptions
 ): AxiosPromise<T> {
   const requestConfig = await withAuth(accountId, options);
-  return axios({ ...requestConfig, method: 'put' });
+  return axios<T>({ ...requestConfig, method: 'put' });
 }
 
 async function patchRequest<T>(
@@ -144,7 +144,7 @@ async function patchRequest<T>(
   options: HttpOptions
 ): AxiosPromise<T> {
   const requestConfig = await withAuth(accountId, options);
-  return axios({ ...requestConfig, method: 'patch' });
+  return axios<T>({ ...requestConfig, method: 'patch' });
 }
 
 async function deleteRequest<T>(
@@ -152,7 +152,7 @@ async function deleteRequest<T>(
   options: HttpOptions
 ): AxiosPromise<T> {
   const requestConfig = await withAuth(accountId, options);
-  return axios({ ...requestConfig, method: 'delete' });
+  return axios<T>({ ...requestConfig, method: 'delete' });
 }
 
 function createGetRequestStream(contentType: string) {

--- a/http/index.ts
+++ b/http/index.ts
@@ -129,11 +129,12 @@ async function getAxiosRequestConfigFromOptions(
   accountId: number,
   options: HttpOptions
 ): Promise<AxiosRequestConfig> {
-  if (options.unauthed) {
+  const { unauthed, ...httpOptions } = options;
+  if (unauthed) {
     const accountConfig = getAccountConfig(accountId);
-    return getAxiosConfig({ env: accountConfig?.env, ...options });
+    return getAxiosConfig({ env: accountConfig?.env, ...httpOptions });
   } else {
-    return withAuth(accountId, options);
+    return withAuth(accountId, httpOptions);
   }
 }
 

--- a/http/index.ts
+++ b/http/index.ts
@@ -125,29 +125,21 @@ function addQueryParams(
   };
 }
 
-async function getAxiosRequestConfigFromOptions(
-  accountId: number,
-  options: HttpOptions
-): Promise<AxiosRequestConfig> {
-  const { unauthed, ...httpOptions } = options;
-  if (unauthed) {
-    const accountConfig = getAccountConfig(accountId);
-    return getAxiosConfig({ env: accountConfig?.env, ...httpOptions });
-  } else {
-    return withAuth(accountId, httpOptions);
-  }
-}
-
 async function getRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
   const { params, ...rest } = options;
   const optionsWithParams = addQueryParams(rest, params);
-  const requestConfig = await getAxiosRequestConfigFromOptions(
-    accountId,
-    optionsWithParams
-  );
+  const requestConfig = await withAuth(accountId, optionsWithParams);
+
+  return axios<T>(requestConfig);
+}
+
+async function unauthedGetRequest<T>(options: HttpOptions): AxiosPromise<T> {
+  const { params, ...rest } = options;
+  const optionsWithParams = addQueryParams(rest, params);
+  const requestConfig = await getAxiosConfig(optionsWithParams);
 
   return axios<T>(requestConfig);
 }
@@ -156,11 +148,12 @@ async function postRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
-  const requestConfig = await getAxiosRequestConfigFromOptions(
-    accountId,
-    options
-  );
+  const requestConfig = await withAuth(accountId, options);
+  return axios({ ...requestConfig, method: 'post' });
+}
 
+async function unauthedPostRequest<T>(options: HttpOptions): AxiosPromise<T> {
+  const requestConfig = await getAxiosConfig(options);
   return axios({ ...requestConfig, method: 'post' });
 }
 
@@ -168,10 +161,12 @@ async function putRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
-  const requestConfig = await getAxiosRequestConfigFromOptions(
-    accountId,
-    options
-  );
+  const requestConfig = await withAuth(accountId, options);
+  return axios({ ...requestConfig, method: 'put' });
+}
+
+async function unauthedPutRequest<T>(options: HttpOptions): AxiosPromise<T> {
+  const requestConfig = await getAxiosConfig(options);
   return axios({ ...requestConfig, method: 'put' });
 }
 
@@ -179,10 +174,12 @@ async function patchRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
-  const requestConfig = await getAxiosRequestConfigFromOptions(
-    accountId,
-    options
-  );
+  const requestConfig = await withAuth(accountId, options);
+  return axios({ ...requestConfig, method: 'patch' });
+}
+
+async function unauthedPatchRequest<T>(options: HttpOptions): AxiosPromise<T> {
+  const requestConfig = await getAxiosConfig(options);
   return axios({ ...requestConfig, method: 'patch' });
 }
 
@@ -190,10 +187,12 @@ async function deleteRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
-  const requestConfig = await getAxiosRequestConfigFromOptions(
-    accountId,
-    options
-  );
+  const requestConfig = await withAuth(accountId, options);
+  return axios({ ...requestConfig, method: 'delete' });
+}
+
+async function unauthedDeleteRequest<T>(options: HttpOptions): AxiosPromise<T> {
+  const requestConfig = await getAxiosConfig(options);
   return axios({ ...requestConfig, method: 'delete' });
 }
 
@@ -266,9 +265,14 @@ const getOctetStream = createGetRequestStream('application/octet-stream');
 
 export const http = {
   get: getRequest,
+  getUnauthed: unauthedGetRequest,
   post: postRequest,
+  postUnauthed: unauthedPostRequest,
   put: putRequest,
+  putUnauthed: unauthedPutRequest,
   patch: patchRequest,
+  patchUnauthed: unauthedPatchRequest,
   delete: deleteRequest,
+  deleteUnauthed: unauthedDeleteRequest,
   getOctetStream,
 };

--- a/http/index.ts
+++ b/http/index.ts
@@ -5,10 +5,11 @@ import axios, { AxiosRequestConfig, AxiosResponse, AxiosPromise } from 'axios';
 
 import { getAccountConfig } from '../config';
 import { USER_AGENTS, getAxiosConfig } from './getAxiosConfig';
+import { addQueryParams } from './addQueryParams';
 import { accessTokenForPersonalAccessKey } from '../lib/personalAccessKey';
 import { getOauthManager } from '../lib/oauth';
 import { FlatAccountFields } from '../types/Accounts';
-import { HttpOptions, QueryParams } from '../types/Http';
+import { HttpOptions } from '../types/Http';
 import { logger } from '../lib/logger';
 import { i18n } from '../utils/lang';
 import { HubSpotHttpError } from '../models/HubSpotHttpError';
@@ -111,20 +112,6 @@ async function withAuth(
   };
 }
 
-function addQueryParams(
-  configOptions: HttpOptions,
-  queryParams: QueryParams = {}
-): HttpOptions {
-  const { params } = configOptions;
-  return {
-    ...configOptions,
-    params: {
-      ...queryParams,
-      ...params,
-    },
-  };
-}
-
 async function getRequest<T>(
   accountId: number,
   options: HttpOptions
@@ -132,14 +119,6 @@ async function getRequest<T>(
   const { params, ...rest } = options;
   const optionsWithParams = addQueryParams(rest, params);
   const requestConfig = await withAuth(accountId, optionsWithParams);
-
-  return axios<T>(requestConfig);
-}
-
-async function unauthedGetRequest<T>(options: HttpOptions): AxiosPromise<T> {
-  const { params, ...rest } = options;
-  const optionsWithParams = addQueryParams(rest, params);
-  const requestConfig = await getAxiosConfig(optionsWithParams);
 
   return axios<T>(requestConfig);
 }
@@ -152,21 +131,11 @@ async function postRequest<T>(
   return axios({ ...requestConfig, method: 'post' });
 }
 
-async function unauthedPostRequest<T>(options: HttpOptions): AxiosPromise<T> {
-  const requestConfig = await getAxiosConfig(options);
-  return axios({ ...requestConfig, method: 'post' });
-}
-
 async function putRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
   const requestConfig = await withAuth(accountId, options);
-  return axios({ ...requestConfig, method: 'put' });
-}
-
-async function unauthedPutRequest<T>(options: HttpOptions): AxiosPromise<T> {
-  const requestConfig = await getAxiosConfig(options);
   return axios({ ...requestConfig, method: 'put' });
 }
 
@@ -178,21 +147,11 @@ async function patchRequest<T>(
   return axios({ ...requestConfig, method: 'patch' });
 }
 
-async function unauthedPatchRequest<T>(options: HttpOptions): AxiosPromise<T> {
-  const requestConfig = await getAxiosConfig(options);
-  return axios({ ...requestConfig, method: 'patch' });
-}
-
 async function deleteRequest<T>(
   accountId: number,
   options: HttpOptions
 ): AxiosPromise<T> {
   const requestConfig = await withAuth(accountId, options);
-  return axios({ ...requestConfig, method: 'delete' });
-}
-
-async function unauthedDeleteRequest<T>(options: HttpOptions): AxiosPromise<T> {
-  const requestConfig = await getAxiosConfig(options);
   return axios({ ...requestConfig, method: 'delete' });
 }
 
@@ -265,14 +224,9 @@ const getOctetStream = createGetRequestStream('application/octet-stream');
 
 export const http = {
   get: getRequest,
-  getUnauthed: unauthedGetRequest,
   post: postRequest,
-  postUnauthed: unauthedPostRequest,
   put: putRequest,
-  putUnauthed: unauthedPutRequest,
   patch: patchRequest,
-  patchUnauthed: unauthedPatchRequest,
   delete: deleteRequest,
-  deleteUnauthed: unauthedDeleteRequest,
   getOctetStream,
 };

--- a/http/unauthed.ts
+++ b/http/unauthed.ts
@@ -1,0 +1,40 @@
+import axios, { AxiosPromise } from 'axios';
+import { getAxiosConfig } from './getAxiosConfig';
+import { addQueryParams } from './addQueryParams';
+import { HttpOptions } from '../types/Http';
+
+async function getRequest<T>(options: HttpOptions): AxiosPromise<T> {
+  const { params, ...rest } = options;
+  const optionsWithParams = addQueryParams(rest, params);
+  const requestConfig = await getAxiosConfig(optionsWithParams);
+
+  return axios<T>(requestConfig);
+}
+
+async function postRequest<T>(options: HttpOptions): AxiosPromise<T> {
+  const requestConfig = await getAxiosConfig(options);
+  return axios<T>({ ...requestConfig, method: 'post' });
+}
+
+async function putRequest<T>(options: HttpOptions): AxiosPromise<T> {
+  const requestConfig = await getAxiosConfig(options);
+  return axios<T>({ ...requestConfig, method: 'put' });
+}
+
+async function patchRequest<T>(options: HttpOptions): AxiosPromise<T> {
+  const requestConfig = await getAxiosConfig(options);
+  return axios<T>({ ...requestConfig, method: 'patch' });
+}
+
+async function deleteRequest<T>(options: HttpOptions): AxiosPromise<T> {
+  const requestConfig = await getAxiosConfig(options);
+  return axios<T>({ ...requestConfig, method: 'delete' });
+}
+
+export const http = {
+  get: getRequest,
+  post: postRequest,
+  put: putRequest,
+  patch: patchRequest,
+  delete: deleteRequest,
+};

--- a/types/Http.ts
+++ b/types/Http.ts
@@ -1,3 +1,4 @@
+import { ResponseType } from 'axios';
 import { ReadStream } from 'fs';
 import { Stream } from 'stream';
 
@@ -10,12 +11,15 @@ export type QueryParams = {
   [key: string]: string | number | boolean | undefined;
 };
 
-export type AxiosConfigOptions = {
+export type FormData = {
+  [key: string]: string | ReadStream;
+};
+
+export type HttpOptions = {
   baseURL?: string;
   url: string;
   env?: string;
   localHostOverride?: boolean;
-  params?: QueryParams;
   data?:
     | Data
     | string
@@ -25,17 +29,9 @@ export type AxiosConfigOptions = {
     | Stream
     | Buffer;
   resolveWithFullResponse?: boolean;
-  timeout?: number;
-  headers?: Data;
-};
-
-export type FormData = {
-  [key: string]: string | ReadStream;
-};
-
-export type HttpOptions = AxiosConfigOptions & {
   params?: QueryParams;
   timeout?: number;
-  responseType?: string;
+  responseType?: ResponseType;
   headers?: { [header: string]: string | string[] | undefined };
+  unauthed?: boolean;
 };

--- a/types/Http.ts
+++ b/types/Http.ts
@@ -33,5 +33,4 @@ export type HttpOptions = {
   timeout?: number;
   responseType?: ResponseType;
   headers?: { [header: string]: string | string[] | undefined };
-  unauthed?: boolean;
 };


### PR DESCRIPTION
## Description and Context
This adds new methods for hitting hubspot endpoints that don't require auth. See thread for more details on this ask:
https://hubspot.slack.com/archives/C076QV345ME/p1721328218238189

Decided it would be easier to put this into the `next` branch due to the changes to `http`, even though it doesn't actually have any breaking changes.

## TODO
I feel like there might be a better way to name these functions? I couldn't think of anything that I really liked though.

## Who to Notify

@brandenrodgers @kemmerle @joe-yeager 
