### PR TITLE
More release script improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "0.0.1-experimental.2",
+  "version": "0.0.1-experimental.3",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "0.0.1-experimental.9",
+  "version": "0.0.1-experimental.10",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-import": "^2.29.1",
     "husky": "^8.0.0",
     "jest": "^29.5.0",
-    "open": "^10.1.0",
+    "open": "^8.4.2",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "0.0.1-experimental.10",
+  "version": "2.3.0",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "2.3.0",
+  "version": "0.0.1-experimental.1",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "0.0.1-experimental.3",
+  "version": "0.0.1-experimental.5",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "0.0.1-experimental.5",
+  "version": "0.0.1-experimental.7",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "0.0.1-experimental.7",
+  "version": "0.0.1-experimental.8",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "0.0.1-experimental.1",
+  "version": "0.0.1-experimental.2",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-import": "^2.29.1",
     "husky": "^8.0.0",
     "jest": "^29.5.0",
+    "open": "^10.1.0",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "0.0.1-experimental.8",
+  "version": "0.0.1-experimental.9",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -270,7 +270,7 @@ async function handler({
 
   logger.log();
   if (!isDryRun) {
-    otp = await input({ message: 'Enter your NPM one-time password' });
+    otp = await input({ message: 'Enter your NPM one-time password:' });
   } else {
     logger.log('Dry run: skipping one-time password entry');
   }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -18,6 +18,9 @@ const TAG = {
   EXPERIMENTAL: 'experimental',
 } as const;
 
+// remove
+const EXPERIMENTAL_TEMP = 'experimental-temp';
+
 const INCREMENT = {
   PATCH: 'patch',
   MINOR: 'minor',
@@ -107,13 +110,13 @@ async function updateNextTag(
   isDryRun: boolean
 ): Promise<void> {
   logger.log();
-  logger.log(`Updating ${TAG.NEXT} tag...`);
+  logger.log(`Updating ${EXPERIMENTAL_TEMP} tag...`);
 
   const commandArgs = [
     'dist-tag',
     'add',
     `${packageName}@${newVersion}`,
-    TAG.NEXT,
+    EXPERIMENTAL_TEMP,
   ];
 
   return new Promise((resolve, reject) => {
@@ -128,7 +131,7 @@ async function updateNextTag(
         if (code !== EXIT_CODES.SUCCESS) {
           reject();
         } else {
-          logger.success(`${TAG.NEXT} tag updated successfully`);
+          logger.success(`${EXPERIMENTAL_TEMP} tag updated successfully`);
           resolve();
         }
       });
@@ -242,7 +245,7 @@ async function handler({
   try {
     await publish(tag, isDryRun);
 
-    if (tag === TAG.LATEST) {
+    if (tag === TAG.EXPERIMENTAL) {
       await updateNextTag(newVersion, isDryRun);
     }
   } catch (e) {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -2,6 +2,7 @@ import { exec as _exec, spawn } from 'child_process';
 import { promisify } from 'util';
 import yargs, { ArgumentsCamelCase, Argv } from 'yargs';
 import semver from 'semver';
+import open from 'open';
 import { confirm, input } from '@inquirer/prompts';
 
 import {
@@ -319,6 +320,10 @@ async function handler({
   logger.log(
     'View on npm: https://www.npmjs.com/package/@hubspot/local-dev-lib?activeTab=versions'
   );
+
+  logger.log();
+  logger.log('Remember to create a new release on Github!');
+  open('https://github.com/HubSpot/hubspot-local-dev-lib/releases/new');
 }
 
 async function builder(yargs: Argv): Promise<Argv> {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -23,9 +23,6 @@ const TAG = {
   EXPERIMENTAL: 'experimental',
 } as const;
 
-// remove
-const EXPERIMENTAL_TEMP = 'experimental-temp';
-
 const INCREMENT = {
   PATCH: 'patch',
   MINOR: 'minor',
@@ -131,13 +128,13 @@ async function updateNextTag(
   isDryRun: boolean
 ): Promise<void> {
   logger.log();
-  logger.log(`Updating ${EXPERIMENTAL_TEMP} tag...`);
+  logger.log(`Updating ${TAG.NEXT} tag...`);
 
   const commandArgs = [
     'dist-tag',
     'add',
     `${packageName}@${newVersion}`,
-    EXPERIMENTAL_TEMP,
+    TAG.NEXT,
     '--registry',
     REGISTRY,
     '--otp',
@@ -156,7 +153,7 @@ async function updateNextTag(
         if (code !== EXIT_CODES.SUCCESS) {
           reject();
         } else {
-          logger.success(`${EXPERIMENTAL_TEMP} tag updated successfully`);
+          logger.success(`${TAG.NEXT} tag updated successfully`);
           resolve();
         }
       });

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -4,7 +4,11 @@ import yargs, { ArgumentsCamelCase, Argv } from 'yargs';
 import semver from 'semver';
 import { confirm } from '@inquirer/prompts';
 
-import { name as packageName, version as localVersion } from '../package.json';
+import {
+  name as packageName,
+  version as localVersion,
+  publishConfig,
+} from '../package.json';
 import { logger, setLogLevel, LOG_LEVEL } from '../lib/logger';
 import { build } from './lib/build';
 
@@ -46,6 +50,9 @@ const EXIT_CODES = {
   ERROR: 1,
 };
 
+// Commands run with `spawn` won't always get this from the package.json
+const REGISTRY = publishConfig.registry;
+
 type ReleaseArguments = {
   versionIncrement: (typeof VERSION_INCREMENT_OPTIONS)[number];
   tag: (typeof TAG_OPTIONS)[number];
@@ -83,7 +90,7 @@ async function publish(tag: Tag, isDryRun: boolean): Promise<void> {
   logger.log('-'.repeat(50));
   logger.log();
 
-  const commandArgs = ['publish', '--tag', tag];
+  const commandArgs = ['publish', '--tag', tag, '--registry', REGISTRY];
 
   if (isDryRun) {
     commandArgs.push('--dry-run');
@@ -117,6 +124,8 @@ async function updateNextTag(
     'add',
     `${packageName}@${newVersion}`,
     EXPERIMENTAL_TEMP,
+    '--registry',
+    REGISTRY,
   ];
 
   return new Promise((resolve, reject) => {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -212,6 +212,25 @@ async function handler({
     process.exit(EXIT_CODES.SUCCESS);
   }
 
+  if (
+    tag === TAG.LATEST &&
+    !localVersion.includes(PRERELEASE_IDENTIFIER.NEXT)
+  ) {
+    logger.log();
+    const proceedWithoutBetaRelease = await confirm({
+      message: `The current changes have not yet been released in beta. It's recommended to release and test all changes on the ${TAG.NEXT} tag before releasing them to ${TAG.LATEST}. Are you sure you want to proceed?`,
+      default: false,
+    });
+
+    if (!proceedWithoutBetaRelease) {
+      logger.log();
+      logger.log(
+        `To release your changes on the next tag, run \`yarn release -v=${versionIncrement} -t=next\``
+      );
+      process.exit(EXIT_CODES.SUCCESS);
+    }
+  }
+
   logger.log();
   logger.log(`Updating version to ${newVersion}...`);
   await exec(`yarn version --new-version ${newVersion}`);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -139,6 +139,8 @@ async function updateNextTag(
     EXPERIMENTAL_TEMP,
     '--registry',
     REGISTRY,
+    '--otp',
+    otp,
   ];
 
   return new Promise((resolve, reject) => {
@@ -266,6 +268,7 @@ async function handler({
 
   let otp = '';
 
+  logger.log();
   if (!isDryRun) {
     otp = await input({ message: 'Enter your NPM one-time password' });
   } else {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -22,9 +22,6 @@ const TAG = {
   EXPERIMENTAL: 'experimental',
 } as const;
 
-// remove
-const EXPERIMENTAL_TEMP = 'experimental-temp';
-
 const INCREMENT = {
   PATCH: 'patch',
   MINOR: 'minor',
@@ -117,13 +114,13 @@ async function updateNextTag(
   isDryRun: boolean
 ): Promise<void> {
   logger.log();
-  logger.log(`Updating ${EXPERIMENTAL_TEMP} tag...`);
+  logger.log(`Updating ${TAG.NEXT} tag...`);
 
   const commandArgs = [
     'dist-tag',
     'add',
     `${packageName}@${newVersion}`,
-    EXPERIMENTAL_TEMP,
+    TAG.NEXT,
     '--registry',
     REGISTRY,
   ];
@@ -140,7 +137,7 @@ async function updateNextTag(
         if (code !== EXIT_CODES.SUCCESS) {
           reject();
         } else {
-          logger.success(`${EXPERIMENTAL_TEMP} tag updated successfully`);
+          logger.success(`${TAG.NEXT} tag updated successfully`);
           resolve();
         }
       });


### PR DESCRIPTION
## Description and Context
This fixes one major bug and makes a few more improvements to the release script
* Previously, the script failed when attempting to update the `next` tag after releases to latest. This is due to a slight difference between how `npm dist-tag` runs within `spawn` and how it runs directly in a terminal. Explicity specifying a `--registry` fixes this.
  * If the `dist-tag` command _does_ fail, the script no longer runs cleanup (since the release itself was successful) and provides instructions for manually updating the `next` tag and pushing to Github.
* Added a confirmation prompt when attempting to release changes to `latest` that haven't already been released to `next`
* Added a prompt for NPM one-time password so you don't have to open your browser. This password seems to work for both the publish and dist-tag operation even if it expires between them, but passing in an expired code will simply open a second prompt so this shouldn't be an issue.
* Opens the browser to remind us to create a new release on Github after all successful runs

## Who to Notify

@brandenrodgers @kemmerle @joe-yeager 
