### PR TITLE
Fix: Temporary fix for tracking so we dont lose events

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3,6 +3,7 @@
     "trackUsage": {
       "invalidEvent": "Usage tracking event {{ eventName }} is not a valid event type.",
       "sendingEventAuthenticated": "Sending usage event to authenticated endpoint",
+      "retryingEventUnauthenticated": "Failed to send the usage event as authenticated. Trying again as unauthenticated.",
       "sendingEventUnauthenticated": "Sending usage event to unauthenticated endpoint"
     },
     "archive": {

--- a/lib/trackUsage.ts
+++ b/lib/trackUsage.ts
@@ -5,6 +5,7 @@ import http from '../http';
 import { getAccountConfig, getEnv } from '../config';
 import { FILE_MAPPER_API_PATH } from '../api/fileMapper';
 import { i18n } from '../utils/lang';
+import { HUBSPOT_ACCOUNT_TYPES } from '../constants/config';
 
 const i18nKey = 'lib.trackUsage';
 
@@ -42,7 +43,11 @@ export async function trackUsage(
 
   const accountConfig = accountId && getAccountConfig(accountId);
 
-  if (accountConfig && accountConfig.authType === 'personalaccesskey') {
+  if (
+    accountConfig &&
+    accountConfig.authType === 'personalaccesskey' &&
+    accountConfig.accountType !== HUBSPOT_ACCOUNT_TYPES.APP_DEVELOPER
+  ) {
     logger.debug(i18n(`${i18nKey}.sendingEventAuthenticated`));
     return http.post(accountId, {
       url: `${path}/authenticated`,

--- a/lib/trackUsage.ts
+++ b/lib/trackUsage.ts
@@ -5,7 +5,6 @@ import http from '../http';
 import { getAccountConfig, getEnv } from '../config';
 import { FILE_MAPPER_API_PATH } from '../api/fileMapper';
 import { i18n } from '../utils/lang';
-import { HUBSPOT_ACCOUNT_TYPES } from '../constants/config';
 
 const i18nKey = 'lib.trackUsage';
 
@@ -43,17 +42,18 @@ export async function trackUsage(
 
   const accountConfig = accountId && getAccountConfig(accountId);
 
-  if (
-    accountConfig &&
-    accountConfig.authType === 'personalaccesskey' &&
-    accountConfig.accountType !== HUBSPOT_ACCOUNT_TYPES.APP_DEVELOPER
-  ) {
+  if (accountConfig && accountConfig.authType === 'personalaccesskey') {
     logger.debug(i18n(`${i18nKey}.sendingEventAuthenticated`));
-    return http.post(accountId, {
-      url: `${path}/authenticated`,
-      data: usageEvent,
-      resolveWithFullResponse: true,
-    });
+    try {
+      const result: void = await http.post(accountId, {
+        url: `${path}/authenticated`,
+        data: usageEvent,
+        resolveWithFullResponse: true,
+      });
+      return result;
+    } catch (e) {
+      logger.debug(i18n(`${i18nKey}.retryingEventUnauthenticated`));
+    }
   }
 
   const env = getEnv(accountId);


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This is a hack to temporarily fix usage tracking when dev accounts are targeted. This will cause those events to track as unauthenticated, which means we'll lose out on some user info, but this is better than losing the events entirely.

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
