### PR TITLE
Update some endpoints to point towards new project's service routes

### DIFF
--- a/api/projects.ts
+++ b/api/projects.ts
@@ -30,7 +30,7 @@ export async function fetchProjects(
   accountId: number
 ): Promise<FetchProjectResponse> {
   return http.get(accountId, {
-    url: PROJECTS_API_PATH,
+    url: DEVELOPER_PROJECTS_API_PATH,
   });
 }
 
@@ -39,7 +39,7 @@ export async function createProject(
   name: string
 ): Promise<Project> {
   return http.post(accountId, {
-    url: PROJECTS_API_PATH,
+    url: DEVELOPER_PROJECTS_API_PATH,
     data: {
       name,
     },
@@ -74,7 +74,7 @@ export async function fetchProject(
   projectName: string
 ): Promise<Project> {
   return http.get(accountId, {
-    url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
+    url: `${DEVELOPER_PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
   });
 }
 

--- a/api/projects.ts
+++ b/api/projects.ts
@@ -188,7 +188,7 @@ export async function fetchProjectSettings(
   projectName: string
 ): Promise<ProjectSettings> {
   return http.get(accountId, {
-    url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/settings`,
+    url: `${DEVELOPER_PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/settings`,
   });
 }
 


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
We have moved over a number of REST endpoints from the build service to the projects service in an attempt to separate out functionality. This PR updates a handful of those endpoints which have changed. Nothing about the endpoints has changed outside of the new routing, so request/responses should be exactly the same.


<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

We will be maintaining the old REST endpoints on the build service for the time being but we will need to coordinate when we can deprecate those without impacting users with older CLI versions. We might be able to utilize what @m-roll made a few weeks ago using the cli version headers to block requests.
## Who to Notify

<!-- /cc those you wish to know about the PR -->
cc @brandenrodgers @ypzheng 
