### PR TITLE
Refactor logger.debug to preserve stack trace

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -48,7 +48,7 @@ export class Logger {
     console.info(...stylize('[INFO]', Styles.info, args));
   }
   debug(...args: any[]) {
-    console.debug(...stylize('[DEBUG]', Styles.log, args));
+    console.trace(...stylize('[DEBUG]', Styles.log, args));
   }
   group(...args: any[]) {
     console.group(...args);


### PR DESCRIPTION
## Description and Context
While I was retooling tests in the CLI, I had an incredibly difficult time pinpointing where errors were originating, because our `logger.debug` function did not preserve the stack trace. I would suggest that we switch from `console.debug` (which is basically useless) to `console.trace` for better debugging. 

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback 

## Who to Notify

<!-- /cc those you wish to know about the PR -->
@brandenrodgers @joe-yeager @camden11 
