### PR TITLE
fix: Update port manager shutdown flow

### DIFF
--- a/lib/portManager.ts
+++ b/lib/portManager.ts
@@ -1,15 +1,31 @@
 import axios from 'axios';
 
-import { PortManagerServer } from '../utils/PortManagerServer';
-import { detectPort } from '../utils/detectPort';
+import {
+  HEALTH_CHECK_PATH,
+  PortManagerServer,
+  SERVICE_HEALTHY,
+} from '../utils/PortManagerServer';
 import { PORT_MANAGER_SERVER_PORT } from '../constants/ports';
 import { RequestPortsData } from '../types/PortManager';
+import { detectPort } from '../utils/detectPort';
+import { logger } from './logger';
 
 export const BASE_URL = `http://localhost:${PORT_MANAGER_SERVER_PORT}`;
 
+export async function isPortManagerPortAvailable(): Promise<boolean> {
+  return (
+    (await detectPort(PORT_MANAGER_SERVER_PORT)) === PORT_MANAGER_SERVER_PORT
+  );
+}
+
 export async function isPortManagerServerRunning(): Promise<boolean> {
-  const port = await detectPort(PORT_MANAGER_SERVER_PORT);
-  return port !== PORT_MANAGER_SERVER_PORT;
+  try {
+    const { data } = await axios.get(`${BASE_URL}${HEALTH_CHECK_PATH}`);
+    return data.status === SERVICE_HEALTHY;
+  } catch (e) {
+    logger.debug(e);
+    return false;
+  }
 }
 
 export async function startPortManagerServer(): Promise<void> {

--- a/utils/PortManagerServer.ts
+++ b/utils/PortManagerServer.ts
@@ -16,6 +16,9 @@ import { RequestPortsData, ServerPortMap } from '../types/PortManager';
 
 const i18nKey = 'utils.PortManagerServer';
 
+export const HEALTH_CHECK_PATH = '/port-manager-health-check';
+export const SERVICE_HEALTHY = 'OK';
+
 class _PortManagerServer {
   app?: Express;
   server?: Server;
@@ -36,6 +39,7 @@ class _PortManagerServer {
 
     try {
       this.server = await this.listen();
+      logger.debug(this.server);
     } catch (e) {
       if (isSystemError(e) && e.code === 'EADDRINUSE') {
         throw new Error(
@@ -80,6 +84,10 @@ class _PortManagerServer {
     this.app.post('/servers', this.assignPortsToServers);
     this.app.delete('/servers/:instanceId', this.deleteServerInstance);
     this.app.post('/close', this.closeServer);
+
+    this.app.use(HEALTH_CHECK_PATH, (req, res) => {
+      res.status(200).send({ status: SERVICE_HEALTHY });
+    });
   }
 
   setPort(instanceId: string, port: number) {


### PR DESCRIPTION
## Description and Context
Updates the portManager shutdown flow to call a health check endpoint before attempting to shutdown the server.

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->


## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
- [x] Update the CLI code accordingly
- [x] The `hs doctor` PR was making use of the `isPortManagerServerRunning` and will need to be updated to use the `isPortManagerPortAvailable`

