### PR TITLE
chore: Update validation types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "3.0.0",
+  "version": "0.1.0-experimental.1",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "main": "lib/index.js",
   "repository": {

--- a/types/MarketplaceValidation.ts
+++ b/types/MarketplaceValidation.ts
@@ -23,6 +23,6 @@ export type GetValidationResultsResponse = {
     REQUIRED: { status: string; results: Array<Check> };
     RECOMMENDED: { status: string; results: Array<Check> };
   };
-  errors: Array<Error>;
+  errors: Array<ValidationError>;
   requestedAt: string;
 };

--- a/types/MarketplaceValidation.ts
+++ b/types/MarketplaceValidation.ts
@@ -1,4 +1,4 @@
-type Check = {
+export type Check = {
   check: string;
   status: string;
   title: string;
@@ -8,6 +8,12 @@ type Check = {
   line: number | null;
   file: string;
 };
+
+export interface ValidationError {
+  validationRequestId: number;
+  failureReasonType: string;
+  context: string;
+}
 
 export type GetValidationResultsResponse = {
   validationRequestId: number;


### PR DESCRIPTION
## Description and Context

This makes a few updates to types used by the `hs module marketplace-validation` command and related endpoints.
* Exports the `Check` type
* Updates the `errors` field on `GetValidationResultsResponse` (see [API catalog ](https://tools.hubteam.com/api-catalog/services/QualityEngineService/v1/spec/internal#operations-Validation-get-%2Fquality-engine%2Fv1%2Fvalidation%2Fresults)for this endpoint

## Who to Notify

@brandenrodgers @kemmerle @joe-yeager 
