### PR TITLE
Add types for CMS function logs API responses

### DIFF
--- a/api/functions.ts
+++ b/api/functions.ts
@@ -1,6 +1,11 @@
 import { http } from '../http';
 import { HubSpotPromise, QueryParams } from '../types/Http';
-import { GetBuildStatusResponse, GetRoutesResponse } from '../types/Functions';
+import {
+  GetBuildStatusResponse,
+  FunctionLog,
+  GetRoutesResponse,
+  GetFunctionLogsResponse,
+} from '../types/Functions';
 
 const FUNCTION_API_PATH = 'cms/v3/functions';
 
@@ -16,7 +21,7 @@ export function getFunctionLogs(
   accountId: number,
   route: string,
   params: QueryParams = {}
-): HubSpotPromise {
+): HubSpotPromise<GetFunctionLogsResponse> {
   const { limit = 5 } = params;
 
   return http.get(accountId, {
@@ -28,7 +33,7 @@ export function getFunctionLogs(
 export function getLatestFunctionLog(
   accountId: number,
   route: string
-): HubSpotPromise {
+): HubSpotPromise<FunctionLog> {
   return http.get(accountId, {
     url: `${FUNCTION_API_PATH}/results/by-route/${encodeURIComponent(
       route

--- a/types/Functions.ts
+++ b/types/Functions.ts
@@ -69,3 +69,31 @@ export type FunctionInfo = {
 export type FunctionOptions = {
   allowExistingFile?: boolean;
 };
+
+export type FunctionLog = {
+  id: string;
+  executionTime: number;
+  log: string;
+  error: {
+    message: string;
+    type: string;
+    stackTrace: string[][];
+  };
+  status: string;
+  createdAt: number;
+  memory: string;
+};
+
+export type GetFunctionLogsResponse = {
+  results: FunctionLog[];
+  paging: {
+    next: {
+      after: string;
+      link: string;
+    };
+    prev: {
+      before: string;
+      link: string;
+    };
+  };
+};


### PR DESCRIPTION
## Description and Context

These types were missing for some reason, but the CLI relies on them.
Pulled from here: https://tools.hubteam.com/api-catalog/services/ContentServerlessFunctionsService/v3/spec/internal

## Who to Notify

@brandenrodgers @kemmerle @joe-yeager 
