### PR TITLE
Restore check for local and npm version sync in release script

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -143,9 +143,7 @@ async function handler({
     process.exit(EXIT_CODES.ERROR);
   }
 
-  const currentVersion = isExperimental
-    ? currentExperimentalTag || '0.0.0'
-    : localVersion;
+  const currentVersion = isExperimental ? currentExperimentalTag : localVersion;
   const prereleaseIdentifier = isExperimental
     ? PRERELEASE_IDENTIFIER.EXPERIMENTAL
     : PRERELEASE_IDENTIFIER.NEXT;

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -133,17 +133,15 @@ async function handler({
     process.exit(EXIT_CODES.ERROR);
   }
 
-  const {
-    // next: currentNextTag,
-    experimental: currentExperimentalTag,
-  } = await getDistTags();
+  const { next: currentNextTag, experimental: currentExperimentalTag } =
+    await getDistTags();
 
-  // if (!isExperimental && currentNextTag !== localVersion) {
-  //   logger.error(
-  //     `Local package.json version ${localVersion} is out of sync with published version ${currentNextTag}`
-  //   );
-  //   process.exit(EXIT_CODES.ERROR);
-  // }
+  if (!isExperimental && currentNextTag !== localVersion) {
+    logger.error(
+      `Local package.json version ${localVersion} is out of sync with published version ${currentNextTag}`
+    );
+    process.exit(EXIT_CODES.ERROR);
+  }
 
   const currentVersion = isExperimental
     ? currentExperimentalTag || '0.0.0'


### PR DESCRIPTION
## Description and Context

Now that we've made a beta release, the release script check for the local version being in sync with `next` will work. I also removed the experimental default value of `0.0.0` since I could see that doing more harm then good if anything weird happens with fetching the version tags

## Who to Notify

@brandenrodgers @kemmerle @joe-yeager 
