### PR TITLE
chore: Refactor types for fetching GitHub content

### DIFF
--- a/api/github.ts
+++ b/api/github.ts
@@ -56,12 +56,12 @@ export function fetchRepoAsZip(zipUrl: string): HubSpotPromise<Buffer> {
 }
 
 // Returns the raw file contents via the raw.githubusercontent endpoint
-export function fetchRepoFile(
+export function fetchRepoFile<T = Buffer>(
   repoPath: RepoPath,
   filePath: string,
   ref: string
-): HubSpotPromise<Buffer> {
-  return axios.get<Buffer>(
+): HubSpotPromise<T> {
+  return axios.get<T>(
     `${GITHUB_RAW_CONTENT_API_PATH}/${repoPath}/${ref}/${filePath}`,
     {
       headers: {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -26,7 +26,8 @@ export async function fetchFileFromRepository(
   repoPath: RepoPath,
   filePath: string,
   ref: string
-): Promise<Buffer> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> {
   try {
     logger.debug(
       i18n(`${i18nKey}.fetchFileFromRepository.fetching`, {
@@ -145,6 +146,7 @@ export async function fetchGitHubRepoContentFromDownloadUrl(
   } else {
     fileContents = resp.data;
   }
+  // @ts-expect-error TODO: Discuss with team how to address error
   fs.outputFileSync(dest, fileContents);
 }
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -22,12 +22,11 @@ import { isHubSpotHttpError, isSystemError } from '../errors';
 
 const i18nKey = 'lib.github';
 
-export async function fetchFileFromRepository(
+export async function fetchFileFromRepository<T = Buffer>(
   repoPath: RepoPath,
   filePath: string,
   ref: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<any> {
+): Promise<T> {
   try {
     logger.debug(
       i18n(`${i18nKey}.fetchFileFromRepository.fetching`, {
@@ -36,7 +35,7 @@ export async function fetchFileFromRepository(
     );
 
     const { data } = await fetchRepoFile(repoPath, filePath, ref);
-    return data;
+    return data as T;
   } catch (err) {
     throw new Error(
       i18n(`${i18nKey}.fetchFileFromRepository.errors.fetchFail`),

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -146,7 +146,6 @@ export async function fetchGitHubRepoContentFromDownloadUrl(
   } else {
     fileContents = resp.data;
   }
-  // @ts-expect-error TODO: Discuss with team how to address error
   fs.outputFileSync(dest, fileContents);
 }
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -34,8 +34,8 @@ export async function fetchFileFromRepository<T = Buffer>(
       })
     );
 
-    const { data } = await fetchRepoFile(repoPath, filePath, ref);
-    return data as T;
+    const { data } = await fetchRepoFile<T>(repoPath, filePath, ref);
+    return data;
   } catch (err) {
     throw new Error(
       i18n(`${i18nKey}.fetchFileFromRepository.errors.fetchFail`),

--- a/types/developerTestAccounts.ts
+++ b/types/developerTestAccounts.ts
@@ -5,6 +5,7 @@ export type DeveloperTestAccount = {
   createdAt: string;
   updatedAt: string;
   status: string;
+  id: number;
 };
 
 export type FetchDeveloperTestAccountsResponse = {


### PR DESCRIPTION
## Description and Context

Is a dependency of: https://github.com/HubSpot/hubspot-cli/pull/1288

As part of our work to convert the CLI to TypeScript, we're typing prompts that rely on downloading content from GitHub. We were mistakenly returning the `Buffer` type from the `fetchFileFromRepository` function. In fact, this function returns the contents of the file (`resp.data`) we're downloading. Since literally anything can be in a file downloaded from GitHub, this is an instance of a true `any` type, in my opinion.

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address feedback. 

## Who to Notify
@camden11 @brandenrodgers @joe-yeager 
