### PR TITLE
fix!: Wrap Axios type and export new type

### DIFF
--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -1,5 +1,4 @@
-import { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import {
   PublicApp,
   PublicAppInstallCounts,
@@ -11,7 +10,7 @@ const APPS_DEV_API_PATH = 'apps-dev/external/public/v3';
 
 export function fetchPublicAppsForPortal(
   accountId: number
-): AxiosPromise<FetchPublicAppsForPortalResponse> {
+): HubSpotResponse<FetchPublicAppsForPortalResponse> {
   return http.get<FetchPublicAppsForPortalResponse>(accountId, {
     url: `${APPS_DEV_API_PATH}/full/portal`,
   });
@@ -20,7 +19,7 @@ export function fetchPublicAppsForPortal(
 export function fetchPublicAppDeveloperTestAccountInstallData(
   appId: number,
   accountId: number
-): AxiosPromise<PublicAppDeveloperTestAccountInstallData> {
+): HubSpotResponse<PublicAppDeveloperTestAccountInstallData> {
   return http.get<PublicAppDeveloperTestAccountInstallData>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/test-portal-installs`,
   });
@@ -29,7 +28,7 @@ export function fetchPublicAppDeveloperTestAccountInstallData(
 export function fetchPublicAppProductionInstallCounts(
   appId: number,
   accountId: number
-): AxiosPromise<PublicAppInstallCounts> {
+): HubSpotResponse<PublicAppInstallCounts> {
   return http.get<PublicAppInstallCounts>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/install-counts-without-test-portals`,
   });
@@ -38,7 +37,7 @@ export function fetchPublicAppProductionInstallCounts(
 export function fetchPublicAppMetadata(
   appId: number,
   accountId: number
-): AxiosPromise<PublicApp> {
+): HubSpotResponse<PublicApp> {
   return http.get<PublicApp>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/full`,
   });

--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -1,10 +1,11 @@
-import { http, HubSpotPromise } from '../http';
+import { http } from '../http';
 import {
   PublicApp,
   PublicAppInstallCounts,
   PublicAppDeveloperTestAccountInstallData,
   FetchPublicAppsForPortalResponse,
 } from '../types/Apps';
+import { HubSpotPromise } from '../types/Http';
 
 const APPS_DEV_API_PATH = 'apps-dev/external/public/v3';
 

--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -1,4 +1,4 @@
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import {
   PublicApp,
   PublicAppInstallCounts,
@@ -10,7 +10,7 @@ const APPS_DEV_API_PATH = 'apps-dev/external/public/v3';
 
 export function fetchPublicAppsForPortal(
   accountId: number
-): HubSpotResponse<FetchPublicAppsForPortalResponse> {
+): HubSpotPromise<FetchPublicAppsForPortalResponse> {
   return http.get<FetchPublicAppsForPortalResponse>(accountId, {
     url: `${APPS_DEV_API_PATH}/full/portal`,
   });
@@ -19,7 +19,7 @@ export function fetchPublicAppsForPortal(
 export function fetchPublicAppDeveloperTestAccountInstallData(
   appId: number,
   accountId: number
-): HubSpotResponse<PublicAppDeveloperTestAccountInstallData> {
+): HubSpotPromise<PublicAppDeveloperTestAccountInstallData> {
   return http.get<PublicAppDeveloperTestAccountInstallData>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/test-portal-installs`,
   });
@@ -28,7 +28,7 @@ export function fetchPublicAppDeveloperTestAccountInstallData(
 export function fetchPublicAppProductionInstallCounts(
   appId: number,
   accountId: number
-): HubSpotResponse<PublicAppInstallCounts> {
+): HubSpotPromise<PublicAppInstallCounts> {
   return http.get<PublicAppInstallCounts>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/install-counts-without-test-portals`,
   });
@@ -37,7 +37,7 @@ export function fetchPublicAppProductionInstallCounts(
 export function fetchPublicAppMetadata(
   appId: number,
   accountId: number
-): HubSpotResponse<PublicApp> {
+): HubSpotPromise<PublicApp> {
   return http.get<PublicApp>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/full`,
   });

--- a/api/customObjects.ts
+++ b/api/customObjects.ts
@@ -1,9 +1,10 @@
-import { http, HubSpotPromise } from '../http';
+import { http } from '../http';
 import {
   FetchSchemasResponse,
   Schema,
   CreateObjectsResponse,
 } from '../types/Schemas';
+import { HubSpotPromise } from '../types/Http';
 
 const CUSTOM_OBJECTS_API_PATH = 'crm/v3/objects';
 const SCHEMA_API_PATH = 'crm-object-schemas/v3/schemas';

--- a/api/customObjects.ts
+++ b/api/customObjects.ts
@@ -1,5 +1,4 @@
-import { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import {
   FetchSchemasResponse,
   Schema,
@@ -13,7 +12,7 @@ export function batchCreateObjects(
   accountId: number,
   objectTypeId: string,
   objects: JSON
-): AxiosPromise<CreateObjectsResponse> {
+): HubSpotResponse<CreateObjectsResponse> {
   return http.post<CreateObjectsResponse>(accountId, {
     url: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}/batch/create`,
     data: objects,
@@ -23,7 +22,7 @@ export function batchCreateObjects(
 export function createObjectSchema(
   accountId: number,
   schema: JSON
-): AxiosPromise<Schema> {
+): HubSpotResponse<Schema> {
   return http.post<Schema>(accountId, {
     url: SCHEMA_API_PATH,
     data: schema,
@@ -34,7 +33,7 @@ export function updateObjectSchema(
   accountId: number,
   schemaObjectType: string,
   schema: Schema
-): AxiosPromise<Schema> {
+): HubSpotResponse<Schema> {
   return http.patch<Schema>(accountId, {
     url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
     data: schema,
@@ -44,7 +43,7 @@ export function updateObjectSchema(
 export function fetchObjectSchema(
   accountId: number,
   schemaObjectType: string
-): AxiosPromise<Schema> {
+): HubSpotResponse<Schema> {
   return http.get<Schema>(accountId, {
     url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
   });
@@ -52,7 +51,7 @@ export function fetchObjectSchema(
 
 export function fetchObjectSchemas(
   accountId: number
-): AxiosPromise<FetchSchemasResponse> {
+): HubSpotResponse<FetchSchemasResponse> {
   return http.get<FetchSchemasResponse>(accountId, {
     url: SCHEMA_API_PATH,
   });
@@ -61,7 +60,7 @@ export function fetchObjectSchemas(
 export function deleteObjectSchema(
   accountId: number,
   schemaObjectType: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.delete(accountId, {
     url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
   });

--- a/api/customObjects.ts
+++ b/api/customObjects.ts
@@ -1,4 +1,4 @@
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import {
   FetchSchemasResponse,
   Schema,
@@ -12,7 +12,7 @@ export function batchCreateObjects(
   accountId: number,
   objectTypeId: string,
   objects: JSON
-): HubSpotResponse<CreateObjectsResponse> {
+): HubSpotPromise<CreateObjectsResponse> {
   return http.post<CreateObjectsResponse>(accountId, {
     url: `${CUSTOM_OBJECTS_API_PATH}/${objectTypeId}/batch/create`,
     data: objects,
@@ -22,7 +22,7 @@ export function batchCreateObjects(
 export function createObjectSchema(
   accountId: number,
   schema: JSON
-): HubSpotResponse<Schema> {
+): HubSpotPromise<Schema> {
   return http.post<Schema>(accountId, {
     url: SCHEMA_API_PATH,
     data: schema,
@@ -33,7 +33,7 @@ export function updateObjectSchema(
   accountId: number,
   schemaObjectType: string,
   schema: Schema
-): HubSpotResponse<Schema> {
+): HubSpotPromise<Schema> {
   return http.patch<Schema>(accountId, {
     url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
     data: schema,
@@ -43,7 +43,7 @@ export function updateObjectSchema(
 export function fetchObjectSchema(
   accountId: number,
   schemaObjectType: string
-): HubSpotResponse<Schema> {
+): HubSpotPromise<Schema> {
   return http.get<Schema>(accountId, {
     url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
   });
@@ -51,7 +51,7 @@ export function fetchObjectSchema(
 
 export function fetchObjectSchemas(
   accountId: number
-): HubSpotResponse<FetchSchemasResponse> {
+): HubSpotPromise<FetchSchemasResponse> {
   return http.get<FetchSchemasResponse>(accountId, {
     url: SCHEMA_API_PATH,
   });
@@ -60,7 +60,7 @@ export function fetchObjectSchemas(
 export function deleteObjectSchema(
   accountId: number,
   schemaObjectType: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.delete(accountId, {
     url: `${SCHEMA_API_PATH}/${schemaObjectType}`,
   });

--- a/api/designManager.ts
+++ b/api/designManager.ts
@@ -1,5 +1,5 @@
-import { http, HubSpotPromise } from '../http';
-import { QueryParams } from '../types/Http';
+import { http } from '../http';
+import { HubSpotPromise, QueryParams } from '../types/Http';
 import {
   FetchThemesResponse,
   FetchBuiltinMappingResponse,

--- a/api/designManager.ts
+++ b/api/designManager.ts
@@ -1,4 +1,4 @@
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { QueryParams } from '../types/Http';
 import {
   FetchThemesResponse,
@@ -10,7 +10,7 @@ const DESIGN_MANAGER_API_PATH = 'designmanager/v1';
 export function fetchThemes(
   accountId: number,
   params: QueryParams = {}
-): HubSpotResponse<FetchThemesResponse> {
+): HubSpotPromise<FetchThemesResponse> {
   return http.get<FetchThemesResponse>(accountId, {
     url: `${DESIGN_MANAGER_API_PATH}/themes/combined`,
     params,
@@ -19,7 +19,7 @@ export function fetchThemes(
 
 export function fetchBuiltinMapping(
   accountId: number
-): HubSpotResponse<FetchBuiltinMappingResponse> {
+): HubSpotPromise<FetchBuiltinMappingResponse> {
   return http.get<FetchBuiltinMappingResponse>(accountId, {
     url: `${DESIGN_MANAGER_API_PATH}/widgets/builtin-mapping`,
   });

--- a/api/designManager.ts
+++ b/api/designManager.ts
@@ -1,5 +1,4 @@
-import { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import { QueryParams } from '../types/Http';
 import {
   FetchThemesResponse,
@@ -11,7 +10,7 @@ const DESIGN_MANAGER_API_PATH = 'designmanager/v1';
 export function fetchThemes(
   accountId: number,
   params: QueryParams = {}
-): AxiosPromise<FetchThemesResponse> {
+): HubSpotResponse<FetchThemesResponse> {
   return http.get<FetchThemesResponse>(accountId, {
     url: `${DESIGN_MANAGER_API_PATH}/themes/combined`,
     params,
@@ -20,7 +19,7 @@ export function fetchThemes(
 
 export function fetchBuiltinMapping(
   accountId: number
-): AxiosPromise<FetchBuiltinMappingResponse> {
+): HubSpotResponse<FetchBuiltinMappingResponse> {
   return http.get<FetchBuiltinMappingResponse>(accountId, {
     url: `${DESIGN_MANAGER_API_PATH}/widgets/builtin-mapping`,
   });

--- a/api/developerTestAccounts.ts
+++ b/api/developerTestAccounts.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { http, HubSpotPromise } from '../http';
+import { http } from '../http';
 import { getAxiosConfig } from '../http/getAxiosConfig';
 import { ENVIRONMENTS } from '../constants/environments';
 import {
@@ -8,6 +8,7 @@ import {
 } from '../types/developerTestAccounts';
 import { SANDBOX_TIMEOUT } from '../constants/api';
 import { Environment } from '../types/Config';
+import { HubSpotPromise } from '../types/Http';
 
 const TEST_ACCOUNTS_API_PATH = 'integrators/test-portals/v2';
 

--- a/api/developerTestAccounts.ts
+++ b/api/developerTestAccounts.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { getAxiosConfig } from '../http/getAxiosConfig';
 import { ENVIRONMENTS } from '../constants/environments';
 import {
@@ -13,7 +13,7 @@ const TEST_ACCOUNTS_API_PATH = 'integrators/test-portals/v2';
 
 export function fetchDeveloperTestAccounts(
   accountId: number
-): HubSpotResponse<FetchDeveloperTestAccountsResponse> {
+): HubSpotPromise<FetchDeveloperTestAccountsResponse> {
   return http.get<FetchDeveloperTestAccountsResponse>(accountId, {
     url: TEST_ACCOUNTS_API_PATH,
   });
@@ -22,7 +22,7 @@ export function fetchDeveloperTestAccounts(
 export function createDeveloperTestAccount(
   accountId: number,
   accountName: string
-): HubSpotResponse<DeveloperTestAccount> {
+): HubSpotPromise<DeveloperTestAccount> {
   return http.post<DeveloperTestAccount>(accountId, {
     url: TEST_ACCOUNTS_API_PATH,
     data: { accountName, generatePersonalAccessKey: true }, // For CLI, generatePersonalAccessKey will always be true since we'll be saving the entry to the config
@@ -33,7 +33,7 @@ export function createDeveloperTestAccount(
 export function deleteDeveloperTestAccount(
   accountId: number,
   testAccountId: number
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.delete(accountId, {
     url: `${TEST_ACCOUNTS_API_PATH}/${testAccountId}`,
   });
@@ -43,7 +43,7 @@ export function fetchDeveloperTestAccountData(
   accessToken: string,
   accountId: number,
   env: Environment = ENVIRONMENTS.PROD
-): HubSpotResponse<DeveloperTestAccount> {
+): HubSpotPromise<DeveloperTestAccount> {
   const axiosConfig = getAxiosConfig({
     env,
     url: `${TEST_ACCOUNTS_API_PATH}/self`,

--- a/api/developerTestAccounts.ts
+++ b/api/developerTestAccounts.ts
@@ -1,5 +1,5 @@
-import axios, { AxiosPromise } from 'axios';
-import { http } from '../http';
+import axios from 'axios';
+import { http, HubSpotResponse } from '../http';
 import { getAxiosConfig } from '../http/getAxiosConfig';
 import { ENVIRONMENTS } from '../constants/environments';
 import {
@@ -13,7 +13,7 @@ const TEST_ACCOUNTS_API_PATH = 'integrators/test-portals/v2';
 
 export function fetchDeveloperTestAccounts(
   accountId: number
-): AxiosPromise<FetchDeveloperTestAccountsResponse> {
+): HubSpotResponse<FetchDeveloperTestAccountsResponse> {
   return http.get<FetchDeveloperTestAccountsResponse>(accountId, {
     url: TEST_ACCOUNTS_API_PATH,
   });
@@ -22,7 +22,7 @@ export function fetchDeveloperTestAccounts(
 export function createDeveloperTestAccount(
   accountId: number,
   accountName: string
-): AxiosPromise<DeveloperTestAccount> {
+): HubSpotResponse<DeveloperTestAccount> {
   return http.post<DeveloperTestAccount>(accountId, {
     url: TEST_ACCOUNTS_API_PATH,
     data: { accountName, generatePersonalAccessKey: true }, // For CLI, generatePersonalAccessKey will always be true since we'll be saving the entry to the config
@@ -33,7 +33,7 @@ export function createDeveloperTestAccount(
 export function deleteDeveloperTestAccount(
   accountId: number,
   testAccountId: number
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.delete(accountId, {
     url: `${TEST_ACCOUNTS_API_PATH}/${testAccountId}`,
   });
@@ -43,7 +43,7 @@ export function fetchDeveloperTestAccountData(
   accessToken: string,
   accountId: number,
   env: Environment = ENVIRONMENTS.PROD
-): AxiosPromise<DeveloperTestAccount> {
+): HubSpotResponse<DeveloperTestAccount> {
   const axiosConfig = getAxiosConfig({
     env,
     url: `${TEST_ACCOUNTS_API_PATH}/self`,

--- a/api/fileManager.ts
+++ b/api/fileManager.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { http, HubSpotPromise } from '../http';
-import { FormData } from '../types/Http';
+import { http } from '../http';
+import { FormData, HubSpotPromise } from '../types/Http';
 import {
   FetchStatResponse,
   FetchFilesResponse,

--- a/api/fileManager.ts
+++ b/api/fileManager.ts
@@ -1,7 +1,6 @@
-import { AxiosPromise } from 'axios';
 import fs from 'fs';
 import path from 'path';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import { FormData } from '../types/Http';
 import {
   FetchStatResponse,
@@ -17,7 +16,7 @@ export function uploadFile(
   accountId: number,
   src: string,
   dest: string
-): AxiosPromise<UploadResponse> {
+): HubSpotResponse<UploadResponse> {
   const directory = path.dirname(dest);
   const filename = path.basename(dest);
   const formData: FormData = {
@@ -45,7 +44,7 @@ export function uploadFile(
 export function fetchStat(
   accountId: number,
   src: string
-): AxiosPromise<FetchStatResponse> {
+): HubSpotResponse<FetchStatResponse> {
   return http.get<FetchStatResponse>(accountId, {
     url: `${FILE_MANAGER_V2_API_PATH}/files/stat/${src}`,
   });
@@ -56,7 +55,7 @@ export function fetchFiles(
   folderId: number | 'None',
   offset: number,
   archived?: boolean
-): AxiosPromise<FetchFilesResponse> {
+): HubSpotResponse<FetchFilesResponse> {
   return http.get<FetchFilesResponse>(accountId, {
     url: `${FILE_MANAGER_V2_API_PATH}/files/`,
     params: {
@@ -71,7 +70,7 @@ export function fetchFiles(
 export function fetchFolders(
   accountId: number,
   folderId: number | 'None'
-): AxiosPromise<FetchFolderResponse> {
+): HubSpotResponse<FetchFolderResponse> {
   return http.get<FetchFolderResponse>(accountId, {
     url: `${FILE_MANAGER_V2_API_PATH}/folders/`,
     params: {

--- a/api/fileManager.ts
+++ b/api/fileManager.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { FormData } from '../types/Http';
 import {
   FetchStatResponse,
@@ -16,7 +16,7 @@ export function uploadFile(
   accountId: number,
   src: string,
   dest: string
-): HubSpotResponse<UploadResponse> {
+): HubSpotPromise<UploadResponse> {
   const directory = path.dirname(dest);
   const filename = path.basename(dest);
   const formData: FormData = {
@@ -44,7 +44,7 @@ export function uploadFile(
 export function fetchStat(
   accountId: number,
   src: string
-): HubSpotResponse<FetchStatResponse> {
+): HubSpotPromise<FetchStatResponse> {
   return http.get<FetchStatResponse>(accountId, {
     url: `${FILE_MANAGER_V2_API_PATH}/files/stat/${src}`,
   });
@@ -55,7 +55,7 @@ export function fetchFiles(
   folderId: number | 'None',
   offset: number,
   archived?: boolean
-): HubSpotResponse<FetchFilesResponse> {
+): HubSpotPromise<FetchFilesResponse> {
   return http.get<FetchFilesResponse>(accountId, {
     url: `${FILE_MANAGER_V2_API_PATH}/files/`,
     params: {
@@ -70,7 +70,7 @@ export function fetchFiles(
 export function fetchFolders(
   accountId: number,
   folderId: number | 'None'
-): HubSpotResponse<FetchFolderResponse> {
+): HubSpotPromise<FetchFolderResponse> {
   return http.get<FetchFolderResponse>(accountId, {
     url: `${FILE_MANAGER_V2_API_PATH}/folders/`,
     params: {

--- a/api/fileMapper.ts
+++ b/api/fileMapper.ts
@@ -2,9 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import contentDisposition from 'content-disposition';
 import { AxiosResponse } from 'axios';
-import { http, HubSpotPromise } from '../http';
+import { http } from '../http';
 import { getCwd } from '../lib/path';
 import { FileMapperNode, FileMapperOptions, FileTree } from '../types/Files';
+import { HubSpotPromise } from '../types/Http';
 
 export const FILE_MAPPER_API_PATH = 'content/filemapper/v1';
 

--- a/api/fileMapper.ts
+++ b/api/fileMapper.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import contentDisposition from 'content-disposition';
 import { AxiosResponse } from 'axios';
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { getCwd } from '../lib/path';
 import { FileMapperNode, FileMapperOptions, FileTree } from '../types/Files';
 
@@ -46,7 +46,7 @@ export function upload(
   src: string,
   dest: string,
   options: FileMapperOptions = {}
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.post<void>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/upload/${encodeURIComponent(dest)}`,
     data: {
@@ -62,7 +62,7 @@ export function fetchModule(
   accountId: number,
   moduleId: number,
   options: FileMapperOptions = {}
-): HubSpotResponse<FileTree> {
+): HubSpotPromise<FileTree> {
   return http.get<FileTree>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/modules/${moduleId}`,
     ...options,
@@ -92,7 +92,7 @@ export function download(
   accountId: number,
   filepath: string,
   options: FileMapperOptions = {}
-): HubSpotResponse<FileMapperNode> {
+): HubSpotPromise<FileMapperNode> {
   return http.get<FileMapperNode>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/download/${encodeURIComponent(filepath)}`,
     ...options,
@@ -104,7 +104,7 @@ export function downloadDefault(
   accountId: number,
   filepath: string,
   options: FileMapperOptions = {}
-): HubSpotResponse<FileMapperNode> {
+): HubSpotPromise<FileMapperNode> {
   return http.get<FileMapperNode>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/download-default/${filepath}`,
     ...options,
@@ -115,7 +115,7 @@ export function downloadDefault(
 export function deleteFile(
   accountId: number,
   filePath: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.delete(accountId, {
     url: `${FILE_MAPPER_API_PATH}/delete/${encodeURIComponent(filePath)}`,
   });
@@ -126,7 +126,7 @@ export function moveFile(
   accountId: number,
   srcPath: string,
   destPath: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.put(accountId, {
     url: `${FILE_MAPPER_API_PATH}/rename/${srcPath}?path=${destPath}`,
     headers: { 'Content-Type': 'application/json' },
@@ -137,7 +137,7 @@ export function moveFile(
 export function getDirectoryContentsByPath(
   accountId: number,
   path: string
-): HubSpotResponse<FileMapperNode> {
+): HubSpotPromise<FileMapperNode> {
   return http.get(accountId, {
     url: `${FILE_MAPPER_API_PATH}/meta/${path}`,
   });

--- a/api/fileMapper.ts
+++ b/api/fileMapper.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import contentDisposition from 'content-disposition';
-import { AxiosResponse, AxiosPromise } from 'axios';
-import { http } from '../http';
+import { AxiosResponse } from 'axios';
+import { http, HubSpotResponse } from '../http';
 import { getCwd } from '../lib/path';
 import { FileMapperNode, FileMapperOptions, FileTree } from '../types/Files';
 
@@ -46,7 +46,7 @@ export function upload(
   src: string,
   dest: string,
   options: FileMapperOptions = {}
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.post<void>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/upload/${encodeURIComponent(dest)}`,
     data: {
@@ -62,7 +62,7 @@ export function fetchModule(
   accountId: number,
   moduleId: number,
   options: FileMapperOptions = {}
-): AxiosPromise<FileTree> {
+): HubSpotResponse<FileTree> {
   return http.get<FileTree>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/modules/${moduleId}`,
     ...options,
@@ -92,7 +92,7 @@ export function download(
   accountId: number,
   filepath: string,
   options: FileMapperOptions = {}
-): AxiosPromise<FileMapperNode> {
+): HubSpotResponse<FileMapperNode> {
   return http.get<FileMapperNode>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/download/${encodeURIComponent(filepath)}`,
     ...options,
@@ -104,7 +104,7 @@ export function downloadDefault(
   accountId: number,
   filepath: string,
   options: FileMapperOptions = {}
-): AxiosPromise<FileMapperNode> {
+): HubSpotResponse<FileMapperNode> {
   return http.get<FileMapperNode>(accountId, {
     url: `${FILE_MAPPER_API_PATH}/download-default/${filepath}`,
     ...options,
@@ -115,7 +115,7 @@ export function downloadDefault(
 export function deleteFile(
   accountId: number,
   filePath: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.delete(accountId, {
     url: `${FILE_MAPPER_API_PATH}/delete/${encodeURIComponent(filePath)}`,
   });
@@ -126,7 +126,7 @@ export function moveFile(
   accountId: number,
   srcPath: string,
   destPath: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.put(accountId, {
     url: `${FILE_MAPPER_API_PATH}/rename/${srcPath}?path=${destPath}`,
     headers: { 'Content-Type': 'application/json' },
@@ -137,7 +137,7 @@ export function moveFile(
 export function getDirectoryContentsByPath(
   accountId: number,
   path: string
-): AxiosPromise<FileMapperNode> {
+): HubSpotResponse<FileMapperNode> {
   return http.get(accountId, {
     url: `${FILE_MAPPER_API_PATH}/meta/${path}`,
   });

--- a/api/fileTransport.ts
+++ b/api/fileTransport.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { getCwd } from '../lib/path';
-import { http, HubSpotPromise } from '../http';
+import { http } from '../http';
+import { HubSpotPromise } from '../types/Http';
 const HUBFILES_API_PATH = '/file-transport/v1/hubfiles';
 
 export function createSchemaFromHubFile(

--- a/api/fileTransport.ts
+++ b/api/fileTransport.ts
@@ -1,14 +1,13 @@
-import { AxiosPromise } from 'axios';
 import fs from 'fs';
 import path from 'path';
 import { getCwd } from '../lib/path';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 const HUBFILES_API_PATH = '/file-transport/v1/hubfiles';
 
 export function createSchemaFromHubFile(
   accountId: number,
   filepath: string
-): AxiosPromise {
+): HubSpotResponse {
   const file = fs.createReadStream(path.resolve(getCwd(), filepath));
   return http.post(accountId, {
     url: `${HUBFILES_API_PATH}/object-schemas`,
@@ -22,7 +21,7 @@ export function createSchemaFromHubFile(
 export async function updateSchemaFromHubFile(
   accountId: number,
   filepath: string
-): AxiosPromise {
+): HubSpotResponse {
   const file = fs.createReadStream(path.resolve(getCwd(), filepath));
   return http.put(accountId, {
     url: `${HUBFILES_API_PATH}/object-schemas`,
@@ -37,7 +36,7 @@ export async function fetchHubFileSchema(
   accountId: number,
   objectName: string,
   path: string
-): AxiosPromise {
+): HubSpotResponse {
   return http.getOctetStream(
     accountId,
     {

--- a/api/fileTransport.ts
+++ b/api/fileTransport.ts
@@ -1,13 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import { getCwd } from '../lib/path';
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 const HUBFILES_API_PATH = '/file-transport/v1/hubfiles';
 
 export function createSchemaFromHubFile(
   accountId: number,
   filepath: string
-): HubSpotResponse {
+): HubSpotPromise {
   const file = fs.createReadStream(path.resolve(getCwd(), filepath));
   return http.post(accountId, {
     url: `${HUBFILES_API_PATH}/object-schemas`,
@@ -21,7 +21,7 @@ export function createSchemaFromHubFile(
 export async function updateSchemaFromHubFile(
   accountId: number,
   filepath: string
-): HubSpotResponse {
+): HubSpotPromise {
   const file = fs.createReadStream(path.resolve(getCwd(), filepath));
   return http.put(accountId, {
     url: `${HUBFILES_API_PATH}/object-schemas`,
@@ -36,7 +36,7 @@ export async function fetchHubFileSchema(
   accountId: number,
   objectName: string,
   path: string
-): HubSpotResponse {
+): HubSpotPromise {
   return http.getOctetStream(
     accountId,
     {

--- a/api/functions.ts
+++ b/api/functions.ts
@@ -1,5 +1,5 @@
-import { http, HubSpotPromise } from '../http';
-import { QueryParams } from '../types/Http';
+import { http } from '../http';
+import { HubSpotPromise, QueryParams } from '../types/Http';
 import { GetBuildStatusResponse, GetRoutesResponse } from '../types/Functions';
 
 const FUNCTION_API_PATH = 'cms/v3/functions';

--- a/api/functions.ts
+++ b/api/functions.ts
@@ -1,11 +1,12 @@
-import { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import { QueryParams } from '../types/Http';
 import { GetBuildStatusResponse, GetRoutesResponse } from '../types/Functions';
 
 const FUNCTION_API_PATH = 'cms/v3/functions';
 
-export function getRoutes(accountId: number): AxiosPromise<GetRoutesResponse> {
+export function getRoutes(
+  accountId: number
+): HubSpotResponse<GetRoutesResponse> {
   return http.get(accountId, {
     url: `${FUNCTION_API_PATH}/routes`,
   });
@@ -15,7 +16,7 @@ export function getFunctionLogs(
   accountId: number,
   route: string,
   params: QueryParams = {}
-): AxiosPromise {
+): HubSpotResponse {
   const { limit = 5 } = params;
 
   return http.get(accountId, {
@@ -27,7 +28,7 @@ export function getFunctionLogs(
 export function getLatestFunctionLog(
   accountId: number,
   route: string
-): AxiosPromise {
+): HubSpotResponse {
   return http.get(accountId, {
     url: `${FUNCTION_API_PATH}/results/by-route/${encodeURIComponent(
       route
@@ -38,7 +39,7 @@ export function getLatestFunctionLog(
 export function buildPackage(
   accountId: number,
   folderPath: string
-): AxiosPromise<string> {
+): HubSpotResponse<string> {
   return http.post(accountId, {
     url: `${FUNCTION_API_PATH}/build/async`,
     headers: {
@@ -53,7 +54,7 @@ export function buildPackage(
 export function getBuildStatus(
   accountId: number,
   buildId: number
-): AxiosPromise<GetBuildStatusResponse> {
+): HubSpotResponse<GetBuildStatusResponse> {
   return http.get(accountId, {
     url: `${FUNCTION_API_PATH}/build/${buildId}/poll`,
   });

--- a/api/functions.ts
+++ b/api/functions.ts
@@ -1,4 +1,4 @@
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { QueryParams } from '../types/Http';
 import { GetBuildStatusResponse, GetRoutesResponse } from '../types/Functions';
 
@@ -6,7 +6,7 @@ const FUNCTION_API_PATH = 'cms/v3/functions';
 
 export function getRoutes(
   accountId: number
-): HubSpotResponse<GetRoutesResponse> {
+): HubSpotPromise<GetRoutesResponse> {
   return http.get(accountId, {
     url: `${FUNCTION_API_PATH}/routes`,
   });
@@ -16,7 +16,7 @@ export function getFunctionLogs(
   accountId: number,
   route: string,
   params: QueryParams = {}
-): HubSpotResponse {
+): HubSpotPromise {
   const { limit = 5 } = params;
 
   return http.get(accountId, {
@@ -28,7 +28,7 @@ export function getFunctionLogs(
 export function getLatestFunctionLog(
   accountId: number,
   route: string
-): HubSpotResponse {
+): HubSpotPromise {
   return http.get(accountId, {
     url: `${FUNCTION_API_PATH}/results/by-route/${encodeURIComponent(
       route
@@ -39,7 +39,7 @@ export function getLatestFunctionLog(
 export function buildPackage(
   accountId: number,
   folderPath: string
-): HubSpotResponse<string> {
+): HubSpotPromise<string> {
   return http.post(accountId, {
     url: `${FUNCTION_API_PATH}/build/async`,
     headers: {
@@ -54,7 +54,7 @@ export function buildPackage(
 export function getBuildStatus(
   accountId: number,
   buildId: number
-): HubSpotResponse<GetBuildStatusResponse> {
+): HubSpotPromise<GetBuildStatusResponse> {
   return http.get(accountId, {
     url: `${FUNCTION_API_PATH}/build/${buildId}/poll`,
   });

--- a/api/github.ts
+++ b/api/github.ts
@@ -1,6 +1,7 @@
-import axios, { AxiosPromise } from 'axios';
+import axios from 'axios';
 import { getDefaultUserAgentHeader } from '../http/getAxiosConfig';
 import { GithubReleaseData, GithubRepoFile, RepoPath } from '../types/Github';
+import { HubSpotResponse } from '../http';
 
 const GITHUB_REPOS_API = 'https://api.github.com/repos';
 const GITHUB_RAW_CONTENT_API_PATH = 'https://raw.githubusercontent.com';
@@ -31,7 +32,7 @@ function getAdditionalHeaders(): AdditionalGitHubHeaders {
 export function fetchRepoReleaseData(
   repoPath: RepoPath,
   tag = ''
-): AxiosPromise<GithubReleaseData> {
+): HubSpotResponse<GithubReleaseData> {
   const URL = `${GITHUB_REPOS_API}/${repoPath}/releases`;
 
   return axios.get<GithubReleaseData>(
@@ -47,7 +48,7 @@ export function fetchRepoReleaseData(
 
 // Returns the entire repo content as a zip, using the zipball_url from fetchRepoReleaseData()
 // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#download-a-repository-archive-zip
-export function fetchRepoAsZip(zipUrl: string): AxiosPromise<Buffer> {
+export function fetchRepoAsZip(zipUrl: string): HubSpotResponse<Buffer> {
   return axios.get<Buffer>(zipUrl, {
     responseType: 'arraybuffer',
     headers: { ...getDefaultUserAgentHeader(), ...getAdditionalHeaders() },
@@ -59,7 +60,7 @@ export function fetchRepoFile(
   repoPath: RepoPath,
   filePath: string,
   ref: string
-): AxiosPromise<Buffer> {
+): HubSpotResponse<Buffer> {
   return axios.get<Buffer>(
     `${GITHUB_RAW_CONTENT_API_PATH}/${repoPath}/${ref}/${filePath}`,
     {
@@ -74,7 +75,7 @@ export function fetchRepoFile(
 // Returns the raw file contents via the raw.githubusercontent endpoint
 export function fetchRepoFileByDownloadUrl(
   downloadUrl: string
-): AxiosPromise<Buffer> {
+): HubSpotResponse<Buffer> {
   return axios.get<Buffer>(downloadUrl, {
     headers: { ...getDefaultUserAgentHeader(), ...getAdditionalHeaders() },
     responseType: 'arraybuffer',
@@ -87,7 +88,7 @@ export function fetchRepoContents(
   repoPath: RepoPath,
   path: string,
   ref?: string
-): AxiosPromise<Array<GithubRepoFile>> {
+): HubSpotResponse<Array<GithubRepoFile>> {
   const refQuery = ref ? `?ref=${ref}` : '';
 
   return axios.get<Array<GithubRepoFile>>(

--- a/api/github.ts
+++ b/api/github.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { getDefaultUserAgentHeader } from '../http/getAxiosConfig';
 import { GithubReleaseData, GithubRepoFile, RepoPath } from '../types/Github';
-import { HubSpotResponse } from '../http';
+import { HubSpotPromise } from '../http';
 
 const GITHUB_REPOS_API = 'https://api.github.com/repos';
 const GITHUB_RAW_CONTENT_API_PATH = 'https://raw.githubusercontent.com';
@@ -32,7 +32,7 @@ function getAdditionalHeaders(): AdditionalGitHubHeaders {
 export function fetchRepoReleaseData(
   repoPath: RepoPath,
   tag = ''
-): HubSpotResponse<GithubReleaseData> {
+): HubSpotPromise<GithubReleaseData> {
   const URL = `${GITHUB_REPOS_API}/${repoPath}/releases`;
 
   return axios.get<GithubReleaseData>(
@@ -48,7 +48,7 @@ export function fetchRepoReleaseData(
 
 // Returns the entire repo content as a zip, using the zipball_url from fetchRepoReleaseData()
 // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#download-a-repository-archive-zip
-export function fetchRepoAsZip(zipUrl: string): HubSpotResponse<Buffer> {
+export function fetchRepoAsZip(zipUrl: string): HubSpotPromise<Buffer> {
   return axios.get<Buffer>(zipUrl, {
     responseType: 'arraybuffer',
     headers: { ...getDefaultUserAgentHeader(), ...getAdditionalHeaders() },
@@ -60,7 +60,7 @@ export function fetchRepoFile(
   repoPath: RepoPath,
   filePath: string,
   ref: string
-): HubSpotResponse<Buffer> {
+): HubSpotPromise<Buffer> {
   return axios.get<Buffer>(
     `${GITHUB_RAW_CONTENT_API_PATH}/${repoPath}/${ref}/${filePath}`,
     {
@@ -75,7 +75,7 @@ export function fetchRepoFile(
 // Returns the raw file contents via the raw.githubusercontent endpoint
 export function fetchRepoFileByDownloadUrl(
   downloadUrl: string
-): HubSpotResponse<Buffer> {
+): HubSpotPromise<Buffer> {
   return axios.get<Buffer>(downloadUrl, {
     headers: { ...getDefaultUserAgentHeader(), ...getAdditionalHeaders() },
     responseType: 'arraybuffer',
@@ -88,7 +88,7 @@ export function fetchRepoContents(
   repoPath: RepoPath,
   path: string,
   ref?: string
-): HubSpotResponse<Array<GithubRepoFile>> {
+): HubSpotPromise<Array<GithubRepoFile>> {
   const refQuery = ref ? `?ref=${ref}` : '';
 
   return axios.get<Array<GithubRepoFile>>(

--- a/api/github.ts
+++ b/api/github.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { getDefaultUserAgentHeader } from '../http/getAxiosConfig';
 import { GithubReleaseData, GithubRepoFile, RepoPath } from '../types/Github';
-import { HubSpotPromise } from '../http';
+import { HubSpotPromise } from '../types/Http';
 
 const GITHUB_REPOS_API = 'https://api.github.com/repos';
 const GITHUB_RAW_CONTENT_API_PATH = 'https://raw.githubusercontent.com';

--- a/api/hubdb.ts
+++ b/api/hubdb.ts
@@ -1,4 +1,4 @@
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { QueryParams } from '../types/Http';
 import {
   CreateRowsResponse,
@@ -13,7 +13,7 @@ const HUBDB_API_PATH = 'cms/v3/hubdb';
 
 export function fetchTables(
   accountId: number
-): HubSpotResponse<FetchTablesResponse> {
+): HubSpotPromise<FetchTablesResponse> {
   return http.get<FetchTablesResponse>(accountId, {
     url: `${HUBDB_API_PATH}/tables`,
   });
@@ -22,7 +22,7 @@ export function fetchTables(
 export function fetchTable(
   accountId: number,
   tableId: string
-): HubSpotResponse<Table> {
+): HubSpotPromise<Table> {
   return http.get<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}`,
   });
@@ -31,7 +31,7 @@ export function fetchTable(
 export function createTable(
   accountId: number,
   schema: Schema
-): HubSpotResponse<Table> {
+): HubSpotPromise<Table> {
   return http.post<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables`,
     data: schema,
@@ -42,7 +42,7 @@ export function updateTable(
   accountId: number,
   tableId: string,
   schema: Schema
-): HubSpotResponse<Table> {
+): HubSpotPromise<Table> {
   return http.patch<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/draft`,
     data: schema,
@@ -52,7 +52,7 @@ export function updateTable(
 export function publishTable(
   accountId: number,
   tableId: string
-): HubSpotResponse<Table> {
+): HubSpotPromise<Table> {
   return http.post<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/draft/publish`,
     headers: {
@@ -64,7 +64,7 @@ export function publishTable(
 export function deleteTable(
   accountId: number,
   tableId: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.delete(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}`,
   });
@@ -74,7 +74,7 @@ export function createRows(
   accountId: number,
   tableId: string,
   rows: Array<Row>
-): HubSpotResponse<CreateRowsResponse> {
+): HubSpotPromise<CreateRowsResponse> {
   return http.post<CreateRowsResponse>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/create`,
     data: { inputs: rows },
@@ -85,7 +85,7 @@ export function fetchRows(
   accountId: number,
   tableId: string,
   params: QueryParams = {}
-): HubSpotResponse<FetchRowsResponse> {
+): HubSpotPromise<FetchRowsResponse> {
   return http.get<FetchRowsResponse>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft`,
     params,
@@ -96,7 +96,7 @@ export function deleteRows(
   accountId: number,
   tableId: string,
   rowIds: Array<string>
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.post(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/purge`,
     data: { inputs: rowIds },

--- a/api/hubdb.ts
+++ b/api/hubdb.ts
@@ -1,5 +1,5 @@
-import { http, HubSpotPromise } from '../http';
-import { QueryParams } from '../types/Http';
+import { http } from '../http';
+import { HubSpotPromise, QueryParams } from '../types/Http';
 import {
   CreateRowsResponse,
   FetchRowsResponse,

--- a/api/hubdb.ts
+++ b/api/hubdb.ts
@@ -1,5 +1,4 @@
-import { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import { QueryParams } from '../types/Http';
 import {
   CreateRowsResponse,
@@ -14,7 +13,7 @@ const HUBDB_API_PATH = 'cms/v3/hubdb';
 
 export function fetchTables(
   accountId: number
-): AxiosPromise<FetchTablesResponse> {
+): HubSpotResponse<FetchTablesResponse> {
   return http.get<FetchTablesResponse>(accountId, {
     url: `${HUBDB_API_PATH}/tables`,
   });
@@ -23,7 +22,7 @@ export function fetchTables(
 export function fetchTable(
   accountId: number,
   tableId: string
-): AxiosPromise<Table> {
+): HubSpotResponse<Table> {
   return http.get<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}`,
   });
@@ -32,7 +31,7 @@ export function fetchTable(
 export function createTable(
   accountId: number,
   schema: Schema
-): AxiosPromise<Table> {
+): HubSpotResponse<Table> {
   return http.post<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables`,
     data: schema,
@@ -43,7 +42,7 @@ export function updateTable(
   accountId: number,
   tableId: string,
   schema: Schema
-): AxiosPromise<Table> {
+): HubSpotResponse<Table> {
   return http.patch<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/draft`,
     data: schema,
@@ -53,7 +52,7 @@ export function updateTable(
 export function publishTable(
   accountId: number,
   tableId: string
-): AxiosPromise<Table> {
+): HubSpotResponse<Table> {
   return http.post<Table>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/draft/publish`,
     headers: {
@@ -65,7 +64,7 @@ export function publishTable(
 export function deleteTable(
   accountId: number,
   tableId: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.delete(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}`,
   });
@@ -75,7 +74,7 @@ export function createRows(
   accountId: number,
   tableId: string,
   rows: Array<Row>
-): AxiosPromise<CreateRowsResponse> {
+): HubSpotResponse<CreateRowsResponse> {
   return http.post<CreateRowsResponse>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/create`,
     data: { inputs: rows },
@@ -86,7 +85,7 @@ export function fetchRows(
   accountId: number,
   tableId: string,
   params: QueryParams = {}
-): AxiosPromise<FetchRowsResponse> {
+): HubSpotResponse<FetchRowsResponse> {
   return http.get<FetchRowsResponse>(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft`,
     params,
@@ -97,7 +96,7 @@ export function deleteRows(
   accountId: number,
   tableId: string,
   rowIds: Array<string>
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.post(accountId, {
     url: `${HUBDB_API_PATH}/tables/${tableId}/rows/draft/batch/purge`,
     data: { inputs: rowIds },

--- a/api/lighthouseScore.ts
+++ b/api/lighthouseScore.ts
@@ -1,5 +1,5 @@
-import { http, HubSpotPromise } from '../http';
-import { Data, QueryParams } from '../types/Http';
+import { http } from '../http';
+import { Data, HubSpotPromise, QueryParams } from '../types/Http';
 import {
   GetLighthouseScoreResponse,
   RequestLighthouseScoreResponse,

--- a/api/lighthouseScore.ts
+++ b/api/lighthouseScore.ts
@@ -1,4 +1,4 @@
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { Data, QueryParams } from '../types/Http';
 import {
   GetLighthouseScoreResponse,
@@ -10,7 +10,7 @@ const LIGHTHOUSE_SCORE_API_BASE = 'quality-engine/v1/lighthouse';
 export function requestLighthouseScore(
   accountId: number,
   data: Data = {}
-): HubSpotResponse<RequestLighthouseScoreResponse> {
+): HubSpotPromise<RequestLighthouseScoreResponse> {
   return http.post<RequestLighthouseScoreResponse>(accountId, {
     url: `${LIGHTHOUSE_SCORE_API_BASE}/request`,
     data,
@@ -20,7 +20,7 @@ export function requestLighthouseScore(
 export function getLighthouseScoreStatus(
   accountId: number,
   params: QueryParams = {}
-): HubSpotResponse<string> {
+): HubSpotPromise<string> {
   return http.get<string>(accountId, {
     url: `${LIGHTHOUSE_SCORE_API_BASE}/status`,
     params,
@@ -30,7 +30,7 @@ export function getLighthouseScoreStatus(
 export function getLighthouseScore(
   accountId: number,
   params: QueryParams = {}
-): HubSpotResponse<GetLighthouseScoreResponse> {
+): HubSpotPromise<GetLighthouseScoreResponse> {
   return http.get<GetLighthouseScoreResponse>(accountId, {
     url: `${LIGHTHOUSE_SCORE_API_BASE}/scores`,
     params,

--- a/api/lighthouseScore.ts
+++ b/api/lighthouseScore.ts
@@ -1,5 +1,4 @@
-import { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import { Data, QueryParams } from '../types/Http';
 import {
   GetLighthouseScoreResponse,
@@ -11,7 +10,7 @@ const LIGHTHOUSE_SCORE_API_BASE = 'quality-engine/v1/lighthouse';
 export function requestLighthouseScore(
   accountId: number,
   data: Data = {}
-): AxiosPromise<RequestLighthouseScoreResponse> {
+): HubSpotResponse<RequestLighthouseScoreResponse> {
   return http.post<RequestLighthouseScoreResponse>(accountId, {
     url: `${LIGHTHOUSE_SCORE_API_BASE}/request`,
     data,
@@ -21,7 +20,7 @@ export function requestLighthouseScore(
 export function getLighthouseScoreStatus(
   accountId: number,
   params: QueryParams = {}
-): AxiosPromise<string> {
+): HubSpotResponse<string> {
   return http.get<string>(accountId, {
     url: `${LIGHTHOUSE_SCORE_API_BASE}/status`,
     params,
@@ -31,7 +30,7 @@ export function getLighthouseScoreStatus(
 export function getLighthouseScore(
   accountId: number,
   params: QueryParams = {}
-): AxiosPromise<GetLighthouseScoreResponse> {
+): HubSpotResponse<GetLighthouseScoreResponse> {
   return http.get<GetLighthouseScoreResponse>(accountId, {
     url: `${LIGHTHOUSE_SCORE_API_BASE}/scores`,
     params,

--- a/api/localDevAuth.ts
+++ b/api/localDevAuth.ts
@@ -1,6 +1,5 @@
-import { AxiosPromise } from 'axios';
 import { getAxiosConfig } from '../http/getAxiosConfig';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import { ENVIRONMENTS } from '../constants/environments';
 import { Environment } from '../types/Config';
 import {
@@ -17,7 +16,7 @@ export function fetchAccessToken(
   personalAccessKey: string,
   env: Environment = ENVIRONMENTS.PROD,
   portalId?: number
-): AxiosPromise<AccessTokenResponse> {
+): HubSpotResponse<AccessTokenResponse> {
   const axiosConfig = getAxiosConfig({
     env,
     localHostOverride: true,
@@ -37,7 +36,7 @@ export function fetchAccessToken(
 export function fetchScopeData(
   accountId: number,
   scopeGroup: string
-): AxiosPromise<ScopeData> {
+): HubSpotResponse<ScopeData> {
   return http.get<ScopeData>(accountId, {
     url: `${LOCALDEVAUTH_API_AUTH_PATH}/check-scopes`,
     params: { scopeGroup },
@@ -50,7 +49,7 @@ export function fetchAppInstallationData(
   appUid: string,
   requiredScopeGroups: Array<string>,
   optionalScopeGroups: Array<string> = []
-): AxiosPromise<PublicAppInstallationData> {
+): HubSpotResponse<PublicAppInstallationData> {
   return http.post<PublicAppInstallationData>(portalId, {
     url: `${LOCALDEVAUTH_API_AUTH_PATH}/install-info`,
     data: {

--- a/api/localDevAuth.ts
+++ b/api/localDevAuth.ts
@@ -1,5 +1,5 @@
 import { getAxiosConfig } from '../http/getAxiosConfig';
-import { http, HubSpotPromise } from '../http';
+import { http } from '../http';
 import { ENVIRONMENTS } from '../constants/environments';
 import { Environment } from '../types/Config';
 import {
@@ -9,6 +9,7 @@ import {
 } from '../types/Accounts';
 import axios from 'axios';
 import { PublicAppInstallationData } from '../types/Apps';
+import { HubSpotPromise } from '../types/Http';
 
 const LOCALDEVAUTH_API_AUTH_PATH = 'localdevauth/v1/auth';
 

--- a/api/localDevAuth.ts
+++ b/api/localDevAuth.ts
@@ -1,5 +1,5 @@
 import { getAxiosConfig } from '../http/getAxiosConfig';
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { ENVIRONMENTS } from '../constants/environments';
 import { Environment } from '../types/Config';
 import {
@@ -16,7 +16,7 @@ export function fetchAccessToken(
   personalAccessKey: string,
   env: Environment = ENVIRONMENTS.PROD,
   portalId?: number
-): HubSpotResponse<AccessTokenResponse> {
+): HubSpotPromise<AccessTokenResponse> {
   const axiosConfig = getAxiosConfig({
     env,
     localHostOverride: true,
@@ -36,7 +36,7 @@ export function fetchAccessToken(
 export function fetchScopeData(
   accountId: number,
   scopeGroup: string
-): HubSpotResponse<ScopeData> {
+): HubSpotPromise<ScopeData> {
   return http.get<ScopeData>(accountId, {
     url: `${LOCALDEVAUTH_API_AUTH_PATH}/check-scopes`,
     params: { scopeGroup },
@@ -49,7 +49,7 @@ export function fetchAppInstallationData(
   appUid: string,
   requiredScopeGroups: Array<string>,
   optionalScopeGroups: Array<string> = []
-): HubSpotResponse<PublicAppInstallationData> {
+): HubSpotPromise<PublicAppInstallationData> {
   return http.post<PublicAppInstallationData>(portalId, {
     url: `${LOCALDEVAUTH_API_AUTH_PATH}/install-info`,
     data: {

--- a/api/marketplaceValidation.ts
+++ b/api/marketplaceValidation.ts
@@ -1,5 +1,5 @@
-import { http, HubSpotPromise } from '../http';
-import { Data, QueryParams } from '../types/Http';
+import { http } from '../http';
+import { Data, HubSpotPromise, QueryParams } from '../types/Http';
 import { GetValidationResultsResponse } from '../types/MarketplaceValidation';
 
 const VALIDATION_API_BASE = 'quality-engine/v1/validation';

--- a/api/marketplaceValidation.ts
+++ b/api/marketplaceValidation.ts
@@ -1,4 +1,4 @@
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { Data, QueryParams } from '../types/Http';
 import { GetValidationResultsResponse } from '../types/MarketplaceValidation';
 
@@ -7,7 +7,7 @@ const VALIDATION_API_BASE = 'quality-engine/v1/validation';
 export function requestValidation(
   accountId: number,
   data: Data = {}
-): HubSpotResponse<number> {
+): HubSpotPromise<number> {
   return http.post<number>(accountId, {
     url: `${VALIDATION_API_BASE}/request`,
     data,
@@ -17,7 +17,7 @@ export function requestValidation(
 export function getValidationStatus(
   accountId: number,
   params: QueryParams = {}
-): HubSpotResponse<string> {
+): HubSpotPromise<string> {
   return http.get<string>(accountId, {
     url: `${VALIDATION_API_BASE}/status`,
     params,
@@ -27,7 +27,7 @@ export function getValidationStatus(
 export function getValidationResults(
   accountId: number,
   params: QueryParams = {}
-): HubSpotResponse<GetValidationResultsResponse> {
+): HubSpotPromise<GetValidationResultsResponse> {
   return http.get<GetValidationResultsResponse>(accountId, {
     url: `${VALIDATION_API_BASE}/results`,
     params,

--- a/api/marketplaceValidation.ts
+++ b/api/marketplaceValidation.ts
@@ -1,5 +1,4 @@
-import { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import { Data, QueryParams } from '../types/Http';
 import { GetValidationResultsResponse } from '../types/MarketplaceValidation';
 
@@ -8,7 +7,7 @@ const VALIDATION_API_BASE = 'quality-engine/v1/validation';
 export function requestValidation(
   accountId: number,
   data: Data = {}
-): AxiosPromise<number> {
+): HubSpotResponse<number> {
   return http.post<number>(accountId, {
     url: `${VALIDATION_API_BASE}/request`,
     data,
@@ -18,7 +17,7 @@ export function requestValidation(
 export function getValidationStatus(
   accountId: number,
   params: QueryParams = {}
-): AxiosPromise<string> {
+): HubSpotResponse<string> {
   return http.get<string>(accountId, {
     url: `${VALIDATION_API_BASE}/status`,
     params,
@@ -28,7 +27,7 @@ export function getValidationStatus(
 export function getValidationResults(
   accountId: number,
   params: QueryParams = {}
-): AxiosPromise<GetValidationResultsResponse> {
+): HubSpotResponse<GetValidationResultsResponse> {
   return http.get<GetValidationResultsResponse>(accountId, {
     url: `${VALIDATION_API_BASE}/results`,
     params,

--- a/api/projects.ts
+++ b/api/projects.ts
@@ -1,4 +1,4 @@
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import fs from 'fs';
 import { FormData, QueryParams } from '../types/Http';
 import {
@@ -30,7 +30,7 @@ const MIGRATIONS_API_PATH = 'dfs/migrations/v1';
 
 export function fetchProjects(
   accountId: number
-): HubSpotResponse<FetchProjectResponse> {
+): HubSpotPromise<FetchProjectResponse> {
   return http.get<FetchProjectResponse>(accountId, {
     url: DEVELOPER_PROJECTS_API_PATH,
   });
@@ -39,7 +39,7 @@ export function fetchProjects(
 export function createProject(
   accountId: number,
   name: string
-): HubSpotResponse<Project> {
+): HubSpotPromise<Project> {
   return http.post<Project>(accountId, {
     url: DEVELOPER_PROJECTS_API_PATH,
     data: {
@@ -54,7 +54,7 @@ export function uploadProject(
   projectFile: string,
   uploadMessage: string,
   platformVersion?: string
-): HubSpotResponse<UploadProjectResponse> {
+): HubSpotPromise<UploadProjectResponse> {
   const formData: FormData = {
     file: fs.createReadStream(projectFile),
     uploadMessage,
@@ -74,7 +74,7 @@ export function uploadProject(
 export function fetchProject(
   accountId: number,
   projectName: string
-): HubSpotResponse<Project> {
+): HubSpotPromise<Project> {
   return http.get<Project>(accountId, {
     url: `${DEVELOPER_PROJECTS_API_PATH}/by-name/${encodeURIComponent(projectName)}`,
   });
@@ -83,7 +83,7 @@ export function fetchProject(
 export async function fetchProjectComponentsMetadata(
   accountId: number,
   projectId: number
-): HubSpotResponse<ProjectComponentsMetadata> {
+): HubSpotPromise<ProjectComponentsMetadata> {
   return http.get(accountId, {
     url: `${DEVELOPER_FILE_SYSTEM_PATH}/projects-deployed-build/${projectId}`,
   });
@@ -93,7 +93,7 @@ export async function downloadProject(
   accountId: number,
   projectName: string,
   buildId: number
-): HubSpotResponse<Buffer> {
+): HubSpotPromise<Buffer> {
   return http.get<Buffer>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -106,7 +106,7 @@ export async function downloadProject(
 export function deleteProject(
   accountId: number,
   projectName: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.delete(accountId, {
     url: `${DEVELOPER_PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
   });
@@ -114,7 +114,7 @@ export function deleteProject(
 
 export function fetchPlatformVersions(
   accountId: number
-): HubSpotResponse<FetchPlatformVersionResponse> {
+): HubSpotPromise<FetchPlatformVersionResponse> {
   return http.get<FetchPlatformVersionResponse>(accountId, {
     url: `${DEVELOPER_PROJECTS_API_PATH}/platformVersion`,
   });
@@ -124,7 +124,7 @@ export function fetchProjectBuilds(
   accountId: number,
   projectName: string,
   params: QueryParams = {}
-): HubSpotResponse<FetchProjectBuildsResponse> {
+): HubSpotPromise<FetchProjectBuildsResponse> {
   return http.get<FetchProjectBuildsResponse>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/builds`,
     params,
@@ -135,7 +135,7 @@ export function getBuildStatus(
   accountId: number,
   projectName: string,
   buildId: number
-): HubSpotResponse<Build> {
+): HubSpotPromise<Build> {
   return http.get<Build>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -147,7 +147,7 @@ export function getBuildStructure(
   accountId: number,
   projectName: string,
   buildId: number
-): HubSpotResponse<ComponentStructureResponse> {
+): HubSpotPromise<ComponentStructureResponse> {
   return http.get<ComponentStructureResponse>(accountId, {
     url: `dfs/v1/builds/by-project-name/${encodeURIComponent(
       projectName
@@ -159,7 +159,7 @@ export function deployProject(
   accountId: number,
   projectName: string,
   buildId: number
-): HubSpotResponse<ProjectDeployResponse> {
+): HubSpotPromise<ProjectDeployResponse> {
   return http.post<ProjectDeployResponse>(accountId, {
     url: `${PROJECTS_DEPLOY_API_PATH}/deploys/queue/async`,
     data: {
@@ -173,7 +173,7 @@ export function getDeployStatus(
   accountId: number,
   projectName: string,
   deployId: number
-): HubSpotResponse<Deploy> {
+): HubSpotPromise<Deploy> {
   return http.get<Deploy>(accountId, {
     url: `${PROJECTS_DEPLOY_API_PATH}/deploy-status/projects/${encodeURIComponent(
       projectName
@@ -185,7 +185,7 @@ export function getDeployStructure(
   accountId: number,
   projectName: string,
   deployId: number
-): HubSpotResponse<ComponentStructureResponse> {
+): HubSpotPromise<ComponentStructureResponse> {
   return http.get<ComponentStructureResponse>(accountId, {
     url: `${PROJECTS_DEPLOY_API_PATH}/deploys/by-project-name/${encodeURIComponent(
       projectName
@@ -196,7 +196,7 @@ export function getDeployStructure(
 export function fetchProjectSettings(
   accountId: number,
   projectName: string
-): HubSpotResponse<ProjectSettings> {
+): HubSpotPromise<ProjectSettings> {
   return http.get<ProjectSettings>(accountId, {
     url: `${DEVELOPER_PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/settings`,
   });
@@ -206,7 +206,7 @@ export async function provisionBuild(
   accountId: number,
   projectName: string,
   platformVersion?: string
-): HubSpotResponse<Build> {
+): HubSpotPromise<Build> {
   return http.post<Build>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -221,7 +221,7 @@ export function queueBuild(
   accountId: number,
   projectName: string,
   platformVersion?: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.post(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -236,7 +236,7 @@ export function uploadFileToBuild(
   projectName: string,
   filePath: string,
   path: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.put(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -252,7 +252,7 @@ export function deleteFileFromBuild(
   accountId: number,
   projectName: string,
   path: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.delete(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -263,7 +263,7 @@ export function deleteFileFromBuild(
 export function cancelStagedBuild(
   accountId: number,
   projectName: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.post(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -280,7 +280,7 @@ export function fetchBuildWarnLogs(
   accountId: number,
   projectName: string,
   buildId: number
-): HubSpotResponse<WarnLogsResponse> {
+): HubSpotPromise<WarnLogsResponse> {
   return http.get<WarnLogsResponse>(accountId, {
     url: `${PROJECTS_LOGS_API_PATH}/logs/projects/${encodeURIComponent(
       projectName
@@ -292,7 +292,7 @@ export function fetchDeployWarnLogs(
   accountId: number,
   projectName: string,
   deployId: number
-): HubSpotResponse<WarnLogsResponse> {
+): HubSpotPromise<WarnLogsResponse> {
   return http.get<WarnLogsResponse>(accountId, {
     url: `${PROJECTS_LOGS_API_PATH}/logs/projects/${encodeURIComponent(
       projectName
@@ -304,7 +304,7 @@ export function migrateApp(
   accountId: number,
   appId: number,
   projectName: string
-): HubSpotResponse<MigrateAppResponse> {
+): HubSpotPromise<MigrateAppResponse> {
   return http.post<MigrateAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/migrations`,
     data: {
@@ -318,7 +318,7 @@ export function migrateApp(
 export function checkMigrationStatus(
   accountId: number,
   id: number
-): HubSpotResponse<PollAppResponse> {
+): HubSpotPromise<PollAppResponse> {
   return http.get<PollAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/migrations/${id}`,
   });
@@ -327,7 +327,7 @@ export function checkMigrationStatus(
 export function cloneApp(
   accountId: number,
   appId: number
-): HubSpotResponse<CloneAppResponse> {
+): HubSpotPromise<CloneAppResponse> {
   return http.post<CloneAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/exports`,
     data: {
@@ -340,7 +340,7 @@ export function cloneApp(
 export function checkCloneStatus(
   accountId: number,
   exportId: number
-): HubSpotResponse<CloneAppResponse> {
+): HubSpotPromise<CloneAppResponse> {
   return http.get<CloneAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/exports/${exportId}/status`,
   });
@@ -349,7 +349,7 @@ export function checkCloneStatus(
 export function downloadClonedProject(
   accountId: number,
   exportId: number
-): HubSpotResponse<Buffer> {
+): HubSpotPromise<Buffer> {
   return http.get<Buffer>(accountId, {
     url: `${MIGRATIONS_API_PATH}/exports/${exportId}/download-as-clone`,
     responseType: 'arraybuffer',

--- a/api/projects.ts
+++ b/api/projects.ts
@@ -1,5 +1,4 @@
-import { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import fs from 'fs';
 import { FormData, QueryParams } from '../types/Http';
 import {
@@ -31,7 +30,7 @@ const MIGRATIONS_API_PATH = 'dfs/migrations/v1';
 
 export function fetchProjects(
   accountId: number
-): AxiosPromise<FetchProjectResponse> {
+): HubSpotResponse<FetchProjectResponse> {
   return http.get<FetchProjectResponse>(accountId, {
     url: DEVELOPER_PROJECTS_API_PATH,
   });
@@ -40,7 +39,7 @@ export function fetchProjects(
 export function createProject(
   accountId: number,
   name: string
-): AxiosPromise<Project> {
+): HubSpotResponse<Project> {
   return http.post<Project>(accountId, {
     url: DEVELOPER_PROJECTS_API_PATH,
     data: {
@@ -55,7 +54,7 @@ export function uploadProject(
   projectFile: string,
   uploadMessage: string,
   platformVersion?: string
-): AxiosPromise<UploadProjectResponse> {
+): HubSpotResponse<UploadProjectResponse> {
   const formData: FormData = {
     file: fs.createReadStream(projectFile),
     uploadMessage,
@@ -75,7 +74,7 @@ export function uploadProject(
 export function fetchProject(
   accountId: number,
   projectName: string
-): AxiosPromise<Project> {
+): HubSpotResponse<Project> {
   return http.get<Project>(accountId, {
     url: `${DEVELOPER_PROJECTS_API_PATH}/by-name/${encodeURIComponent(projectName)}`,
   });
@@ -84,7 +83,7 @@ export function fetchProject(
 export async function fetchProjectComponentsMetadata(
   accountId: number,
   projectId: number
-): AxiosPromise<ProjectComponentsMetadata> {
+): HubSpotResponse<ProjectComponentsMetadata> {
   return http.get(accountId, {
     url: `${DEVELOPER_FILE_SYSTEM_PATH}/projects-deployed-build/${projectId}`,
   });
@@ -94,7 +93,7 @@ export async function downloadProject(
   accountId: number,
   projectName: string,
   buildId: number
-): AxiosPromise<Buffer> {
+): HubSpotResponse<Buffer> {
   return http.get<Buffer>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -107,7 +106,7 @@ export async function downloadProject(
 export function deleteProject(
   accountId: number,
   projectName: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.delete(accountId, {
     url: `${DEVELOPER_PROJECTS_API_PATH}/${encodeURIComponent(projectName)}`,
   });
@@ -115,7 +114,7 @@ export function deleteProject(
 
 export function fetchPlatformVersions(
   accountId: number
-): AxiosPromise<FetchPlatformVersionResponse> {
+): HubSpotResponse<FetchPlatformVersionResponse> {
   return http.get<FetchPlatformVersionResponse>(accountId, {
     url: `${DEVELOPER_PROJECTS_API_PATH}/platformVersion`,
   });
@@ -125,7 +124,7 @@ export function fetchProjectBuilds(
   accountId: number,
   projectName: string,
   params: QueryParams = {}
-): AxiosPromise<FetchProjectBuildsResponse> {
+): HubSpotResponse<FetchProjectBuildsResponse> {
   return http.get<FetchProjectBuildsResponse>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/builds`,
     params,
@@ -136,7 +135,7 @@ export function getBuildStatus(
   accountId: number,
   projectName: string,
   buildId: number
-): AxiosPromise<Build> {
+): HubSpotResponse<Build> {
   return http.get<Build>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -148,7 +147,7 @@ export function getBuildStructure(
   accountId: number,
   projectName: string,
   buildId: number
-): AxiosPromise<ComponentStructureResponse> {
+): HubSpotResponse<ComponentStructureResponse> {
   return http.get<ComponentStructureResponse>(accountId, {
     url: `dfs/v1/builds/by-project-name/${encodeURIComponent(
       projectName
@@ -160,7 +159,7 @@ export function deployProject(
   accountId: number,
   projectName: string,
   buildId: number
-): AxiosPromise<ProjectDeployResponse> {
+): HubSpotResponse<ProjectDeployResponse> {
   return http.post<ProjectDeployResponse>(accountId, {
     url: `${PROJECTS_DEPLOY_API_PATH}/deploys/queue/async`,
     data: {
@@ -174,7 +173,7 @@ export function getDeployStatus(
   accountId: number,
   projectName: string,
   deployId: number
-): AxiosPromise<Deploy> {
+): HubSpotResponse<Deploy> {
   return http.get<Deploy>(accountId, {
     url: `${PROJECTS_DEPLOY_API_PATH}/deploy-status/projects/${encodeURIComponent(
       projectName
@@ -186,7 +185,7 @@ export function getDeployStructure(
   accountId: number,
   projectName: string,
   deployId: number
-): AxiosPromise<ComponentStructureResponse> {
+): HubSpotResponse<ComponentStructureResponse> {
   return http.get<ComponentStructureResponse>(accountId, {
     url: `${PROJECTS_DEPLOY_API_PATH}/deploys/by-project-name/${encodeURIComponent(
       projectName
@@ -197,7 +196,7 @@ export function getDeployStructure(
 export function fetchProjectSettings(
   accountId: number,
   projectName: string
-): AxiosPromise<ProjectSettings> {
+): HubSpotResponse<ProjectSettings> {
   return http.get<ProjectSettings>(accountId, {
     url: `${DEVELOPER_PROJECTS_API_PATH}/${encodeURIComponent(projectName)}/settings`,
   });
@@ -207,7 +206,7 @@ export async function provisionBuild(
   accountId: number,
   projectName: string,
   platformVersion?: string
-): AxiosPromise<Build> {
+): HubSpotResponse<Build> {
   return http.post<Build>(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -222,7 +221,7 @@ export function queueBuild(
   accountId: number,
   projectName: string,
   platformVersion?: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.post(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -237,7 +236,7 @@ export function uploadFileToBuild(
   projectName: string,
   filePath: string,
   path: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.put(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -253,7 +252,7 @@ export function deleteFileFromBuild(
   accountId: number,
   projectName: string,
   path: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.delete(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -264,7 +263,7 @@ export function deleteFileFromBuild(
 export function cancelStagedBuild(
   accountId: number,
   projectName: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.post(accountId, {
     url: `${PROJECTS_API_PATH}/${encodeURIComponent(
       projectName
@@ -281,7 +280,7 @@ export function fetchBuildWarnLogs(
   accountId: number,
   projectName: string,
   buildId: number
-): AxiosPromise<WarnLogsResponse> {
+): HubSpotResponse<WarnLogsResponse> {
   return http.get<WarnLogsResponse>(accountId, {
     url: `${PROJECTS_LOGS_API_PATH}/logs/projects/${encodeURIComponent(
       projectName
@@ -293,7 +292,7 @@ export function fetchDeployWarnLogs(
   accountId: number,
   projectName: string,
   deployId: number
-): AxiosPromise<WarnLogsResponse> {
+): HubSpotResponse<WarnLogsResponse> {
   return http.get<WarnLogsResponse>(accountId, {
     url: `${PROJECTS_LOGS_API_PATH}/logs/projects/${encodeURIComponent(
       projectName
@@ -305,7 +304,7 @@ export function migrateApp(
   accountId: number,
   appId: number,
   projectName: string
-): AxiosPromise<MigrateAppResponse> {
+): HubSpotResponse<MigrateAppResponse> {
   return http.post<MigrateAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/migrations`,
     data: {
@@ -319,7 +318,7 @@ export function migrateApp(
 export function checkMigrationStatus(
   accountId: number,
   id: number
-): AxiosPromise<PollAppResponse> {
+): HubSpotResponse<PollAppResponse> {
   return http.get<PollAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/migrations/${id}`,
   });
@@ -328,7 +327,7 @@ export function checkMigrationStatus(
 export function cloneApp(
   accountId: number,
   appId: number
-): AxiosPromise<CloneAppResponse> {
+): HubSpotResponse<CloneAppResponse> {
   return http.post<CloneAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/exports`,
     data: {
@@ -341,7 +340,7 @@ export function cloneApp(
 export function checkCloneStatus(
   accountId: number,
   exportId: number
-): AxiosPromise<CloneAppResponse> {
+): HubSpotResponse<CloneAppResponse> {
   return http.get<CloneAppResponse>(accountId, {
     url: `${MIGRATIONS_API_PATH}/exports/${exportId}/status`,
   });
@@ -350,7 +349,7 @@ export function checkCloneStatus(
 export function downloadClonedProject(
   accountId: number,
   exportId: number
-): AxiosPromise<Buffer> {
+): HubSpotResponse<Buffer> {
   return http.get<Buffer>(accountId, {
     url: `${MIGRATIONS_API_PATH}/exports/${exportId}/download-as-clone`,
     responseType: 'arraybuffer',

--- a/api/projects.ts
+++ b/api/projects.ts
@@ -1,6 +1,6 @@
-import { http, HubSpotPromise } from '../http';
+import { http } from '../http';
 import fs from 'fs';
-import { FormData, QueryParams } from '../types/Http';
+import { FormData, HubSpotPromise, QueryParams } from '../types/Http';
 import {
   Project,
   FetchProjectResponse,

--- a/api/sandboxHubs.ts
+++ b/api/sandboxHubs.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import { getAxiosConfig } from '../http/getAxiosConfig';
 import { ENVIRONMENTS } from '../constants/environments';
 import { SANDBOX_TIMEOUT } from '../constants/api';
@@ -17,7 +17,7 @@ export function createSandbox(
   accountId: number,
   name: string,
   type: 1 | 2
-): AxiosPromise<SandboxResponse> {
+): HubSpotResponse<SandboxResponse> {
   return http.post<SandboxResponse>(accountId, {
     data: { name, type, generatePersonalAccessKey: true }, // For CLI, generatePersonalAccessKey will always be true since we'll be saving the entry to the config
     timeout: SANDBOX_TIMEOUT,
@@ -28,7 +28,7 @@ export function createSandbox(
 export function deleteSandbox(
   parentAccountId: number,
   sandboxAccountId: number
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.delete(parentAccountId, {
     url: `${SANDBOX_API_PATH}/${sandboxAccountId}`,
   });
@@ -36,7 +36,7 @@ export function deleteSandbox(
 
 export function getSandboxUsageLimits(
   parentAccountId: number
-): AxiosPromise<SandboxUsageLimitsResponse> {
+): HubSpotResponse<SandboxUsageLimitsResponse> {
   return http.get<SandboxUsageLimitsResponse>(parentAccountId, {
     url: `${SANDBOX_API_PATH}/parent/${parentAccountId}/usage`,
   });

--- a/api/sandboxHubs.ts
+++ b/api/sandboxHubs.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosPromise } from 'axios';
-import { http, HubSpotPromise } from '../http';
+import { http } from '../http';
 import { getAxiosConfig } from '../http/getAxiosConfig';
 import { ENVIRONMENTS } from '../constants/environments';
 import { SANDBOX_TIMEOUT } from '../constants/api';
@@ -9,6 +9,7 @@ import {
   SandboxResponse,
   SandboxUsageLimitsResponse,
 } from '../types/Sandbox';
+import { HubSpotPromise } from '../types/Http';
 
 const SANDBOX_API_PATH = 'sandbox-hubs/v1';
 const SANDBOX_API_PATH_V2 = 'sandbox-hubs/v2';

--- a/api/sandboxHubs.ts
+++ b/api/sandboxHubs.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosPromise } from 'axios';
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { getAxiosConfig } from '../http/getAxiosConfig';
 import { ENVIRONMENTS } from '../constants/environments';
 import { SANDBOX_TIMEOUT } from '../constants/api';
@@ -17,7 +17,7 @@ export function createSandbox(
   accountId: number,
   name: string,
   type: 1 | 2
-): HubSpotResponse<SandboxResponse> {
+): HubSpotPromise<SandboxResponse> {
   return http.post<SandboxResponse>(accountId, {
     data: { name, type, generatePersonalAccessKey: true }, // For CLI, generatePersonalAccessKey will always be true since we'll be saving the entry to the config
     timeout: SANDBOX_TIMEOUT,
@@ -28,7 +28,7 @@ export function createSandbox(
 export function deleteSandbox(
   parentAccountId: number,
   sandboxAccountId: number
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.delete(parentAccountId, {
     url: `${SANDBOX_API_PATH}/${sandboxAccountId}`,
   });
@@ -36,7 +36,7 @@ export function deleteSandbox(
 
 export function getSandboxUsageLimits(
   parentAccountId: number
-): HubSpotResponse<SandboxUsageLimitsResponse> {
+): HubSpotPromise<SandboxUsageLimitsResponse> {
   return http.get<SandboxUsageLimitsResponse>(parentAccountId, {
     url: `${SANDBOX_API_PATH}/parent/${parentAccountId}/usage`,
   });

--- a/api/sandboxSync.ts
+++ b/api/sandboxSync.ts
@@ -1,10 +1,11 @@
-import { http, HubSpotPromise } from '../http';
+import { http } from '../http';
 import {
   InitiateSyncResponse,
   FetchTypesResponse,
   TaskRequestData,
 } from '../types/Sandbox';
 import { SANDBOX_TIMEOUT } from '../constants/api';
+import { HubSpotPromise } from '../types/Http';
 const SANDBOXES_SYNC_API_PATH = 'sandboxes-sync/v1';
 
 export async function initiateSync(

--- a/api/sandboxSync.ts
+++ b/api/sandboxSync.ts
@@ -1,5 +1,4 @@
-import { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import {
   InitiateSyncResponse,
   FetchTypesResponse,
@@ -8,12 +7,12 @@ import {
 import { SANDBOX_TIMEOUT } from '../constants/api';
 const SANDBOXES_SYNC_API_PATH = 'sandboxes-sync/v1';
 
-export function initiateSync(
+export async function initiateSync(
   fromHubId: number,
   toHubId: number,
   tasks: Array<TaskRequestData>,
   sandboxHubId: number
-): AxiosPromise<InitiateSyncResponse> {
+): HubSpotResponse<InitiateSyncResponse> {
   return http.post<InitiateSyncResponse>(fromHubId, {
     data: {
       command: 'SYNC',
@@ -30,7 +29,7 @@ export function initiateSync(
 export async function fetchTypes(
   accountId: number,
   toHubId: number
-): AxiosPromise<FetchTypesResponse> {
+): HubSpotResponse<FetchTypesResponse> {
   return http.get<FetchTypesResponse>(accountId, {
     url: `${SANDBOXES_SYNC_API_PATH}/types${
       toHubId ? `?toHubId=${toHubId}` : ''

--- a/api/sandboxSync.ts
+++ b/api/sandboxSync.ts
@@ -1,4 +1,4 @@
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import {
   InitiateSyncResponse,
   FetchTypesResponse,
@@ -12,7 +12,7 @@ export async function initiateSync(
   toHubId: number,
   tasks: Array<TaskRequestData>,
   sandboxHubId: number
-): HubSpotResponse<InitiateSyncResponse> {
+): HubSpotPromise<InitiateSyncResponse> {
   return http.post<InitiateSyncResponse>(fromHubId, {
     data: {
       command: 'SYNC',
@@ -29,7 +29,7 @@ export async function initiateSync(
 export async function fetchTypes(
   accountId: number,
   toHubId: number
-): HubSpotResponse<FetchTypesResponse> {
+): HubSpotPromise<FetchTypesResponse> {
   return http.get<FetchTypesResponse>(accountId, {
     url: `${SANDBOXES_SYNC_API_PATH}/types${
       toHubId ? `?toHubId=${toHubId}` : ''

--- a/api/secrets.ts
+++ b/api/secrets.ts
@@ -1,5 +1,4 @@
-import { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import { FetchSecretsResponse } from '../types/Secrets';
 
 const SECRETS_API_PATH = 'cms/v3/functions/secrets';
@@ -8,7 +7,7 @@ export function addSecret(
   accountId: number,
   key: string,
   value: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.post(accountId, {
     url: SECRETS_API_PATH,
     data: {
@@ -22,7 +21,7 @@ export function updateSecret(
   accountId: number,
   key: string,
   value: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.put(accountId, {
     url: SECRETS_API_PATH,
     data: {
@@ -35,7 +34,7 @@ export function updateSecret(
 export function deleteSecret(
   accountId: number,
   key: string
-): AxiosPromise<void> {
+): HubSpotResponse<void> {
   return http.delete(accountId, {
     url: `${SECRETS_API_PATH}/${key}`,
   });
@@ -43,7 +42,7 @@ export function deleteSecret(
 
 export function fetchSecrets(
   accountId: number
-): AxiosPromise<FetchSecretsResponse> {
+): HubSpotResponse<FetchSecretsResponse> {
   return http.get<FetchSecretsResponse>(accountId, {
     url: `${SECRETS_API_PATH}`,
   });

--- a/api/secrets.ts
+++ b/api/secrets.ts
@@ -1,4 +1,4 @@
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { FetchSecretsResponse } from '../types/Secrets';
 
 const SECRETS_API_PATH = 'cms/v3/functions/secrets';
@@ -7,7 +7,7 @@ export function addSecret(
   accountId: number,
   key: string,
   value: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.post(accountId, {
     url: SECRETS_API_PATH,
     data: {
@@ -21,7 +21,7 @@ export function updateSecret(
   accountId: number,
   key: string,
   value: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.put(accountId, {
     url: SECRETS_API_PATH,
     data: {
@@ -34,7 +34,7 @@ export function updateSecret(
 export function deleteSecret(
   accountId: number,
   key: string
-): HubSpotResponse<void> {
+): HubSpotPromise<void> {
   return http.delete(accountId, {
     url: `${SECRETS_API_PATH}/${key}`,
   });
@@ -42,7 +42,7 @@ export function deleteSecret(
 
 export function fetchSecrets(
   accountId: number
-): HubSpotResponse<FetchSecretsResponse> {
+): HubSpotPromise<FetchSecretsResponse> {
   return http.get<FetchSecretsResponse>(accountId, {
     url: `${SECRETS_API_PATH}`,
   });

--- a/api/secrets.ts
+++ b/api/secrets.ts
@@ -1,5 +1,6 @@
-import { http, HubSpotPromise } from '../http';
+import { http } from '../http';
 import { FetchSecretsResponse } from '../types/Secrets';
+import { HubSpotPromise } from '../types/Http';
 
 const SECRETS_API_PATH = 'cms/v3/functions/secrets';
 

--- a/api/validateHubl.ts
+++ b/api/validateHubl.ts
@@ -1,5 +1,6 @@
-import { http, HubSpotPromise } from '../http';
+import { http } from '../http';
 import { Validation, HublValidationOptions } from '../types/HublValidation';
+import { HubSpotPromise } from '../types/Http';
 
 const HUBL_VALIDATE_API_PATH = 'cos-rendering/v1/internal/validate';
 

--- a/api/validateHubl.ts
+++ b/api/validateHubl.ts
@@ -1,4 +1,4 @@
-import { http, HubSpotResponse } from '../http';
+import { http, HubSpotPromise } from '../http';
 import { Validation, HublValidationOptions } from '../types/HublValidation';
 
 const HUBL_VALIDATE_API_PATH = 'cos-rendering/v1/internal/validate';
@@ -7,7 +7,7 @@ export function validateHubl(
   accountId: number,
   sourceCode: string,
   hublValidationOptions?: HublValidationOptions
-): HubSpotResponse<Validation> {
+): HubSpotPromise<Validation> {
   return http.post<Validation>(accountId, {
     url: HUBL_VALIDATE_API_PATH,
     data: {

--- a/api/validateHubl.ts
+++ b/api/validateHubl.ts
@@ -1,5 +1,4 @@
-import { AxiosPromise } from 'axios';
-import { http } from '../http';
+import { http, HubSpotResponse } from '../http';
 import { Validation, HublValidationOptions } from '../types/HublValidation';
 
 const HUBL_VALIDATE_API_PATH = 'cos-rendering/v1/internal/validate';
@@ -8,7 +7,7 @@ export function validateHubl(
   accountId: number,
   sourceCode: string,
   hublValidationOptions?: HublValidationOptions
-): AxiosPromise<Validation> {
+): HubSpotResponse<Validation> {
   return http.post<Validation>(accountId, {
     url: HUBL_VALIDATE_API_PATH,
     data: {

--- a/http/index.ts
+++ b/http/index.ts
@@ -16,7 +16,7 @@ import { HubSpotHttpError } from '../models/HubSpotHttpError';
 
 const i18nKey = 'http.index';
 
-export type HubSpotResponse<T = unknown> = Promise<AxiosResponse<T>>;
+export type HubSpotResponse<T = unknown> = AxiosPromise<T>;
 
 axios.interceptors.response.use(undefined, error => {
   // Wrap all axios errors in our own Error class.  Attach the error

--- a/http/index.ts
+++ b/http/index.ts
@@ -16,7 +16,7 @@ import { HubSpotHttpError } from '../models/HubSpotHttpError';
 
 const i18nKey = 'http.index';
 
-export type HubSpotResponse<T = unknown> = AxiosPromise<T>;
+export type HubSpotPromise<T = unknown> = AxiosPromise<T>;
 
 axios.interceptors.response.use(undefined, error => {
   // Wrap all axios errors in our own Error class.  Attach the error
@@ -117,7 +117,7 @@ async function withAuth(
 async function getRequest<T>(
   accountId: number,
   options: HttpOptions
-): HubSpotResponse<T> {
+): HubSpotPromise<T> {
   const { params, ...rest } = options;
   const optionsWithParams = addQueryParams(rest, params);
   const requestConfig = await withAuth(accountId, optionsWithParams);
@@ -128,7 +128,7 @@ async function getRequest<T>(
 async function postRequest<T>(
   accountId: number,
   options: HttpOptions
-): HubSpotResponse<T> {
+): HubSpotPromise<T> {
   const requestConfig = await withAuth(accountId, options);
   return axios<T>({ ...requestConfig, method: 'post' });
 }
@@ -136,7 +136,7 @@ async function postRequest<T>(
 async function putRequest<T>(
   accountId: number,
   options: HttpOptions
-): HubSpotResponse<T> {
+): HubSpotPromise<T> {
   const requestConfig = await withAuth(accountId, options);
   return axios<T>({ ...requestConfig, method: 'put' });
 }
@@ -144,7 +144,7 @@ async function putRequest<T>(
 async function patchRequest<T>(
   accountId: number,
   options: HttpOptions
-): HubSpotResponse<T> {
+): HubSpotPromise<T> {
   const requestConfig = await withAuth(accountId, options);
   return axios<T>({ ...requestConfig, method: 'patch' });
 }
@@ -152,7 +152,7 @@ async function patchRequest<T>(
 async function deleteRequest<T>(
   accountId: number,
   options: HttpOptions
-): HubSpotResponse<T> {
+): HubSpotPromise<T> {
   const requestConfig = await withAuth(accountId, options);
   return axios<T>({ ...requestConfig, method: 'delete' });
 }

--- a/http/index.ts
+++ b/http/index.ts
@@ -9,14 +9,12 @@ import { addQueryParams } from './addQueryParams';
 import { accessTokenForPersonalAccessKey } from '../lib/personalAccessKey';
 import { getOauthManager } from '../lib/oauth';
 import { FlatAccountFields } from '../types/Accounts';
-import { HttpOptions } from '../types/Http';
+import { HttpOptions, HubSpotPromise } from '../types/Http';
 import { logger } from '../lib/logger';
 import { i18n } from '../utils/lang';
 import { HubSpotHttpError } from '../models/HubSpotHttpError';
 
 const i18nKey = 'http.index';
-
-export type HubSpotPromise<T = unknown> = AxiosPromise<T>;
 
 axios.interceptors.response.use(undefined, error => {
   // Wrap all axios errors in our own Error class.  Attach the error

--- a/http/index.ts
+++ b/http/index.ts
@@ -16,6 +16,8 @@ import { HubSpotHttpError } from '../models/HubSpotHttpError';
 
 const i18nKey = 'http.index';
 
+export type HubSpotResponse<T = unknown> = Promise<AxiosResponse<T>>;
+
 axios.interceptors.response.use(undefined, error => {
   // Wrap all axios errors in our own Error class.  Attach the error
   // as the cause for the new error, so we maintain the stack trace
@@ -115,7 +117,7 @@ async function withAuth(
 async function getRequest<T>(
   accountId: number,
   options: HttpOptions
-): AxiosPromise<T> {
+): HubSpotResponse<T> {
   const { params, ...rest } = options;
   const optionsWithParams = addQueryParams(rest, params);
   const requestConfig = await withAuth(accountId, optionsWithParams);
@@ -126,7 +128,7 @@ async function getRequest<T>(
 async function postRequest<T>(
   accountId: number,
   options: HttpOptions
-): AxiosPromise<T> {
+): HubSpotResponse<T> {
   const requestConfig = await withAuth(accountId, options);
   return axios<T>({ ...requestConfig, method: 'post' });
 }
@@ -134,7 +136,7 @@ async function postRequest<T>(
 async function putRequest<T>(
   accountId: number,
   options: HttpOptions
-): AxiosPromise<T> {
+): HubSpotResponse<T> {
   const requestConfig = await withAuth(accountId, options);
   return axios<T>({ ...requestConfig, method: 'put' });
 }
@@ -142,7 +144,7 @@ async function putRequest<T>(
 async function patchRequest<T>(
   accountId: number,
   options: HttpOptions
-): AxiosPromise<T> {
+): HubSpotResponse<T> {
   const requestConfig = await withAuth(accountId, options);
   return axios<T>({ ...requestConfig, method: 'patch' });
 }
@@ -150,7 +152,7 @@ async function patchRequest<T>(
 async function deleteRequest<T>(
   accountId: number,
   options: HttpOptions
-): AxiosPromise<T> {
+): HubSpotResponse<T> {
   const requestConfig = await withAuth(accountId, options);
   return axios<T>({ ...requestConfig, method: 'delete' });
 }

--- a/http/unauthed.ts
+++ b/http/unauthed.ts
@@ -1,9 +1,10 @@
-import axios, { AxiosPromise } from 'axios';
+import axios from 'axios';
 import { getAxiosConfig } from './getAxiosConfig';
 import { addQueryParams } from './addQueryParams';
 import { HttpOptions } from '../types/Http';
+import { HubSpotResponse } from './index';
 
-async function getRequest<T>(options: HttpOptions): AxiosPromise<T> {
+async function getRequest<T>(options: HttpOptions): HubSpotResponse<T> {
   const { params, ...rest } = options;
   const optionsWithParams = addQueryParams(rest, params);
   const requestConfig = await getAxiosConfig(optionsWithParams);
@@ -11,22 +12,22 @@ async function getRequest<T>(options: HttpOptions): AxiosPromise<T> {
   return axios<T>(requestConfig);
 }
 
-async function postRequest<T>(options: HttpOptions): AxiosPromise<T> {
+async function postRequest<T>(options: HttpOptions): HubSpotResponse<T> {
   const requestConfig = await getAxiosConfig(options);
   return axios<T>({ ...requestConfig, method: 'post' });
 }
 
-async function putRequest<T>(options: HttpOptions): AxiosPromise<T> {
+async function putRequest<T>(options: HttpOptions): HubSpotResponse<T> {
   const requestConfig = await getAxiosConfig(options);
   return axios<T>({ ...requestConfig, method: 'put' });
 }
 
-async function patchRequest<T>(options: HttpOptions): AxiosPromise<T> {
+async function patchRequest<T>(options: HttpOptions): HubSpotResponse<T> {
   const requestConfig = await getAxiosConfig(options);
   return axios<T>({ ...requestConfig, method: 'patch' });
 }
 
-async function deleteRequest<T>(options: HttpOptions): AxiosPromise<T> {
+async function deleteRequest<T>(options: HttpOptions): HubSpotResponse<T> {
   const requestConfig = await getAxiosConfig(options);
   return axios<T>({ ...requestConfig, method: 'delete' });
 }

--- a/http/unauthed.ts
+++ b/http/unauthed.ts
@@ -1,8 +1,7 @@
 import axios from 'axios';
 import { getAxiosConfig } from './getAxiosConfig';
 import { addQueryParams } from './addQueryParams';
-import { HttpOptions } from '../types/Http';
-import { HubSpotPromise } from './index';
+import { HttpOptions, HubSpotPromise } from '../types/Http';
 
 async function getRequest<T>(options: HttpOptions): HubSpotPromise<T> {
   const { params, ...rest } = options;

--- a/http/unauthed.ts
+++ b/http/unauthed.ts
@@ -2,9 +2,9 @@ import axios from 'axios';
 import { getAxiosConfig } from './getAxiosConfig';
 import { addQueryParams } from './addQueryParams';
 import { HttpOptions } from '../types/Http';
-import { HubSpotResponse } from './index';
+import { HubSpotPromise } from './index';
 
-async function getRequest<T>(options: HttpOptions): HubSpotResponse<T> {
+async function getRequest<T>(options: HttpOptions): HubSpotPromise<T> {
   const { params, ...rest } = options;
   const optionsWithParams = addQueryParams(rest, params);
   const requestConfig = await getAxiosConfig(optionsWithParams);
@@ -12,22 +12,22 @@ async function getRequest<T>(options: HttpOptions): HubSpotResponse<T> {
   return axios<T>(requestConfig);
 }
 
-async function postRequest<T>(options: HttpOptions): HubSpotResponse<T> {
+async function postRequest<T>(options: HttpOptions): HubSpotPromise<T> {
   const requestConfig = await getAxiosConfig(options);
   return axios<T>({ ...requestConfig, method: 'post' });
 }
 
-async function putRequest<T>(options: HttpOptions): HubSpotResponse<T> {
+async function putRequest<T>(options: HttpOptions): HubSpotPromise<T> {
   const requestConfig = await getAxiosConfig(options);
   return axios<T>({ ...requestConfig, method: 'put' });
 }
 
-async function patchRequest<T>(options: HttpOptions): HubSpotResponse<T> {
+async function patchRequest<T>(options: HttpOptions): HubSpotPromise<T> {
   const requestConfig = await getAxiosConfig(options);
   return axios<T>({ ...requestConfig, method: 'patch' });
 }
 
-async function deleteRequest<T>(options: HttpOptions): HubSpotResponse<T> {
+async function deleteRequest<T>(options: HttpOptions): HubSpotPromise<T> {
   const requestConfig = await getAxiosConfig(options);
   return axios<T>({ ...requestConfig, method: 'delete' });
 }

--- a/lib/__tests__/validate.test.ts
+++ b/lib/__tests__/validate.test.ts
@@ -3,7 +3,7 @@ import { validateHubl } from '../../api/validateHubl';
 import { walk } from '../fs';
 import { lint } from '../cms/validate';
 import { LintResult, Validation } from '../../types/HublValidation';
-import { AxiosPromise } from 'axios';
+import { HubSpotResponse } from '../../http';
 
 jest.mock('fs-extra');
 jest.mock('../../api/validateHubl');
@@ -76,7 +76,7 @@ describe('lib/cms/validate', () => {
     mockedFsReadFile.mockResolvedValue(mockSource);
     mockedValidateHubl.mockResolvedValue({
       data: mockValidation,
-    } as unknown as AxiosPromise<Validation>);
+    } as unknown as HubSpotResponse<Validation>);
     const result = await lint(accountId, filePath);
     expect(validateHubl).toHaveBeenCalledWith(accountId, mockSource);
     expect(result).toEqual([{ file: filePath, validation: mockValidation }]);
@@ -89,7 +89,7 @@ describe('lib/cms/validate', () => {
     mockedFsReadFile.mockResolvedValue('valid HUBL content');
     mockedValidateHubl.mockResolvedValue({
       data: mockValidation,
-    } as unknown as AxiosPromise<Validation>);
+    } as unknown as HubSpotResponse<Validation>);
 
     const result = await lint(accountId, filePath);
 
@@ -104,7 +104,7 @@ describe('lib/cms/validate', () => {
     mockedFsReadFile.mockResolvedValue(mockSource);
     mockedValidateHubl.mockResolvedValue({
       data: mockValidation,
-    } as unknown as AxiosPromise<Validation>);
+    } as unknown as HubSpotResponse<Validation>);
 
     await lint(accountId, filePath, mockCallback);
     expect(mockCallback).toHaveBeenCalledWith({

--- a/lib/__tests__/validate.test.ts
+++ b/lib/__tests__/validate.test.ts
@@ -3,7 +3,7 @@ import { validateHubl } from '../../api/validateHubl';
 import { walk } from '../fs';
 import { lint } from '../cms/validate';
 import { LintResult, Validation } from '../../types/HublValidation';
-import { HubSpotResponse } from '../../http';
+import { HubSpotPromise } from '../../http';
 
 jest.mock('fs-extra');
 jest.mock('../../api/validateHubl');
@@ -76,7 +76,7 @@ describe('lib/cms/validate', () => {
     mockedFsReadFile.mockResolvedValue(mockSource);
     mockedValidateHubl.mockResolvedValue({
       data: mockValidation,
-    } as unknown as HubSpotResponse<Validation>);
+    } as unknown as HubSpotPromise<Validation>);
     const result = await lint(accountId, filePath);
     expect(validateHubl).toHaveBeenCalledWith(accountId, mockSource);
     expect(result).toEqual([{ file: filePath, validation: mockValidation }]);
@@ -89,7 +89,7 @@ describe('lib/cms/validate', () => {
     mockedFsReadFile.mockResolvedValue('valid HUBL content');
     mockedValidateHubl.mockResolvedValue({
       data: mockValidation,
-    } as unknown as HubSpotResponse<Validation>);
+    } as unknown as HubSpotPromise<Validation>);
 
     const result = await lint(accountId, filePath);
 
@@ -104,7 +104,7 @@ describe('lib/cms/validate', () => {
     mockedFsReadFile.mockResolvedValue(mockSource);
     mockedValidateHubl.mockResolvedValue({
       data: mockValidation,
-    } as unknown as HubSpotResponse<Validation>);
+    } as unknown as HubSpotPromise<Validation>);
 
     await lint(accountId, filePath, mockCallback);
     expect(mockCallback).toHaveBeenCalledWith({

--- a/lib/__tests__/validate.test.ts
+++ b/lib/__tests__/validate.test.ts
@@ -3,7 +3,7 @@ import { validateHubl } from '../../api/validateHubl';
 import { walk } from '../fs';
 import { lint } from '../cms/validate';
 import { LintResult, Validation } from '../../types/HublValidation';
-import { HubSpotPromise } from '../../http';
+import { HubSpotPromise } from '../../types/Http';
 
 jest.mock('fs-extra');
 jest.mock('../../api/validateHubl');

--- a/types/Http.ts
+++ b/types/Http.ts
@@ -1,6 +1,8 @@
-import { ResponseType } from 'axios';
+import { AxiosPromise, ResponseType } from 'axios';
 import { ReadStream } from 'fs';
 import { Stream } from 'stream';
+
+export type HubSpotPromise<T = unknown> = AxiosPromise<T>;
 
 export type Data = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description and Context
Wraps the `AxiosPromise` in a `HubSpotPromise` type and exports it so that integrators don't need to use `ReturnType` annotations to have access to the type.
