### PR TITLE
Add release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint --max-warnings=0 . && prettier . --check",
     "local-dev": "yarn build && cd dist && yarn link && cd .. && tsc --watch --rootDir . --outdir dist",
     "prettier:write": "prettier . --write",
-    "release": "ts-node ./scripts/release.ts",
+    "release": "ts-node ./scripts/release.ts release",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ./node_modules/.bin/jest"
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -13,15 +13,10 @@
   },
   "scripts": {
     "build": "ts-node ./scripts/build.ts",
-    "check-main": "branch=$(git rev-parse --abbrev-ref HEAD) && [ $branch = main ] || (echo 'Error: New release can only be published on main branch' && exit 1)",
     "lint": "eslint --max-warnings=0 . && prettier . --check",
     "local-dev": "yarn build && cd dist && yarn link && cd .. && tsc --watch --rootDir . --outdir dist",
     "prettier:write": "prettier . --write",
-    "pub": "cd dist && npm publish --tag latest && cd ..",
-    "push": "git push --atomic origin main v$npm_package_version",
-    "release:major": "yarn check-main && yarn version --major && yarn build && yarn pub && yarn push",
-    "release:minor": "yarn check-main && yarn version --minor && yarn build && yarn pub && yarn push",
-    "release:patch": "yarn check-main && yarn version --patch && yarn build && yarn pub && yarn push",
+    "release": "ts-node ./scripts/release.ts",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ./node_modules/.bin/jest"
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@inquirer/prompts": "^7.0.1",
     "@types/content-disposition": "^0.5.5",
     "@types/cors": "^2.8.15",
     "@types/debounce": "^1.2.1",
@@ -44,7 +45,8 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.2",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "yargs": "^17.7.2"
   },
   "exports": {
     "./*": "./lib/*.js",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,34 +1,3 @@
-import { spawn, exec as _exec } from 'child_process';
-import { promisify } from 'util';
-import fs from 'fs';
-
-const exec = promisify(_exec);
-
-export async function build(): Promise<void> {
-  // Remove the current dist dir
-  fs.rmSync('dist', { recursive: true, force: true });
-
-  // Build typescript
-  await new Promise(resolve => {
-    const childProcess = spawn('yarn', ['tsc'], {
-      stdio: 'inherit',
-    });
-
-    childProcess.on('close', code => {
-      if (code !== 0) {
-        process.exit(code || 1);
-      }
-      resolve('');
-    });
-  });
-
-  // Copy remaining files
-  fs.cpSync('lang', 'dist/lang', { recursive: true });
-  fs.cpSync('README.md', 'dist/README.md');
-  fs.cpSync('LICENSE', 'dist/LICENSE');
-
-  // Remove postinstall from built package.json
-  exec('npm pkg delete scripts.postinstall', { cwd: './dist' });
-}
+import { build } from './lib/build';
 
 build();

--- a/scripts/lib/build.ts
+++ b/scripts/lib/build.ts
@@ -1,0 +1,40 @@
+import { spawn, exec as _exec } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+
+import { logger, setLogLevel, LOG_LEVEL } from '../../lib/logger';
+
+const exec = promisify(_exec);
+
+export async function build(): Promise<void> {
+  setLogLevel(LOG_LEVEL.LOG);
+  logger.log('Creating a new build...');
+  logger.log();
+
+  // Remove the current dist dir
+  fs.rmSync('dist', { recursive: true, force: true });
+
+  // Build typescript
+  await new Promise(resolve => {
+    const childProcess = spawn('yarn', ['tsc'], {
+      stdio: 'inherit',
+    });
+
+    childProcess.on('close', code => {
+      if (code !== 0) {
+        process.exit(code || 1);
+      }
+      resolve('');
+    });
+  });
+
+  // Copy remaining files
+  fs.cpSync('lang', 'dist/lang', { recursive: true });
+  fs.cpSync('README.md', 'dist/README.md');
+  fs.cpSync('LICENSE', 'dist/LICENSE');
+
+  // Remove postinstall from built package.json
+  await exec('npm pkg delete scripts.postinstall', { cwd: './dist' });
+
+  logger.success('Build successful');
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -6,7 +6,7 @@ import { confirm } from '@inquirer/prompts';
 
 import { name as packageName, version as localVersion } from '../package.json';
 import { logger, setLogLevel, LOG_LEVEL } from '../lib/logger';
-import { build } from './build';
+import { build } from './lib/build';
 
 const exec = promisify(_exec);
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -133,17 +133,21 @@ async function handler({
     process.exit(EXIT_CODES.ERROR);
   }
 
-  const { next: currentNextTag, experimental: currentExperimentalTag } =
-    await getDistTags();
+  const {
+    // next: currentNextTag,
+    experimental: currentExperimentalTag,
+  } = await getDistTags();
 
-  if (!isExperimental && currentNextTag !== localVersion) {
-    logger.error(
-      `Local package.json version ${localVersion} is out of sync with published version ${currentNextTag}`
-    );
-    process.exit(EXIT_CODES.ERROR);
-  }
+  // if (!isExperimental && currentNextTag !== localVersion) {
+  //   logger.error(
+  //     `Local package.json version ${localVersion} is out of sync with published version ${currentNextTag}`
+  //   );
+  //   process.exit(EXIT_CODES.ERROR);
+  // }
 
-  const currentVersion = isExperimental ? currentExperimentalTag : localVersion;
+  const currentVersion = isExperimental
+    ? currentExperimentalTag || '0.0.0'
+    : localVersion;
   const prereleaseIdentifier = isExperimental
     ? PRERELEASE_IDENTIFIER.EXPERIMENTAL
     : PRERELEASE_IDENTIFIER.NEXT;

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,256 @@
+import { exec as _exec, spawn } from 'child_process';
+import { promisify } from 'util';
+import yargs, { ArgumentsCamelCase, Argv } from 'yargs';
+import semver from 'semver';
+import { confirm } from '@inquirer/prompts';
+
+import { name as packageName, version as localVersion } from '../package.json';
+import { logger, setLogLevel, LOG_LEVEL } from '../lib/logger';
+import { build } from './build';
+
+const exec = promisify(_exec);
+
+const MAIN_BRANCH = 'main';
+
+const TAG = {
+  LATEST: 'latest',
+  NEXT: 'next',
+  EXPERIMENTAL: 'experimental',
+} as const;
+
+const INCREMENT = {
+  PATCH: 'patch',
+  MINOR: 'minor',
+  MAJOR: 'major',
+  PRERELEASE: 'prerelease',
+} as const;
+
+const VERSION_INCREMENT_OPTIONS = [
+  INCREMENT.PATCH,
+  INCREMENT.MINOR,
+  INCREMENT.MAJOR,
+  INCREMENT.PRERELEASE,
+] as const;
+const TAG_OPTIONS = [TAG.LATEST, TAG.NEXT, TAG.EXPERIMENTAL] as const;
+
+const PRERELEASE_IDENTIFIER = {
+  NEXT: 'beta',
+  EXPERIMENTAL: 'experimental',
+} as const;
+
+const EXIT_CODES = {
+  SUCCESS: 0,
+  ERROR: 1,
+};
+
+type ReleaseArguments = {
+  versionIncrement: (typeof VERSION_INCREMENT_OPTIONS)[number];
+  tag: (typeof TAG_OPTIONS)[number];
+  dryRun?: boolean;
+};
+
+type DistTags = {
+  [TAG.LATEST]: string;
+  [TAG.NEXT]: string;
+  [TAG.EXPERIMENTAL]: string;
+};
+
+type Tag = (typeof TAG_OPTIONS)[number];
+
+async function getGitBranch(): Promise<string> {
+  const { stdout } = await exec('git rev-parse --abbrev-ref HEAD');
+  return stdout.trim();
+}
+
+async function getDistTags(): Promise<DistTags> {
+  const { stdout } = await exec(`npm view ${packageName} dist-tags --json`);
+  const distTags = stdout.trim();
+  return JSON.parse(distTags) as DistTags;
+}
+
+async function cleanup(newVersion: string): Promise<void> {
+  await exec(`git reset HEAD~`);
+  await exec(`git checkout .`);
+  await exec(`git tag -d v${newVersion}`);
+}
+
+async function publish(tag: Tag, isDryRun: boolean): Promise<void> {
+  logger.log();
+  logger.log(`Publishing to ${tag}...`);
+  logger.log('-'.repeat(50));
+  logger.log();
+
+  const commandArgs = ['publish', '--tag', tag];
+
+  if (isDryRun) {
+    commandArgs.push('--dry-run');
+  }
+
+  return new Promise((resolve, reject) => {
+    const childProcess = spawn('npm', commandArgs, {
+      stdio: 'inherit',
+      cwd: './dist',
+    });
+
+    childProcess.on('close', code => {
+      if (code !== EXIT_CODES.SUCCESS) {
+        reject();
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+async function handler({
+  versionIncrement,
+  tag,
+  dryRun,
+}: ArgumentsCamelCase<ReleaseArguments>): Promise<void> {
+  setLogLevel(LOG_LEVEL.LOG);
+
+  const branch = await getGitBranch();
+
+  const isExperimental = tag === TAG.EXPERIMENTAL;
+  const isDryRun = Boolean(dryRun);
+
+  if (isExperimental && branch === MAIN_BRANCH) {
+    logger.error(
+      'Releases to experimental tag cannot be published from the main branch'
+    );
+    process.exit(EXIT_CODES.ERROR);
+  } else if (!isExperimental && branch !== MAIN_BRANCH) {
+    logger.error(
+      'Releases to latest and next tags can only be published from the main branch'
+    );
+    process.exit(EXIT_CODES.ERROR);
+  }
+
+  if (tag === TAG.LATEST && versionIncrement === INCREMENT.PRERELEASE) {
+    logger.error(
+      'Invalid release: cannot increment prerelease number on latest tag.'
+    );
+    process.exit(EXIT_CODES.ERROR);
+  }
+
+  const { next: currentNextTag, experimental: currentExperimentalTag } =
+    await getDistTags();
+
+  if (!isExperimental && currentNextTag !== localVersion) {
+    logger.error(
+      `Local package.json version ${localVersion} is out of sync with published version ${currentNextTag}`
+    );
+    process.exit(EXIT_CODES.ERROR);
+  }
+
+  const currentVersion = isExperimental ? currentExperimentalTag : localVersion;
+  const prereleaseIdentifier = isExperimental
+    ? PRERELEASE_IDENTIFIER.EXPERIMENTAL
+    : PRERELEASE_IDENTIFIER.NEXT;
+  const incrementType =
+    tag === TAG.LATEST || versionIncrement === INCREMENT.PRERELEASE
+      ? versionIncrement
+      : (`pre${versionIncrement}` as const);
+
+  const newVersion = semver.inc(
+    currentVersion,
+    incrementType,
+    prereleaseIdentifier
+  );
+
+  if (!newVersion) {
+    logger.error('Error incrementing version.');
+    process.exit(EXIT_CODES.ERROR);
+  }
+
+  logger.log();
+  logger.log(`Current version: ${currentVersion}`);
+  logger.log(`New version to release: ${newVersion}`);
+
+  const shouldRelease = await confirm({
+    message: `Release version ${newVersion} on tag ${tag}?`,
+  });
+
+  if (!shouldRelease) {
+    process.exit(EXIT_CODES.SUCCESS);
+  }
+
+  logger.log();
+  logger.log(`Updating version to ${newVersion}...`);
+  await exec(`yarn version --new-version ${newVersion}`);
+  logger.success('Version updated successfully');
+
+  logger.log();
+  logger.log('Creating a new build...');
+  await build();
+  logger.success('Build successful');
+
+  try {
+    await publish(tag, isDryRun);
+
+    if (tag === TAG.LATEST) {
+      await publish(TAG.NEXT, isDryRun);
+    }
+  } catch (e) {
+    logger.error(
+      'An error occurred while releasing the package. Correct the error and re-run `yarn build`.'
+    );
+    await cleanup(newVersion);
+    process.exit(EXIT_CODES.ERROR);
+  }
+
+  if (isDryRun) {
+    await cleanup(newVersion);
+    logger.log();
+    logger.success('Dry run release finished successfully');
+    process.exit(EXIT_CODES.SUCCESS);
+  }
+
+  logger.log();
+  logger.log(`Pushing changes to Github...`);
+  await exec(`git push --atomic origin ${branch} v${newVersion}`);
+  logger.log(`Changes pushed successfully`);
+
+  logger.log();
+  logger.success(
+    `@hubspot/local-dev-lib version ${newVersion} published successfully`
+  );
+  logger.log(
+    'View on npm: https://www.npmjs.com/package/@hubspot/local-dev-lib?activeTab=versions'
+  );
+}
+
+async function builder(yargs: Argv): Promise<Argv> {
+  return yargs.options({
+    versionIncrement: {
+      alias: 'v',
+      demandOption: true,
+      describe: 'SemVer increment type for the next release',
+      choices: VERSION_INCREMENT_OPTIONS,
+    },
+    tag: {
+      alias: 't',
+      demandOption: true,
+      describe: 'Tag for the next release',
+      choices: TAG_OPTIONS,
+    },
+    dryRun: {
+      alias: 'd',
+      describe: 'Run through the publish process without actually publishing',
+      type: 'boolean',
+    },
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+yargs(process.argv.slice(2))
+  .scriptName('yarn')
+  .usage('Release script')
+  .command(
+    'release',
+    'Create a new npm release of local-dev-lib with the specified version and tag',
+    builder,
+    handler
+  )
+  .version(false)
+  .help().argv;

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -185,9 +185,7 @@ async function handler({
   logger.success('Version updated successfully');
 
   logger.log();
-  logger.log('Creating a new build...');
   await build();
-  logger.success('Build successful');
 
   try {
     await publish(tag, isDryRun);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -242,7 +242,6 @@ async function builder(yargs: Argv): Promise<Argv> {
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 yargs(process.argv.slice(2))
   .scriptName('yarn')
   .usage('Release script')


### PR DESCRIPTION
## Description and Context
This ports the new release script that was recently added to the CLI to local-dev-lib. The release script here is more or less identical, but doesn't contain the additional confirmation prompt when publishing to latest without a beta release. (Beta releases likely won't be as useful as this is a library, but I didn't see any reason to remove the option).

This also includes the recent change to move the logic for `build` into its own file.

Like the CLI, we'll have to do a bit of work to get things in the proper state:
* Release to the experimental tag
* Release to the beta tag
* Add back in the check for local/beta tag sync (and potentially remove the default experimental version)

## Who to Notify

@brandenrodgers @joe-yeager @kemmerle 
