### PR TITLE
Fix auth type for deprecated config

### DIFF
--- a/types/Accounts.ts
+++ b/types/Accounts.ts
@@ -32,6 +32,8 @@ export interface CLIAccount_DEPRECATED {
   authType?: AuthType;
   auth?: {
     tokenInfo?: TokenInfo;
+    clientId?: string;
+    clientSecret?: string;
   };
   sandboxAccountType?: string | null;
   parentAccountId?: number | null;


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
I missed the auth type in the deprecated config in https://github.com/HubSpot/hubspot-local-dev-lib/pull/220. We also need to fix it here.


## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
