### PR TITLE
Chore: Fixing type for the auth field in the config

### DIFF
--- a/types/Accounts.ts
+++ b/types/Accounts.ts
@@ -14,6 +14,8 @@ export interface CLIAccount_NEW {
   authType?: AuthType;
   auth?: {
     tokenInfo?: TokenInfo;
+    clientId?: string;
+    clientSecret?: string;
   };
   sandboxAccountType?: string | null;
   parentAccountId?: number | null;


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

The type for auth was missing `clientId` and `clientSecret`. This was causing issues over in the CLI.

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
