### PR TITLE
fix: Move GitHub downloads to optimized method

### DIFF
--- a/lib/__tests__/templates.test.ts
+++ b/lib/__tests__/templates.test.ts
@@ -4,15 +4,14 @@ import {
   isCodedFile,
   createTemplate,
 } from '../cms/templates';
-import { downloadGithubRepoContents as __downloadGithubRepoContents } from '../github';
+import { cloneGithubRepo as __cloneGithubRepo } from '../github';
 
 jest.mock('fs-extra');
 jest.mock('../github');
 
-const downloadGithubRepoContents =
-  __downloadGithubRepoContents as jest.MockedFunction<
-    typeof __downloadGithubRepoContents
-  >;
+const cloneGithubRepo = __cloneGithubRepo as jest.MockedFunction<
+  typeof __cloneGithubRepo
+>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const makeAnnotation = (options: { [key: string]: any } = {}) => {
@@ -63,10 +62,10 @@ describe('lib/cms/templates', () => {
       jest.spyOn(fs, 'existsSync').mockReturnValue(false);
       await createTemplate('my-template', '/', 'page-template');
 
-      expect(downloadGithubRepoContents).toHaveBeenCalledWith(
+      expect(cloneGithubRepo).toHaveBeenCalledWith(
         'HubSpot/cms-sample-assets',
-        'templates/page-template.html',
-        '/my-template.html'
+        '/my-template.html',
+        { sourceDir: 'templates/page-template.html' }
       );
     });
   });

--- a/lib/cms/functions.ts
+++ b/lib/cms/functions.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import findup from 'findup-sync';
 import { getCwd } from '../path';
-import { downloadGithubRepoContents } from '../github';
+import { fetchFileFromRepository } from '../github';
 import { logger } from '../logger';
 import { i18n } from '../../utils/lang';
 import { FileSystemError } from '../../models/FileSystemError';
@@ -192,11 +192,13 @@ export async function createFunction(
     );
   }
 
-  await downloadGithubRepoContents(
+  const result = await fetchFileFromRepository(
     'HubSpot/cms-sample-assets',
     'functions/sample-function.js',
-    functionFilePath
+    'main'
   );
+
+  fs.writeFileSync(functionFilePath, result);
 
   logger.log(
     i18n(`${i18nKey}.createFunction.createdFunctionFile`, {

--- a/lib/cms/modules.ts
+++ b/lib/cms/modules.ts
@@ -239,12 +239,13 @@ export async function createModule(
     ? 'Sample.module'
     : 'SampleReactModule';
 
+  const sourceDir = `modules/${sampleAssetPath}`;
+
   await cloneGithubRepo('HubSpot/cms-sample-assets', destPath, {
-    sourceDir: `modules/${sampleAssetPath}`,
+    sourceDir,
   });
 
-  // TODO: Validate these changes with tests
-  const files = await walk(`modules/${sampleAssetPath}`);
+  const files = await walk(destPath);
 
   files
     .filter(filePath => !moduleFileFilter(filePath))
@@ -258,7 +259,7 @@ export async function createModule(
   );
 
   metaFiles.forEach(metaFile => {
-    fs.writeJSONSync(path.join(destPath, metaFile), moduleMetaData, {
+    fs.writeJSONSync(metaFile, moduleMetaData, {
       spaces: 2,
     });
   });

--- a/lib/cms/modules.ts
+++ b/lib/cms/modules.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import { getCwd } from '../path';
 import { walk } from '../fs';
-import { listGithubRepoContents, downloadGithubRepoContents } from '../github';
+import { listGithubRepoContents, cloneGithubRepo } from '../github';
 import { logger } from '../logger';
 import {
   isPathInput,
@@ -240,13 +240,10 @@ export async function createModule(
     ? 'Sample.module'
     : 'SampleReactModule';
 
-  await downloadGithubRepoContents(
-    'HubSpot/cms-sample-assets',
-    `modules/${sampleAssetPath}`,
-    destPath,
-    '',
-    moduleFileFilter
-  );
+  // TODO: figure out how to handle the module file filter
+  await cloneGithubRepo('HubSpot/cms-sample-assets', destPath, {
+    sourceDir: `modules/${sampleAssetPath}`,
+  });
 
   // Updating React module files after fetch
   if (isReactModule) {
@@ -271,11 +268,9 @@ export async function retrieveDefaultModule(
     return defaultReactModules;
   }
 
-  await downloadGithubRepoContents(
-    'HubSpot/cms-react',
-    `default-react-modules/src/components/modules/${name}`,
-    dest
-  );
+  await cloneGithubRepo('HubSpot/cms-react', dest, {
+    sourceDir: `default-react-modules/src/components/modules/${name}`,
+  });
 }
 
 const MODULE_HTML_EXTENSION_REGEX = new RegExp(

--- a/lib/cms/modules.ts
+++ b/lib/cms/modules.ts
@@ -218,17 +218,9 @@ export async function createModule(
         return false;
       case 'module.js':
       case 'module.css':
-        if (emailEnabled) {
-          return false;
-        }
-        return true;
+        return !emailEnabled;
       case 'global-sample-react-module.css':
-      case 'stories':
-      case 'tests':
-        if (getInternalVersion) {
-          return true;
-        }
-        return false;
+        return getInternalVersion;
       default:
         return true;
     }
@@ -252,6 +244,11 @@ export async function createModule(
     .forEach(filePath => {
       fs.unlinkSync(filePath);
     });
+
+  if (!getInternalVersion) {
+    fs.removeSync(path.join(destPath, 'stories'));
+    fs.removeSync(path.join(destPath, 'tests'));
+  }
 
   // Get and write the metafiles
   const metaFiles = files.filter(

--- a/lib/cms/templates.ts
+++ b/lib/cms/templates.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { downloadGithubRepoContents } from '../github';
+import { cloneGithubRepo } from '../github';
 import { logger } from '../logger';
 import { i18n } from '../../utils/lang';
 
@@ -74,11 +74,9 @@ export async function createTemplate(
     })
   );
 
-  await downloadGithubRepoContents(
-    'HubSpot/cms-sample-assets',
-    assetPath,
-    filePath
-  );
+  await cloneGithubRepo('HubSpot/cms-sample-assets', filePath, {
+    sourceDir: assetPath,
+  });
 }
 
 export const TEMPLATE_TYPES = {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -148,7 +148,10 @@ export async function fetchGitHubRepoContentFromDownloadUrl(
   fs.outputFileSync(dest, fileContents);
 }
 
-// Writes files from a public repository to the destination folder
+/**
+ * Writes files from a public repository to the destination folder
+  @deprecated - This method fetches all the files individually, which can hit rate limits for unauthorized requests. Use `cloneGithubRepo` instead.
+ */
 export async function downloadGithubRepoContents(
   repoPath: RepoPath,
   contentPath: string,


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Changes made:
- Deprecate `downloadGithubRepoContents` because it is inefficient and tends to hit rate limits
- Replace `downloadGithubRepoContents` with `cloneGithubRepo` to optimize the number of calls to GitHub
- Make any required tweaks to account for the transition