### PR TITLE
Add fetchEnabledFeatures

### DIFF
--- a/api/localDevAuth.ts
+++ b/api/localDevAuth.ts
@@ -2,7 +2,11 @@ import { getAxiosConfig } from '../http/getAxiosConfig';
 import http from '../http';
 import { ENVIRONMENTS } from '../constants/environments';
 import { Environment } from '../types/Config';
-import { ScopeData, AccessTokenResponse } from '../types/Accounts';
+import {
+  ScopeData,
+  AccessTokenResponse,
+  EnabledFeaturesResponse,
+} from '../types/Accounts';
 import axios from 'axios';
 import { PublicAppInstallationData } from '../types/Apps';
 
@@ -57,5 +61,11 @@ export async function fetchAppInstallationData(
       requiredScopeGroups,
       optionalScopeGroups,
     },
+  });
+}
+
+export async function fetchEnabledFeatures(accountId: number) {
+  return http.get<EnabledFeaturesResponse>(accountId, {
+    url: `${LOCALDEVAUTH_API_AUTH_PATH}/enabled-features`,
   });
 }

--- a/types/Accounts.ts
+++ b/types/Accounts.ts
@@ -140,6 +140,10 @@ export type AccessTokenResponse = {
   accountType: ValueOf<typeof HUBSPOT_ACCOUNT_TYPES>;
 };
 
+export type EnabledFeaturesResponse = {
+  enabledFeatures?: { [key: string]: number };
+};
+
 export type UpdateAccountConfigOptions =
   Partial<FlatAccountFields_DEPRECATED> & {
     environment?: Environment;

--- a/types/Accounts.ts
+++ b/types/Accounts.ts
@@ -141,7 +141,7 @@ export type AccessTokenResponse = {
 };
 
 export type EnabledFeaturesResponse = {
-  enabledFeatures?: { [key: string]: number };
+  enabledFeatures: { [key: string]: boolean };
 };
 
 export type UpdateAccountConfigOptions =


### PR DESCRIPTION
## Description and Context

This adds a new `fetchEnabledFeatures` function to the `localDevAuth` api module that we can use to check gates for an account.

See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/590

## Who to Notify

@brandenrodgers @kemmerle @joe-yeager 
