### PR TITLE
Fix: Add function to interpret tilde in file paths

### DIFF
--- a/api/__tests__/projects.test.ts
+++ b/api/__tests__/projects.test.ts
@@ -102,7 +102,9 @@ describe('api/projects', () => {
       );
       expect(http.post).toHaveBeenCalledTimes(1);
       expect(http.post).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/projects/upload/${encodeURIComponent(projectNameIllegalChars)}`,
+        url: `dfs/v1/projects/upload/${encodeURIComponent(
+          projectNameIllegalChars
+        )}`,
         timeout: 60_000,
         data: {
           file: formData,
@@ -148,7 +150,9 @@ describe('api/projects', () => {
       await fetchProject(accountId, projectNameIllegalChars);
       expect(http.get).toHaveBeenCalledTimes(1);
       expect(http.get).toHaveBeenCalledWith(accountId, {
-        url: `developer/projects/v1/by-name/${encodeURIComponent(projectNameIllegalChars)}`,
+        url: `developer/projects/v1/by-name/${encodeURIComponent(
+          projectNameIllegalChars
+        )}`,
       });
     });
   });
@@ -183,7 +187,9 @@ describe('api/projects', () => {
       await downloadProject(accountId, projectNameIllegalChars, buildId);
       expect(http.get).toHaveBeenCalledTimes(1);
       expect(http.get).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/projects/${encodeURIComponent(projectNameIllegalChars)}/builds/${buildId}/archive-full`,
+        url: `dfs/v1/projects/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/builds/${buildId}/archive-full`,
         responseType: 'arraybuffer',
         headers: {
           accept: 'application/zip',
@@ -206,7 +212,9 @@ describe('api/projects', () => {
       await deleteProject(accountId, projectNameIllegalChars);
       expect(http.delete).toHaveBeenCalledTimes(1);
       expect(http.delete).toHaveBeenCalledWith(accountId, {
-        url: `developer/projects/v1/${encodeURIComponent(projectNameIllegalChars)}`,
+        url: `developer/projects/v1/${encodeURIComponent(
+          projectNameIllegalChars
+        )}`,
       });
     });
   });
@@ -238,7 +246,9 @@ describe('api/projects', () => {
       await fetchProjectBuilds(accountId, projectNameIllegalChars);
       expect(http.get).toHaveBeenCalledTimes(1);
       expect(http.get).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/projects/${encodeURIComponent(projectNameIllegalChars)}/builds`,
+        url: `dfs/v1/projects/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/builds`,
         params: {},
       });
     });
@@ -258,7 +268,9 @@ describe('api/projects', () => {
       await getBuildStatus(accountId, projectNameIllegalChars, buildId);
       expect(http.get).toHaveBeenCalledTimes(1);
       expect(http.get).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/projects/${encodeURIComponent(projectNameIllegalChars)}/builds/${buildId}/status`,
+        url: `dfs/v1/projects/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/builds/${buildId}/status`,
       });
     });
   });
