### PR TITLE
feat: add fixtures to fetch scope authorization data per portal and user

### DIFF
--- a/api/localDevAuth.ts
+++ b/api/localDevAuth.ts
@@ -6,7 +6,6 @@ import {
   ScopeData,
   AccessTokenResponse,
   EnabledFeaturesResponse,
-  ScopeGroupAuthorization,
   ScopeAuthorizationResponse,
 } from '../types/Accounts';
 import axios from 'axios';

--- a/api/localDevAuth.ts
+++ b/api/localDevAuth.ts
@@ -49,7 +49,7 @@ export async function fetchScopeAuthorizationData(
   accountId: number
 ): HubSpotPromise<ScopeAuthorizationResponse> {
   return http.get<ScopeAuthorizationResponse>(accountId, {
-    url: `${LOCALDEVAUTH_API_AUTH_PATH}/scope-groups/authorized`
+    url: `${LOCALDEVAUTH_API_AUTH_PATH}/scope-groups/authorized`,
   });
 }
 

--- a/api/localDevAuth.ts
+++ b/api/localDevAuth.ts
@@ -6,6 +6,8 @@ import {
   ScopeData,
   AccessTokenResponse,
   EnabledFeaturesResponse,
+  ScopeGroupAuthorization,
+  ScopeAuthorizationResponse,
 } from '../types/Accounts';
 import axios from 'axios';
 import { PublicAppInstallationData } from '../types/Apps';
@@ -41,6 +43,14 @@ export function fetchScopeData(
   return http.get<ScopeData>(accountId, {
     url: `${LOCALDEVAUTH_API_AUTH_PATH}/check-scopes`,
     params: { scopeGroup },
+  });
+}
+
+export async function fetchScopeAuthorizationData(
+  accountId: number
+): HubSpotPromise<ScopeAuthorizationResponse> {
+  return http.get<ScopeAuthorizationResponse>(accountId, {
+    url: `${LOCALDEVAUTH_API_AUTH_PATH}/scope-groups/authorized`
   });
 }
 

--- a/lib/personalAccessKey.ts
+++ b/lib/personalAccessKey.ts
@@ -1,9 +1,9 @@
 import moment from 'moment';
 import { ENVIRONMENTS } from '../constants/environments';
 import { PERSONAL_ACCESS_KEY_AUTH_METHOD } from '../constants/auth';
-import { fetchAccessToken } from '../api/localDevAuth';
+import { fetchAccessToken, fetchScopeAuthorizationData } from '../api/localDevAuth';
 import { fetchSandboxHubData } from '../api/sandboxHubs';
-import { CLIAccount, PersonalAccessKeyAccount } from '../types/Accounts';
+import { CLIAccount, PersonalAccessKeyAccount, ScopeGroupAuthorization } from '../types/Accounts';
 import { Environment } from '../types/Config';
 import {
   getAccountConfig,
@@ -166,6 +166,12 @@ export async function scopesOnAccessToken(
   accountId: number
 ): Promise<Array<string>> {
   return (await getNewAccessTokenByAccountId(accountId)).scopeGroups;
+}
+
+export async function authorizedScopesForPortalAndUser(
+  accountId: number
+): Promise<Array<ScopeGroupAuthorization>> {
+  return (await fetchScopeAuthorizationData(accountId)).data.results;
 }
 
 export async function updateConfigWithAccessToken(

--- a/types/Accounts.ts
+++ b/types/Accounts.ts
@@ -132,6 +132,22 @@ export type ScopeData = {
   userScopesInGroup: Array<string>;
 };
 
+export type ScopeAuthorizationResponse = {
+  results: Array<ScopeGroupAuthorization>;
+}
+
+export type ScopeGroupAuthorization = {
+  scopeGroup: ScopeGroup;
+  portalAuthorized: boolean;
+  userAuthorized: boolean;
+}
+
+export type ScopeGroup = {
+  name: string;
+  shortDescription: string;
+  longDescription: string;
+}
+
 export type AccessTokenResponse = {
   hubId: number;
   userId: number;


### PR DESCRIPTION
## Description and Context

Adds various models so we can fetch scope authorization data for use in the CLI when debugging potential local dev issues.

Subsequent PR incoming in [HubSpot/hubspot-cli](https://github.com/HubSpot/hubspot-cli/) and will link accordingly.