### PR TITLE
chore!: Rename Mode to CmsPublishMode

### DIFF
--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -64,7 +64,7 @@ class _CLIConfiguration {
           })
         );
         this.useEnvConfig = true;
-        this.config = configFromEnv;
+        this.config = this.handleLegacyCmsPublishMode(configFromEnv);
       }
     } else {
       const configFromFile = loadConfigFromFile();
@@ -75,7 +75,7 @@ class _CLIConfiguration {
         this.config = { accounts: [] };
       }
       this.useEnvConfig = false;
-      this.config = configFromFile;
+      this.config = this.handleLegacyCmsPublishMode(configFromFile);
     }
 
     return this.config;
@@ -625,6 +625,16 @@ class _CLIConfiguration {
       return true;
     }
     return this.config.allowUsageTracking !== false;
+  }
+
+  handleLegacyCmsPublishMode(
+    config: CLIConfig_NEW | null
+  ): CLIConfig_NEW | null {
+    if (config?.defaultMode) {
+      config.defaultCmsPublishMode = config.defaultMode;
+      delete config.defaultMode;
+    }
+    return config;
   }
 }
 

--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -12,7 +12,7 @@ import { commaSeparatedValues } from '../lib/text';
 import { ENVIRONMENTS } from '../constants/environments';
 import { API_KEY_AUTH_METHOD } from '../constants/auth';
 import { HUBSPOT_ACCOUNT_TYPES, MIN_HTTP_TIMEOUT } from '../constants/config';
