### PR TITLE
Only prompt to create release for latest releases

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -318,9 +318,11 @@ async function handler({
     'View on npm: https://www.npmjs.com/package/@hubspot/local-dev-lib?activeTab=versions'
   );
 
-  logger.log();
-  logger.log('Remember to create a new release on Github!');
-  open('https://github.com/HubSpot/hubspot-local-dev-lib/releases/new');
+  if (tag === TAG.LATEST) {
+    logger.log();
+    logger.log('Remember to create a new release on Github!');
+    open('https://github.com/HubSpot/hubspot-local-dev-lib/releases/new');
+  }
 }
 
 async function builder(yargs: Argv): Promise<Argv> {


### PR DESCRIPTION
## Description and Context
The release script now opens your browser to create a new release on Github, but this isn't necessary for `next` and `experimental` releases

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
