### PR TITLE
Add error case in deprecated config

### DIFF
--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -105,6 +105,12 @@ export function validateConfig(): boolean {
     logger.error('config.portals[] is not defined');
     return false;
   }
+
+  if (accounts.length === 0) {
+    logger.error('There are no accounts defined in the configuration file');
+    return false;
+  }
+
   const accountIdsHash: { [id: number]: CLIAccount_DEPRECATED } = {};
   const accountNamesHash: { [name: string]: CLIAccount_DEPRECATED } = {};
 


### PR DESCRIPTION
## Description and Context
https://github.com/HubSpot/hubspot-cli/pull/1307 relies on this PR.

While we were porting it to TypeScript, we made a change in the deprecated config, so that on creation, the config contains a `portals` property set to an empty array (`{ portals: [] }`). This means that we need to refactor our error handling in config validation to handle cases where `portals` is set to an empty array.

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback

## Who to Notify

<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
