### PR TITLE
Return promises from async functions

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -147,9 +147,9 @@ export async function renameAccount(
   newName: string
 ): Promise<void> {
   if (CLIConfiguration.isActive()) {
-    CLIConfiguration.renameAccount(currentName, newName);
+    return CLIConfiguration.renameAccount(currentName, newName);
   } else {
-    config_DEPRECATED.renameAccount(currentName, newName);
+    return config_DEPRECATED.renameAccount(currentName, newName);
   }
 }
 
@@ -169,11 +169,13 @@ export function removeSandboxAccountFromConfig(
   return config_DEPRECATED.removeSandboxAccountFromConfig(nameOrId);
 }
 
-export async function deleteAccount(accountName: string): Promise<void> {
+export async function deleteAccount(
+  accountName: string
+): Promise<void | boolean> {
   if (CLIConfiguration.isActive()) {
-    CLIConfiguration.removeAccountFromConfig(accountName);
+    return CLIConfiguration.removeAccountFromConfig(accountName);
   } else {
-    config_DEPRECATED.deleteAccount(accountName);
+    return config_DEPRECATED.deleteAccount(accountName);
   }
 }
 


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This was manifesting itself in the `hs account rename` command in the CLI. These async functions weren't returning a promise, so there was nothing to `await` for in the CLI code. This meant that the errors thrown by these utils would never get caught by any try/catch block in the CLI.

You can see the impact of this by running `hs account rename blah-blah some-gibberish`

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
