### PR TITLE
fix: Return the tracking request when not authenticated 

### DIFF
--- a/lib/trackUsage.ts
+++ b/lib/trackUsage.ts
@@ -59,5 +59,5 @@ export async function trackUsage(
     resolveWithFullResponse: true,
   });
   logger.debug(i18n(`${i18nKey}.sendingEventUnauthenticated`));
-  axios({ ...axiosConfig, method: 'post' });
+  return axios({ ...axiosConfig, method: 'post' });
 }


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This is for consistency between the authed and unauthed tracking events. I wasn't able to test this, but I'm fairly certain this is preventing our unauthed requests from sending correctly in some cases. The impact is that our tracking for successful runs of `hs init` isn't accurate 

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
