### PR TITLE
Support `hs account` bucket refactor

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -244,9 +244,8 @@ export function getConfigDefaultAccount(): string | number | null | undefined {
 export function getDisplayDefaultAccount(): string | number | null | undefined {
   if (CLIConfiguration.isActive()) {
     return CLIConfiguration.config?.defaultAccount;
-  } else {
-    return config_DEPRECATED.getConfigDefaultAccount();
   }
+  return config_DEPRECATED.getConfigDefaultAccount();
 }
 
 export function getConfigAccounts():

--- a/config/index.ts
+++ b/config/index.ts
@@ -241,13 +241,9 @@ export function getConfigDefaultAccount(): string | number | null | undefined {
   return config_DEPRECATED.getConfigDefaultAccount();
 }
 
-export function getDisplayDefaultAccount(
-  isOverride: boolean
-): string | number | null | undefined {
+export function getDisplayDefaultAccount(): string | number | null | undefined {
   if (CLIConfiguration.isActive()) {
-    return isOverride
-      ? CLIConfiguration.getCWDAccountOverride()
-      : CLIConfiguration.config?.defaultAccount;
+    return CLIConfiguration.config?.defaultAccount;
   } else {
     return config_DEPRECATED.getConfigDefaultAccount();
   }

--- a/config/index.ts
+++ b/config/index.ts
@@ -241,6 +241,18 @@ export function getConfigDefaultAccount(): string | number | null | undefined {
   return config_DEPRECATED.getConfigDefaultAccount();
 }
 
+export function getDisplayDefaultAccount(
+  isOverride: boolean
+): string | number | null | undefined {
+  if (CLIConfiguration.isActive()) {
+    return isOverride
+      ? CLIConfiguration.getCWDAccountOverride()
+      : CLIConfiguration.config?.defaultAccount;
+  } else {
+    return config_DEPRECATED.getConfigDefaultAccount();
+  }
+}
+
 export function getConfigAccounts():
   | Array<CLIAccount_NEW>
   | Array<CLIAccount_DEPRECATED>


### PR DESCRIPTION
## Description and Context

This PR adds functions that support refactoring the `hs account` bucket to account for `.hsaccount` override files with the new config. 

## Screenshots
See https://github.com/HubSpot/hubspot-cli/pull/1407

## TODO

- [ ] Address feedback

## Who to Notify
@brandenrodgers @camden11 @joe-yeager 
