### PR TITLE
Fix fetch for themes with JSR modules

### DIFF
--- a/constants/extensions.ts
+++ b/constants/extensions.ts
@@ -18,6 +18,7 @@ export const ALLOWED_EXTENSIONS = new Set([
   'woff2',
   'graphql',
 ]);
+export const JSR_ALLOWED_EXTENSIONS = new Set(['jsx', 'tsx', 'ts']);
 
 export const HUBL_EXTENSIONS = new Set(['css', 'html', 'js']);
 export const MODULE_EXTENSION = 'module';

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -197,7 +197,7 @@ async function fetchAndWriteFileStream(
     logger.log(i18n(`${i18nKey}.skippedExisting`, { filepath }));
     return;
   }
-  if (!isAllowedExtension(srcPath, ['tsx', 'jsx', 'ts'])) {
+  if (!isAllowedExtension(srcPath, ['tsx', 'ts', 'jsx'])) {
     throwErrorWithMessage(`${i18nKey}.errors.invalidFileType`, { srcPath });
   }
   let node: FileMapperNode;
@@ -368,6 +368,12 @@ async function downloadFolder(
           );
           if (succeeded === false) {
             success = false;
+            logger.debug(
+              i18n(`${i18nKey}.errors.failedToFetchFile`, {
+                src: childNode.path,
+                dest: filepath || '',
+              })
+            );
           }
         });
         return success;

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -13,7 +13,11 @@ import {
 import { logger } from './logger';
 import { fetchFileStream, download, downloadDefault } from '../api/fileMapper';
 import { throwError, throwErrorWithMessage } from '../errors/standardErrors';
-import { MODULE_EXTENSION, FUNCTIONS_EXTENSION } from '../constants/extensions';
+import {
+  MODULE_EXTENSION,
+  FUNCTIONS_EXTENSION,
+  JSR_ALLOWED_EXTENSIONS,
+} from '../constants/extensions';
 import { MODE } from '../constants/files';
 import {
   FileMapperNode,
@@ -197,7 +201,7 @@ async function fetchAndWriteFileStream(
     logger.log(i18n(`${i18nKey}.skippedExisting`, { filepath }));
     return;
   }
-  if (!isAllowedExtension(srcPath, ['tsx', 'ts', 'jsx'])) {
+  if (!isAllowedExtension(srcPath, Array.from(JSR_ALLOWED_EXTENSIONS))) {
     throwErrorWithMessage(`${i18nKey}.errors.invalidFileType`, { srcPath });
   }
   let node: FileMapperNode;

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -197,7 +197,7 @@ async function fetchAndWriteFileStream(
     logger.log(i18n(`${i18nKey}.skippedExisting`, { filepath }));
     return;
   }
-  if (!isAllowedExtension(srcPath)) {
+  if (!isAllowedExtension(srcPath, ['tsx', 'jsx', 'ts'])) {
     throwErrorWithMessage(`${i18nKey}.errors.invalidFileType`, { srcPath });
   }
   let node: FileMapperNode;


### PR DESCRIPTION
 ## Description and Context
Report in cms dev tooling channel from infra that elevate theme is silently erroring on `tsx, ts, jsx` files when trying to fetch the theme.

This just adds those to the allowlist when checking extensions (don't want to add them to the default allowlist since that runs for `hs watch` as well). Error message here already exists just doesn't get logged in this circumstance