@@ -277,7 +289,9 @@ describe('api/projects', () => {
       await getBuildStructure(accountId, projectNameIllegalChars, buildId);
       expect(http.get).toHaveBeenCalledTimes(1);
       expect(http.get).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/builds/by-project-name/${encodeURIComponent(projectNameIllegalChars)}/builds/${buildId}/structure`,
+        url: `dfs/v1/builds/by-project-name/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/builds/${buildId}/structure`,
       });
     });
   });
@@ -311,7 +325,9 @@ describe('api/projects', () => {
       await getDeployStatus(accountId, projectNameIllegalChars, deployId);
       expect(http.get).toHaveBeenCalledTimes(1);
       expect(http.get).toHaveBeenCalledWith(accountId, {
-        url: `dfs/deploy/v1/deploy-status/projects/${encodeURIComponent(projectNameIllegalChars)}/deploys/${deployId}`,
+        url: `dfs/deploy/v1/deploy-status/projects/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/deploys/${deployId}`,
       });
     });
   });
@@ -330,7 +346,9 @@ describe('api/projects', () => {
       await getDeployStructure(accountId, projectNameIllegalChars, deployId);
       expect(http.get).toHaveBeenCalledTimes(1);
       expect(http.get).toHaveBeenCalledWith(accountId, {
-        url: `dfs/deploy/v1/deploys/by-project-name/${encodeURIComponent(projectNameIllegalChars)}/deploys/${deployId}/structure`,
+        url: `dfs/deploy/v1/deploys/by-project-name/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/deploys/${deployId}/structure`,
       });
     });
   });
@@ -348,7 +366,9 @@ describe('api/projects', () => {
       await fetchProjectSettings(accountId, projectNameIllegalChars);
       expect(http.get).toHaveBeenCalledTimes(1);
       expect(http.get).toHaveBeenCalledWith(accountId, {
-        url: `developer/projects/v1/${encodeURIComponent(projectNameIllegalChars)}/settings`,
+        url: `developer/projects/v1/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/settings`,
       });
     });
   });
@@ -370,7 +390,9 @@ describe('api/projects', () => {
       await provisionBuild(accountId, projectNameIllegalChars);
       expect(http.post).toHaveBeenCalledTimes(1);
       expect(http.post).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/projects/${encodeURIComponent(projectNameIllegalChars)}/builds/staged/provision`,
+        url: `dfs/v1/projects/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/builds/staged/provision`,
         params: {},
         headers: { 'Content-Type': 'application/json' },
         timeout: 50_000,
@@ -394,7 +416,9 @@ describe('api/projects', () => {
       await queueBuild(accountId, projectNameIllegalChars);
       expect(http.post).toHaveBeenCalledTimes(1);
       expect(http.post).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/projects/${encodeURIComponent(projectNameIllegalChars)}/builds/staged/queue`,
+        url: `dfs/v1/projects/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/builds/staged/queue`,
         params: {},
         headers: { 'Content-Type': 'application/json' },
       });
@@ -408,7 +432,9 @@ describe('api/projects', () => {
       await uploadFileToBuild(accountId, projectName, filePath, path);
       expect(http.put).toHaveBeenCalledTimes(1);
       expect(http.put).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/projects/${projectName}/builds/staged/files/${encodeURIComponent(path)}`,
+        url: `dfs/v1/projects/${projectName}/builds/staged/files/${encodeURIComponent(
+          path
+        )}`,
         data: { file: formData },
         headers: { 'Content-Type': 'multipart/form-data' },
       });
@@ -425,7 +451,9 @@ describe('api/projects', () => {
       );
       expect(http.put).toHaveBeenCalledTimes(1);
       expect(http.put).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/projects/${encodeURIComponent(projectNameIllegalChars)}/builds/staged/files/${encodeURIComponent(path)}`,
+        url: `dfs/v1/projects/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/builds/staged/files/${encodeURIComponent(path)}`,
         data: { file: formData },
         headers: { 'Content-Type': 'multipart/form-data' },
       });
@@ -438,7 +466,9 @@ describe('api/projects', () => {
       await deleteFileFromBuild(accountId, projectName, path);
       expect(http.delete).toHaveBeenCalledTimes(1);
       expect(http.delete).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/projects/${projectName}/builds/staged/files/${encodeURIComponent(path)}`,
+        url: `dfs/v1/projects/${projectName}/builds/staged/files/${encodeURIComponent(
+          path
+        )}`,
       });
     });
 
