### PR TITLE
Add hide logs option to GH download util

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -22,6 +22,9 @@ import { isHubSpotHttpError, isSystemError } from '../errors';
 
 const i18nKey = 'lib.github';
 
+/**
+ * @deprecated Use `fetchRepoFile` instead - this util is a thin wrapper around it
+ */
 export async function fetchFileFromRepository<T = Buffer>(
   repoPath: RepoPath,
   filePath: string,
@@ -113,15 +116,18 @@ export async function cloneGithubRepo(
   dest: string,
   options: CloneGithubRepoOptions = {}
 ): Promise<boolean> {
-  const { tag, isRelease, branch, sourceDir, type } = options;
+  const { tag, isRelease, branch, sourceDir, type, hideLogs } = options;
   const zip = await downloadGithubRepoZip(repoPath, isRelease, {
     tag,
     branch,
   });
   const repoName = repoPath.split('/')[1];
-  const success = await extractZipArchive(zip, repoName, dest, { sourceDir });
+  const success = await extractZipArchive(zip, repoName, dest, {
+    sourceDir,
+    hideLogs,
+  });
 
-  if (success) {
+  if (success && !hideLogs) {
     logger.log(
       i18n(`${i18nKey}.cloneGithubRepo.success`, {
         type: type || '',

--- a/types/Github.ts
+++ b/types/Github.ts
@@ -78,4 +78,5 @@ export type CloneGithubRepoOptions = {
   branch?: string; // Repo branch
   tag?: string; // Repo tag
   sourceDir?: string; // The directory within the downloaded repo to write after extraction
+  hideLogs?: boolean; // Hide logs from the console
 };


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
This adds a `hideLogs` option to the GH download util that prevents it from logging anything to the console. The CLI will leverage this for the project-related downloads, where we can provide our own logs from the CLI side.

This also deprecates the thin wrapper around fetchRepoFile

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
