### PR TITLE
Revert "Revert "Merge pull request #172 from HubSpot/refactor-config""

### DIFF
--- a/config/__tests__/CLIConfiguration.test.ts
+++ b/config/__tests__/CLIConfiguration.test.ts
@@ -51,9 +51,9 @@ describe('config/CLIConfiguration', () => {
     });
   });
 
-  describe('getConfigAccountIndex()', () => {
+  describe('getAccountIndex()', () => {
     it('returns -1 when no config is loaded', () => {
-      expect(config.getConfigAccountIndex(123)).toBe(-1);
+      expect(config.getAccountIndex(123)).toBe(-1);
     });
   });
 

--- a/config/getAccountIdentifier.ts
+++ b/config/getAccountIdentifier.ts
@@ -1,0 +1,13 @@
+import { GenericAccount } from '../types/Accounts';
+
+export function getAccountIdentifier(
+  account?: GenericAccount | null
+): number | undefined {
+  if (!account) {
+    return undefined;
+  } else if (Object.hasOwn(account, 'portalId')) {
+    return account.portalId;
+  } else if (Object.hasOwn(account, 'accountId')) {
+    return account.accountId;
+  }
+}

--- a/config/index.ts
+++ b/config/index.ts
@@ -232,14 +232,14 @@ export function getAccountType(
   return config_DEPRECATED.getAccountType(accountType, sandboxAccountType);
 }
 
-export function getDefaultAccount(): string | number | null | undefined {
+export function getConfigDefaultAccount(): string | number | null | undefined {
   if (CLIConfiguration.isActive()) {
     return CLIConfiguration.getDefaultAccount();
   }
   return config_DEPRECATED.getConfigDefaultAccount();
 }
 
-export function getAccounts():
+export function getConfigAccounts():
   | Array<CLIAccount_NEW>
   | Array<CLIAccount_DEPRECATED>
   | null

--- a/constants/config.ts
+++ b/constants/config.ts
@@ -2,7 +2,7 @@ import { i18n } from '../utils/lang';
 
 export const DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME = 'hubspot.config.yml';
 
-export const HUBSPOT_CONFIGURATION_FOLDER = '.hubspot';
+export const HUBSPOT_CONFIGURATION_FOLDER = '.hubspot-cli';
 export const HUBSPOT_CONFIGURATION_FILE = 'config.yml';
 
 export const MIN_HTTP_TIMEOUT = 3000;

--- a/lib/__tests__/oauth.test.ts
+++ b/lib/__tests__/oauth.test.ts
@@ -1,6 +1,6 @@
 import { addOauthToAccountConfig, getOauthManager } from '../oauth';
 
-jest.mock('../../utils/getAccountIdentifier');
+jest.mock('../../config/getAccountIdentifier');
 jest.mock('../../config');
 jest.mock('../logger');
 jest.mock('../../errors');

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -2,7 +2,7 @@ import { OAuth2Manager } from '../models/OAuth2Manager';
 import { AUTH_METHODS } from '../constants/auth';
 import { FlatAccountFields } from '../types/Accounts';
 import { logger } from './logger';
-import { getAccountIdentifier } from '../utils/getAccountIdentifier';
+import { getAccountIdentifier } from '../config/getAccountIdentifier';
 import { updateAccountConfig, writeConfig } from '../config';
 import { i18n } from '../utils/lang';
 

--- a/lib/personalAccessKey.ts
+++ b/lib/personalAccessKey.ts
@@ -15,6 +15,7 @@ import {
 import { HUBSPOT_ACCOUNT_TYPES } from '../constants/config';
 import { fetchDeveloperTestAccountData } from '../api/developerTestAccounts';
 import { logger } from './logger';
+import { CLIConfiguration } from '../config/CLIConfiguration';
 import { i18n } from '../utils/lang';
 import { isHubSpotHttpError } from '../errors';
 import { AccessToken } from '../types/Accounts';
@@ -216,7 +217,7 @@ export async function updateConfigWithAccessToken(
     logger.debug(err);
   }
 
-  const updatedConfig = updateAccountConfig({
+  const updatedAccount = updateAccountConfig({
     accountId: portalId,
     accountType,
     personalAccessKey,
@@ -226,11 +227,13 @@ export async function updateConfigWithAccessToken(
     parentAccountId,
     env: accountEnv,
   });
-  writeConfig();
+  if (!CLIConfiguration.isActive()) {
+    writeConfig();
+  }
 
   if (makeDefault && name) {
     updateDefaultAccount(name);
   }
 
-  return updatedConfig;
+  return updatedAccount;
 }

--- a/models/OAuth2Manager.ts
+++ b/models/OAuth2Manager.ts
@@ -11,7 +11,7 @@ import {
   ExchangeProof,
 } from '../types/Accounts';
 import { logger } from '../lib/logger';
-import { getAccountIdentifier } from '../utils/getAccountIdentifier';
+import { getAccountIdentifier } from '../config/getAccountIdentifier';
 import { AUTH_METHODS } from '../constants/auth';
 import { i18n } from '../utils/lang';
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "./errors/*": "./errors/*.js",
     "./http": "./http/index.js",
     "./http/*": "./http/*.js",
+    "./config/getAccountIdentifier": "./config/getAccountIdentifier.js",
     "./config": "./config/index.js",
     "./constants/*": "./constants/*.js",
     "./models/*": "./models/*.js",

--- a/utils/accounts.ts
+++ b/utils/accounts.ts
@@ -1,21 +1,9 @@
-import { CLIAccount, GenericAccount } from '../types/Accounts';
+import { CLIAccount } from '../types/Accounts';
 import {
   CLIConfig,
   CLIConfig_DEPRECATED,
   CLIConfig_NEW,
 } from '../types/Config';
-
-export function getAccountIdentifier(
-  account?: GenericAccount | null
-): number | undefined {
-  if (!account) {
-    return undefined;
-  } else if (Object.hasOwn(account, 'portalId')) {
-    return account.portalId;
-  } else if (Object.hasOwn(account, 'accountId')) {
-    return account.accountId;
-  }
-}
 
 export function getAccounts(config?: CLIConfig | null): Array<CLIAccount> {
   if (!config) {


### PR DESCRIPTION
## Description and Context

**THIS PR WAS REVERTED in #203--this PR reverts the revert.**

We are updating our HubSpot CLI configuration file, so that it will be created the root directory in a hidden folder: `~/.hubspot-cli/config.yml`. This will encourage users to take advantage of the `init`, `auth`, and `accounts` commands to update their config and help prevent config-related bugs. 

We will also be supporting the old configuration, which means that power users will still be able to use nested configs for different projects.

Sister PR: https://github.com/HubSpot/hubspot-cli/pull/1123

## QUESTIONS:

For Sandra, how would we like to alert customers about the new config? Currently, I have a prompt that asks them whether they'd like to use the new vs. old, but I'm not sure that's the best solution.

## Screenshots

<!-- Provide images of the before and after functionality -->

`hs init` (with new config):

<img width="2560" alt="Screenshot 2024-08-05 at 11 34 19 AM" src="https://github.com/user-attachments/assets/9cd9601c-bf8d-4afd-9c03-53ef61c539a5">

`hs init` (Erroring out because config exists):

This isn't the greatest, because the prompt for new vs old config still appears.

<img width="986" alt="Screenshot 2024-08-05 at 11 39 57 AM" src="https://github.com/user-attachments/assets/30722d63-6066-423d-b3c8-8aa5393ee805">

`hs auth` (Adding another account):

<img width="2560" alt="Screenshot 2024-08-05 at 11 34 59 AM" src="https://github.com/user-attachments/assets/f843d41a-35b8-48aa-bee9-b092f4ff3d9d">

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Need to fix minor bug where choose default account prompt still appears when re-authing a default account.
- [x] Need to check for both old and new config paths to prevent users from using both config types. 
- [x] Add tests

## Who to Notify

<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
