### PR TITLE
Use portability-sync service

### DIFF
--- a/api/sandboxSync.ts
+++ b/api/sandboxSync.ts
@@ -6,7 +6,9 @@ import {
 } from '../types/Sandbox';
 import { SANDBOX_TIMEOUT } from '../constants/api';
 import { HubSpotPromise } from '../types/Http';
+
 const SANDBOXES_SYNC_API_PATH = 'sandboxes-sync/v1';
+const PORTABILITY_SYNC_API_PATH = 'portability-sync/v1';
 
 export async function initiateSync(
   fromHubId: number,
@@ -32,7 +34,7 @@ export async function fetchTypes(
   toHubId: number
 ): HubSpotPromise<FetchTypesResponse> {
   return http.get<FetchTypesResponse>(accountId, {
-    url: `${SANDBOXES_SYNC_API_PATH}/types${
+    url: `${PORTABILITY_SYNC_API_PATH}/types${
       toHubId ? `?toHubId=${toHubId}` : ''
     }`,
   });


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Sandboxes is deprecating some old endpoints and have moved from our SandboxesSync service over to PortabilitySync service. This PR updates a base URL which is functionally the same as the old version

New: https://tools.hubteam.com/api-catalog/services/PortabilitySyncService/v1/spec/internal#operations-Types-get-%2Fportability-sync%2Fv1%2Ftypes
Old: https://tools.hubteam.com/api-catalog/services/SandboxesSyncService/v1/spec/internal#operations-Types-get-%2Fsandboxes-sync%2Fv1%2Ftypes

## Screenshots

<!-- Provide images of the before and after functionality -->
n/a

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