@@ -447,7 +477,9 @@ describe('api/projects', () => {
       await deleteFileFromBuild(accountId, projectNameIllegalChars, filePath);
       expect(http.delete).toHaveBeenCalledTimes(1);
       expect(http.delete).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/projects/${encodeURIComponent(projectNameIllegalChars)}/builds/staged/files/${encodeURIComponent(filePath)}`,
+        url: `dfs/v1/projects/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/builds/staged/files/${encodeURIComponent(filePath)}`,
       });
     });
   });
@@ -466,7 +498,9 @@ describe('api/projects', () => {
       await cancelStagedBuild(accountId, projectNameIllegalChars);
       expect(http.post).toHaveBeenCalledTimes(1);
       expect(http.post).toHaveBeenCalledWith(accountId, {
-        url: `dfs/v1/projects/${encodeURIComponent(projectNameIllegalChars)}/builds/staged/cancel`,
+        url: `dfs/v1/projects/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/builds/staged/cancel`,
         headers: { 'Content-Type': 'application/json' },
       });
     });
@@ -486,7 +520,9 @@ describe('api/projects', () => {
       await fetchBuildWarnLogs(accountId, projectNameIllegalChars, buildId);
       expect(http.get).toHaveBeenCalledTimes(1);
       expect(http.get).toHaveBeenCalledWith(accountId, {
-        url: `dfs/logging/v1/logs/projects/${encodeURIComponent(projectNameIllegalChars)}/builds/${buildId}/combined/warn`,
+        url: `dfs/logging/v1/logs/projects/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/builds/${buildId}/combined/warn`,
       });
     });
   });
@@ -505,7 +541,9 @@ describe('api/projects', () => {
       await fetchDeployWarnLogs(accountId, projectNameIllegalChars, deployId);
       expect(http.get).toHaveBeenCalledTimes(1);
       expect(http.get).toHaveBeenCalledWith(accountId, {
-        url: `dfs/logging/v1/logs/projects/${encodeURIComponent(projectNameIllegalChars)}/deploys/${deployId}/combined/warn`,
+        url: `dfs/logging/v1/logs/projects/${encodeURIComponent(
+          projectNameIllegalChars
+        )}/deploys/${deployId}/combined/warn`,
       });
     });
   });

--- a/api/projects.ts
+++ b/api/projects.ts
@@ -76,7 +76,9 @@ export async function fetchProject(
   projectName: string
 ): Promise<Project> {
   return http.get(accountId, {
-    url: `${DEVELOPER_PROJECTS_API_PATH}/by-name/${encodeURIComponent(projectName)}`,
+    url: `${DEVELOPER_PROJECTS_API_PATH}/by-name/${encodeURIComponent(
+      projectName
+    )}`,
   });
 }
 
@@ -198,7 +200,9 @@ export async function fetchProjectSettings(
   projectName: string
 ): Promise<ProjectSettings> {
   return http.get(accountId, {
-    url: `${DEVELOPER_PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/settings`,
+    url: `${DEVELOPER_PROJECTS_API_PATH}/${encodeURIComponent(
+      projectName
+    )}/settings`,
   });
 }
 

--- a/lib/path.ts
+++ b/lib/path.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import unixify from 'unixify';
 import { ALLOWED_EXTENSIONS } from '../constants/extensions';
+import os from 'os';
 
 export function convertToUnixPath(_path: string): string {
   return unixify(path.normalize(_path));
@@ -128,4 +129,16 @@ export function isValidPath(_path: string): boolean {
   }
 
   return true;
+}
+
+// Based on the untildify package: https://github.com/sindresorhus/untildify/blob/main/index.js
+export function untildify(pathWithTilde: string): string {
+  const homeDirectory = os.homedir();
+  if (typeof pathWithTilde !== 'string') {
+    throw new TypeError(`Expected a string, got ${typeof pathWithTilde}`);
+  }
+
+  return homeDirectory
+    ? pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory)
+    : pathWithTilde;
 }


### PR DESCRIPTION
## Description and Context
In the create project prompt, when a user is prompted to enter a project location, we are not interpreting the `~` correctly. I've added a util function that allows us to untildify the tilde. 

NOTE: For some reason, I received Prettier warnings about some files that @joe-yeager recently edited iirc. Changed them, let me know if I should revert. 

## Screenshots
<!-- Provide images of the before and after functionality -->

Before (Note the weird location: `/Users/akemmerle/src/~/src/test-proj828`):

<img width="2014" alt="Screenshot 2024-08-28 at 4 29 58 PM" src="https://github.com/user-attachments/assets/f6cef2b8-5e4e-4035-a836-b8338c38095c">

After:

<img width="2560" alt="Screenshot 2024-08-28 at 4 30 09 PM" src="https://github.com/user-attachments/assets/186d2f27-e8f3-47b3-9a54-e86ba5ee05ad">

## TODO
<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback
- [ ] Merge local-dev-lib PR and update version in CLI. 

## Who to Notify
<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
