### PR TITLE
Chore: Remove main field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@hubspot/local-dev-lib",
   "version": "3.3.1",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
-  "main": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/HubSpot/hubspot-local-dev-lib"


### PR DESCRIPTION
## Description and Context
Noticed that we were still using the `main` field in `package.json` to specify an entry point file that doesn't exist. `exports` replaces `main` so we can remove this

## Who to Notify

@brandenrodgers @kemmerle @joe-yeager 
