### PR TITLE
Feature (POC): Add default account overrides

### DIFF
--- a/types/Config.ts
+++ b/types/Config.ts
@@ -7,6 +7,7 @@ export interface CLIConfig_NEW {
   accounts: Array<CLIAccount_NEW>;
   allowUsageTracking?: boolean;
   defaultAccount?: string | number;
+  defaultAccountOverrides?: { [key: string]: string | number };
   defaultMode?: CmsPublishMode; // Deprecated - left in to handle existing configs with this field
   defaultCmsPublishMode?: CmsPublishMode;
   httpTimeout?: number;


### PR DESCRIPTION
## Description and Context

In this PR, I've created a small proof of concept for how we can implement default account overrides in the new configuration file with minimal code changes. For full details and proposals for future work, please see [this Canvas](https://hubspot.enterprise.slack.com/docs/T024G0P55/F088P14PK6Y). 

One bug that @brandenrodgers and I discussed yesterday: Currently, I'm overriding the default account for a specific directory and its subdirectories. I think there's an edge case, where if a customer sets overrides for `~/projects/tmp` and `~/projects/tmp/sampleFolder`, I'll need to make sure that files and folders within the `sampleFolder` subdirectory respect the closest override (I hope that makes sense). 

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback 

## Who to Notify

<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
