### PR TITLE
Add build script to LDL

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,12 @@
+Copyright 2019  HubSpot, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -12,13 +12,10 @@
     "access": "public"
   },
   "scripts": {
-    "build": "rm -rf ./dist/ && tsc --rootDir . --outdir dist && yarn copy-files && yarn clear-postinstall",
+    "build": "ts-node ./scripts/build.ts",
     "check-main": "branch=$(git rev-parse --abbrev-ref HEAD) && [ $branch = main ] || (echo 'Error: New release can only be published on main branch' && exit 1)",
-    "clear-postinstall": "cd dist && npm pkg delete scripts.postinstall",
-    "copy-files": "cp -r lang dist/lang",
     "lint": "eslint --max-warnings=0 . && prettier . --check",
     "local-dev": "yarn build && cd dist && yarn link && cd .. && tsc --watch --rootDir . --outdir dist",
-    "postinstall": "husky install",
     "prettier:write": "prettier . --write",
     "pub": "cd dist && npm publish --tag latest && cd ..",
     "push": "git push --atomic origin main v$npm_package_version",
@@ -46,6 +43,7 @@
     "husky": "^8.0.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.0.5",
+    "ts-node": "^10.9.2",
     "typescript": "^4.9.5"
   },
   "exports": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,34 @@
+import { spawn, exec as _exec } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+
+const exec = promisify(_exec);
+
+export async function build(): Promise<void> {
+  // Remove the current dist dir
+  fs.rmSync('dist', { recursive: true, force: true });
+
+  // Build typescript
+  await new Promise(resolve => {
+    const childProcess = spawn('yarn', ['tsc'], {
+      stdio: 'inherit',
+    });
+
+    childProcess.on('close', code => {
+      if (code !== 0) {
+        process.exit(code || 1);
+      }
+      resolve('');
+    });
+  });
+
+  // Copy remaining files
+  fs.cpSync('lang', 'dist/lang', { recursive: true });
+  fs.cpSync('README.md', 'dist/README.md');
+  fs.cpSync('LICENSE', 'dist/LICENSE');
+
+  // Remove postinstall from built package.json
+  exec('npm pkg delete scripts.postinstall', { cwd: './dist' });
+}
+
+build();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "rootDir": ".",
+    "outDir": "dist"
   },
   "include": [
     "api",


### PR DESCRIPTION
## Description and Context
This adds a (very slightly) modified version of the build script from the CLI to local-dev-lib. It also adds a LICENSE file (which we didn't have before for some reason. If there was a good reason for that I can remove) and includes the LICENSE and readme as part of the build output.

Up next: add the release script

## Who to Notify

@brandenrodgers @kemmerle @joe-yeager 