-import { MODE } from '../constants/files';
+import { CMS_PUBLISH_MODE } from '../constants/files';
 import { CLIConfig_NEW, Environment } from '../types/Config';
 import {
   CLIAccount_NEW,
@@ -21,9 +21,8 @@ import {
   AccountType,
 } from '../types/Accounts';
 import { CLIOptions } from '../types/CLIOptions';
-import { ValueOf } from '../types/Utils';
 import { i18n } from '../utils/lang';
-import { Mode } from '../types/Files';
+import { CmsPublishMode } from '../types/Files';
 
 const i18nKey = 'config.cliConfiguration';
 
@@ -342,7 +341,7 @@ class _CLIConfiguration {
       authType,
       clientId,
       clientSecret,
-      defaultMode,
+      defaultCmsPublishMode,
       env,
       name,
       parentAccountId,
@@ -397,8 +396,9 @@ class _CLIConfiguration {
     const updatedEnv = getValidEnv(
       env || (currentAccountConfig && currentAccountConfig.env)
     );
-    const updatedDefaultMode: ValueOf<typeof MODE> | undefined =
-      defaultMode && (defaultMode.toLowerCase() as ValueOf<typeof MODE>);
+    const updatedDefaultCmsPublishMode: CmsPublishMode | undefined =
+      defaultCmsPublishMode &&
+      (defaultCmsPublishMode.toLowerCase() as CmsPublishMode);
     const updatedAccountType =
       accountType || (currentAccountConfig && currentAccountConfig.accountType);
 
@@ -410,9 +410,12 @@ class _CLIConfiguration {
     if (nextAccountConfig.authType === API_KEY_AUTH_METHOD.value) {
       safelyApplyUpdates('apiKey', apiKey);
     }
-    if (typeof updatedDefaultMode !== 'undefined') {
+    if (typeof updatedDefaultCmsPublishMode !== 'undefined') {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      safelyApplyUpdates('defaultMode', MODE[updatedDefaultMode]);
+      safelyApplyUpdates(
+        'defaultCmsPublishMode',
+        CMS_PUBLISH_MODE[updatedDefaultCmsPublishMode]
+      );
     }
     safelyApplyUpdates('personalAccessKey', personalAccessKey);
 
@@ -554,21 +557,26 @@ class _CLIConfiguration {
   /**
    * @throws {Error}
    */
-  updateDefaultMode(defaultMode: Mode): CLIConfig_NEW | null {
+  updateDefaultCmsPublishMode(
+    defaultCmsPublishMode: CmsPublishMode
+  ): CLIConfig_NEW | null {
     if (!this.config) {
       throw new Error(i18n(`${i18nKey}.errors.noConfigLoaded`));
     }
-    const ALL_MODES = Object.values(MODE);
-    if (!defaultMode || !ALL_MODES.find(m => m === defaultMode)) {
+    const ALL_CMS_PUBLISH_MODES = Object.values(CMS_PUBLISH_MODE);
+    if (
+      !defaultCmsPublishMode ||
+      !ALL_CMS_PUBLISH_MODES.find(m => m === defaultCmsPublishMode)
+    ) {
       throw new Error(
         i18n(`${i18nKey}.updateDefaultMode.errors.invalidMode`, {
-          defaultMode,
-          validModes: commaSeparatedValues(ALL_MODES),
+          defaultCmsPublishMode,
+          validCmsPublishModes: commaSeparatedValues(ALL_CMS_PUBLISH_MODES),
         })
       );
     }
 
-    this.config.defaultMode = defaultMode;
+    this.config.defaultCmsPublishMode = defaultCmsPublishMode;
     return this.write();
   }
 

--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -569,10 +569,13 @@ class _CLIConfiguration {
       !ALL_CMS_PUBLISH_MODES.find(m => m === defaultCmsPublishMode)
     ) {
       throw new Error(
-        i18n(`${i18nKey}.updateDefaultMode.errors.invalidMode`, {
-          defaultCmsPublishMode,
-          validCmsPublishModes: commaSeparatedValues(ALL_CMS_PUBLISH_MODES),
-        })
+        i18n(
+          `${i18nKey}.updateDefaultCmsPublishMode.errors.invalidCmsPublishMode`,
+          {
+            defaultCmsPublishMode,
+            validCmsPublishModes: commaSeparatedValues(ALL_CMS_PUBLISH_MODES),
+          }
+        )
       );
     }
 

--- a/config/__tests__/CLIConfiguration.test.ts
+++ b/config/__tests__/CLIConfiguration.test.ts
@@ -118,10 +118,10 @@ describe('config/CLIConfiguration', () => {
     });
   });
 
-  describe('updateDefaultMode()', () => {
+  describe('updateDefaultCmsPublishMode()', () => {
     it('throws when no config is loaded', () => {
       expect(() => {
-        config.updateDefaultMode('draft');
+        config.updateDefaultCmsPublishMode('draft');
       }).toThrow();
     });
   });

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -38,7 +38,7 @@ export function getOrderedConfig(
 ): CLIConfig_NEW {
   const {
     defaultAccount,
-    defaultMode,
+    defaultCmsPublishMode,
     httpTimeout,
     allowUsageTracking,
     accounts,
@@ -47,7 +47,7 @@ export function getOrderedConfig(
 
   return {
     ...(defaultAccount && { defaultAccount }),
-    defaultMode,
+    defaultCmsPublishMode,
     httpTimeout,
     allowUsageTracking,
     ...rest,

--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -288,7 +288,7 @@ function loadConfigFromFile(path?: string, options: CLIOptions = {}) {
   if (sourceError) return;
   const { parsed, error: parseError } = parseConfig(source);
   if (parseError) return;
-  setConfig(parsed);
+  setConfig(handleLegacyCmsPublishMode(parsed));
 
   if (!getConfig()) {
     logger.debug('The config file was empty config');
@@ -886,7 +886,7 @@ function loadEnvironmentVariableConfig(options: {
     `Loaded config from environment variables for account ${portalId}`
   );
 
-  return setConfig(envConfig);
+  return setConfig(handleLegacyCmsPublishMode(envConfig));
 }
 
 export function isConfigFlagEnabled(flag: keyof CLIConfig_DEPRECATED): boolean {
@@ -897,4 +897,14 @@ export function isConfigFlagEnabled(flag: keyof CLIConfig_DEPRECATED): boolean {
   const config = getAndLoadConfigIfNeeded();
 
   return Boolean(config[flag] || false);
+}
+
+function handleLegacyCmsPublishMode(
+  config: CLIConfig_DEPRECATED | undefined
+): CLIConfig_DEPRECATED | undefined {
+  if (config?.defaultMode) {
+    config.defaultCmsPublishMode = config.defaultMode;
+    delete config.defaultMode;
+  }
+  return config;
 }

--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -14,7 +14,7 @@ import {
   PERSONAL_ACCESS_KEY_AUTH_METHOD,
   OAUTH_SCOPES,
 } from '../constants/auth';
-import { MODE } from '../constants/files';
+import { CMS_PUBLISH_MODE } from '../constants/files';
 import { getValidEnv } from '../lib/environment';
 import { logger } from '../lib/logger';
 import { isConfigPathInGitRepo } from '../utils/git';
@@ -32,10 +32,10 @@ import {
   UpdateAccountConfigOptions,
 } from '../types/Accounts';
 import { BaseError } from '../types/Error';
-import { Mode } from '../types/Files';
+import { CmsPublishMode } from '../types/Files';
 import { CLIOptions, WriteConfigOptions } from '../types/CLIOptions';
 
-const ALL_MODES = Object.values(MODE);
+const ALL_CMS_PUBLISH_MODES = Object.values(CMS_PUBLISH_MODE);
 let _config: CLIConfig_DEPRECATED | null;
 let _configPath: string | null;
 let environmentVariableConfigLoaded = false;
@@ -182,7 +182,7 @@ export function getOrderedAccount(
 export function getOrderedConfig(unorderedConfig: CLIConfig_DEPRECATED) {
   const {
     defaultPortal,
-    defaultMode,
+    defaultCmsPublishMode,
     httpTimeout,
     allowUsageTracking,
     portals,
@@ -191,7 +191,7 @@ export function getOrderedConfig(unorderedConfig: CLIConfig_DEPRECATED) {
 
   return {
     ...(defaultPortal && { defaultPortal }),
-    defaultMode,
+    defaultCmsPublishMode,
     httpTimeout,
     allowUsageTracking,
     ...rest,
@@ -491,7 +491,7 @@ export function updateAccountConfig(
     authType,
     clientId,
     clientSecret,
-    defaultMode,
+    defaultCmsPublishMode,
     environment,
     name,
     parentAccountId,
@@ -526,8 +526,8 @@ export function updateAccountConfig(
       (configOptions && configOptions.env) ||
       (accountConfig && accountConfig.env)
   );
-  const mode: Mode | undefined =
-    defaultMode && (defaultMode.toLowerCase() as Mode);
+  const cmsPublishMode: CmsPublishMode | undefined =
+    defaultCmsPublishMode?.toLowerCase() as CmsPublishMode;
   const nextAccountConfig: FlatAccountFields_DEPRECATED = {
     ...accountConfig,
     name: name || (accountConfig && accountConfig.name),
@@ -537,7 +537,10 @@ export function updateAccountConfig(
     auth,
     accountType: getAccountType(accountType, sandboxAccountType),
     apiKey,
-    defaultMode: mode && Object.hasOwn(MODE, mode) ? mode : undefined,
+    defaultCmsPublishMode:
+      cmsPublishMode && Object.hasOwn(CMS_PUBLISH_MODE, cmsPublishMode)
+        ? cmsPublishMode
+        : undefined,
     personalAccessKey,
     sandboxAccountType,
     parentAccountId,
@@ -583,17 +586,22 @@ export function updateDefaultAccount(defaultAccount: string | number): void {
 /**
  * @throws {Error}
  */
-export function updateDefaultMode(defaultMode: Mode): void {
-  if (!defaultMode || !ALL_MODES.find(m => m === defaultMode)) {
+export function updateDefaultCmsPublishMode(
+  defaultCmsPublishMode: CmsPublishMode
+): void {
+  if (
+    !defaultCmsPublishMode ||
+    !ALL_CMS_PUBLISH_MODES.find(m => m === defaultCmsPublishMode)
+  ) {
     throw new Error(
-      `The mode ${defaultMode} is invalid. Valid values are ${commaSeparatedValues(
-        ALL_MODES
+      `The mode ${defaultCmsPublishMode} is invalid. Valid values are ${commaSeparatedValues(
+        ALL_CMS_PUBLISH_MODES
       )}.`
     );
   }
 
   const config = getAndLoadConfigIfNeeded();
-  config.defaultMode = defaultMode;
+  config.defaultCmsPublishMode = defaultCmsPublishMode;
 
   setDefaultConfigPathIfUnset();
   writeConfig();

--- a/config/index.ts
+++ b/config/index.ts
@@ -15,7 +15,7 @@ import {
   FlatAccountFields,
 } from '../types/Accounts';
 import { getAccountIdentifier } from './getAccountIdentifier';
-import { Mode } from '../types/Files';
+import { CmsPublishMode } from '../types/Files';
 
 // Use new config if it exists
 export function loadConfig(
@@ -250,11 +250,13 @@ export function getConfigAccounts():
   return config_DEPRECATED.getConfigAccounts();
 }
 
-export function updateDefaultMode(mode: Mode): void | CLIConfig_NEW | null {
+export function updateDefaultCmsPublishMode(
+  cmsPublishMode: CmsPublishMode
+): void | CLIConfig_NEW | null {
   if (CLIConfiguration.isActive()) {
-    return CLIConfiguration.updateDefaultMode(mode);
+    return CLIConfiguration.updateDefaultCmsPublishMode(cmsPublishMode);
   }
-  return config_DEPRECATED.updateDefaultMode(mode);
+  return config_DEPRECATED.updateDefaultCmsPublishMode(cmsPublishMode);
 }
 
 // These functions are not supported with the new config setup

--- a/constants/files.ts
+++ b/constants/files.ts
@@ -4,12 +4,12 @@ export const STAT_TYPES = {
   DIRECTORY: 'dir',
 } as const;
 
-export const MODE = {
+export const CMS_PUBLISH_MODE = {
   draft: 'draft',
   publish: 'publish',
 } as const;
 
-export const DEFAULT_MODE = MODE.publish;
+export const DEFAULT_CMS_PUBLISH_MODE = CMS_PUBLISH_MODE.publish;
 
 export const FILE_UPLOAD_RESULT_TYPES = {
   SUCCESS: 'SUCCESS',

--- a/lang/en.json
+++ b/lang/en.json
@@ -274,9 +274,9 @@
           "invalidId": "Unable to find account for {{ nameOrId }}."
         }
       },
-      "updateDefaultMode": {
+      "updateDefaultCmsPublishMode": {
         "errors": {
-          "invalidMode": "The mode {{ defaultMode }} is invalid. Valid values are {{ validModes }}."
+          "invalidCmsPublishMode": "The CMS publish mode {{ defaultCmsPublishMode }} is invalid. Valid values are {{ validCmsPublishModes }}."
         }
       },
       "updateHttpTimeout": {

--- a/lib/__tests__/watch.test.ts
+++ b/lib/__tests__/watch.test.ts
@@ -3,7 +3,7 @@ import PQueue from 'p-queue';
 
 import { uploadFolder } from '../cms/uploadFolder';
 import { watch } from '../cms/watch';
-import { MODE } from '../../constants/files';
+import { CMS_PUBLISH_MODE } from '../../constants/files';
 
 jest.mock('chokidar');
 jest.mock('axios');
@@ -36,7 +36,7 @@ describe('lib/cms/watch', () => {
     const src = 'src-folder';
     const dest = 'dest-folder';
     const options = {
-      mode: MODE.draft,
+      cmsPublishMode: CMS_PUBLISH_MODE.draft,
       remove: false,
       disableInitial: true,
       notify: '',
@@ -57,7 +57,7 @@ describe('lib/cms/watch', () => {
     const src = 'src-folder';
     const dest = 'dest-folder';
     const options = {
-      mode: MODE.draft,
+      cmsPublishMode: CMS_PUBLISH_MODE.draft,
       remove: false,
       disableInitial: false,
       notify: '',
@@ -77,7 +77,7 @@ describe('lib/cms/watch', () => {
       {},
       options.commandOptions,
       options.filePaths,
-      options.mode
+      options.cmsPublishMode
     );
     expect(postInitialUploadCallback).toHaveBeenCalled();
   });
@@ -87,7 +87,7 @@ describe('lib/cms/watch', () => {
     const src = 'src-folder';
     const dest = 'dest-folder';
     const options = {
-      mode: MODE.draft,
+      cmsPublishMode: CMS_PUBLISH_MODE.draft,
       remove: false,
       disableInitial: true,
       notify: '',
@@ -105,7 +105,7 @@ describe('lib/cms/watch', () => {
     const src = 'src-folder';
     const dest = 'dest-folder';
     const options = {
-      mode: MODE.draft,
+      cmsPublishMode: CMS_PUBLISH_MODE.draft,
       remove: false,
       disableInitial: true,
       notify: '',
@@ -126,7 +126,7 @@ describe('lib/cms/watch', () => {
     const src = 'src-folder';
     const dest = 'dest-folder';
     const options = {
-      mode: MODE.draft,
+      cmsPublishMode: CMS_PUBLISH_MODE.draft,
       remove: true,
       disableInitial: true,
       notify: '',

--- a/lib/cms/uploadFolder.ts
+++ b/lib/cms/uploadFolder.ts
@@ -22,7 +22,7 @@ import {
   CommandOptions,
   FilePathsByType,
 } from '../../types/Files';
-import { Mode } from '../../types/Files';
+import { CmsPublishMode } from '../../types/Files';
 import { i18n } from '../../utils/lang';
 import { HubSpotHttpError } from '../../models/HubSpotHttpError';
 
@@ -172,7 +172,7 @@ export async function uploadFolder(
   fileMapperOptions: FileMapperInputOptions,
   commandOptions: CommandOptions = {},
   filePaths: Array<string> = [],
-  mode: Mode | null = null
+  cmsPublishMode: CmsPublishMode | null = null
 ): Promise<Array<UploadFolderResults>> {
   const {
     saveOutput,
@@ -197,7 +197,10 @@ export async function uploadFolder(
     : null;
   const regex = new RegExp(`^${escapeRegExp(src)}`);
 
-  const apiOptions = getFileMapperQueryValues(mode, fileMapperOptions);
+  const apiOptions = getFileMapperQueryValues(
+    cmsPublishMode,
+    fileMapperOptions
+  );
   const failures: Array<{ file: string; destPath: string }> = [];
   let fieldsJsPaths: Array<Partial<FieldsJs>> = [];
   let tmpDirRegex: RegExp;

--- a/lib/cms/watch.ts
+++ b/lib/cms/watch.ts
@@ -16,7 +16,7 @@ import { getThemePreviewUrl, getThemeJSONPath } from './themes';
 import { logger } from '../logger';
 import {
   UploadFileOptions,
-  Mode,
+  CmsPublishMode,
   WatchOptions,
   WatchErrorHandler,
 } from '../../types/Files';
@@ -69,7 +69,7 @@ async function uploadFile(
   file: string,
   dest: string,
   options: UploadFileOptions,
-  mode: Mode | null = null,
+  cmsPublishMode: CmsPublishMode | null = null,
   onUploadFileError: (
     file: string,
     dest: string,
@@ -115,7 +115,7 @@ async function uploadFile(
     convertFields && fieldsJs?.outputPath ? fieldsJs.outputPath : file;
 
   logger.debug(i18n(`${i18nKey}.uploadAttempt`, { file, dest }));
-  const apiOptions = getFileMapperQueryValues(mode, options);
+  const apiOptions = getFileMapperQueryValues(cmsPublishMode, options);
   queue.add(() => {
     return upload(accountId, fileToUpload, dest, apiOptions)
       .then(() => {
@@ -171,7 +171,7 @@ export function watch(
   src: string,
   dest: string,
   {
-    mode,
+    cmsPublishMode,
     remove,
     disableInitial,
     notify,
@@ -213,7 +213,7 @@ export function watch(
       {},
       commandOptions,
       filePaths,
-      mode || null
+      cmsPublishMode || null
     ).then(result => {
       logger.log(
         i18n(`${i18nKey}.folderUploadSuccess`, {
@@ -246,7 +246,7 @@ export function watch(
         src,
         commandOptions,
       },
-      mode,
+      cmsPublishMode,
       onUploadFileError
     );
     triggerNotify(notify, 'Added', filePath, uploadPromise);
@@ -308,7 +308,7 @@ export function watch(
         src,
         commandOptions,
       },
-      mode,
+      cmsPublishMode,
       onUploadFileError
     );
     triggerNotify(notify, 'Changed', filePath, uploadPromise);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "2.3.0",
+  "version": "0.1.0-experimental.0",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "0.1.0-experimental.0",
+  "version": "2.3.0",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/types/Accounts.ts
+++ b/types/Accounts.ts
@@ -1,5 +1,5 @@
 import { HUBSPOT_ACCOUNT_TYPES } from '../constants/config';
-import { Mode } from './Files';
+import { CmsPublishMode } from './Files';
 import { Environment } from './Config';
 import { ValueOf } from './Utils';
 
@@ -9,7 +9,7 @@ export interface CLIAccount_NEW {
   name?: string;
   accountId: number;
   accountType?: AccountType;
-  defaultMode?: Mode;
+  defaultCmsPublishMode?: CmsPublishMode;
   env: Environment;
   authType?: AuthType;
   auth?: {
@@ -24,7 +24,7 @@ export interface CLIAccount_NEW {
 export interface CLIAccount_DEPRECATED {
   name?: string;
   portalId?: number;
-  defaultMode?: Mode;
+  defaultCmsPublishMode?: CmsPublishMode;
   env: Environment;
   accountType?: AccountType;
   authType?: AuthType;

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -1,13 +1,13 @@
 import { ENVIRONMENTS } from '../constants/environments';
 import { CLIAccount_NEW, CLIAccount_DEPRECATED } from './Accounts';
-import { Mode } from './Files';
+import { CmsPublishMode } from './Files';
 import { ValueOf } from './Utils';
 
 export interface CLIConfig_NEW {
   accounts: Array<CLIAccount_NEW>;
   allowUsageTracking?: boolean;
   defaultAccount?: string | number;
-  defaultMode?: Mode;
+  defaultCmsPublishMode?: CmsPublishMode;
   httpTimeout?: number;
   env?: Environment;
   httpUseLocalhost?: boolean;
@@ -17,7 +17,7 @@ export interface CLIConfig_DEPRECATED {
   portals: Array<CLIAccount_DEPRECATED>;
   allowUsageTracking?: boolean;
   defaultPortal?: string | number;
-  defaultMode?: Mode;
+  defaultCmsPublishMode?: CmsPublishMode;
   httpTimeout?: number;
   env?: Environment;
   httpUseLocalhost?: boolean;

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -7,6 +7,7 @@ export interface CLIConfig_NEW {
   accounts: Array<CLIAccount_NEW>;
   allowUsageTracking?: boolean;
   defaultAccount?: string | number;
+  defaultMode?: CmsPublishMode; // Deprecated - left in to handle existing configs with this field
   defaultCmsPublishMode?: CmsPublishMode;
   httpTimeout?: number;
   env?: Environment;
@@ -17,6 +18,7 @@ export interface CLIConfig_DEPRECATED {
   portals: Array<CLIAccount_DEPRECATED>;
   allowUsageTracking?: boolean;
   defaultPortal?: string | number;
+  defaultMode?: CmsPublishMode; // Deprecated - left in to handle existing configs with this field
   defaultCmsPublishMode?: CmsPublishMode;
   httpTimeout?: number;
   env?: Environment;

--- a/types/Files.ts
+++ b/types/Files.ts
@@ -4,7 +4,7 @@ import {
   FILE_TYPES,
   FILE_UPLOAD_RESULT_TYPES,
 } from '../constants/files';
-import { MODE } from '../constants/files';
+import { CMS_PUBLISH_MODE } from '../constants/files';
 import { HttpOptions } from './Http';
 import { AxiosError } from 'axios';
 
@@ -26,7 +26,7 @@ export type FileMapperNode = {
   children: Array<FileMapperNode>;
 };
 
-export type Mode = ValueOf<typeof MODE>;
+export type CmsPublishMode = ValueOf<typeof CMS_PUBLISH_MODE>;
 
 export type FileMapperOptions = Omit<HttpOptions, 'url'>;
 
@@ -98,7 +98,7 @@ export type UploadFileOptions = FileMapperInputOptions & {
 };
 
 export type WatchOptions = {
-  mode?: Mode;
+  cmsPublishMode?: CmsPublishMode;
   remove?: boolean;
   disableInitial?: boolean;
   notify?: string;


### PR DESCRIPTION
## Description and Context
See https://git.hubteam.com/HubSpot/hubspot-cli-issues/issues/718
This updates all references to `mode` to `cmsPublishMode` and renames all related functions and variables. It also changes the `defaultMode` setting within `hubspot.config.yml` to `defaultCmsPublishMode`. Both the new and legacy config modules have been updated to be able to read configs with either `defaultMode` or `defaultCmsPublishMode`, but will now always  use `defaultCmsPublishMode` when making updates to config files.

Currently released on `v0.1.0-experimental.0`
## TODO
Test thoroughly. Also might be worth updating the config unit tests to test the backwards compatibility functionality/

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 