### PR TITLE
Fix `hs config migrate` bug

### DIFF
--- a/config/migrate.ts
+++ b/config/migrate.ts
@@ -152,11 +152,15 @@ export function mergeConfigProperties(
     DEFAULT_PORTAL in deprecatedConfig &&
     globalConfig.defaultAccount !== deprecatedConfig.defaultPortal
   ) {
-    conflicts.push({
-      property: DEFAULT_ACCOUNT,
-      oldValue: deprecatedConfig.defaultPortal!,
-      newValue: globalConfig.defaultAccount!,
-    });
+    if (force) {
+      globalConfig.defaultAccount = deprecatedConfig.defaultPortal;
+    } else {
+      conflicts.push({
+        property: DEFAULT_ACCOUNT,
+        oldValue: deprecatedConfig.defaultPortal!,
+        newValue: globalConfig.defaultAccount!,
+      });
+    }
   } else if (DEFAULT_PORTAL in deprecatedConfig) {
     globalConfig.defaultAccount = deprecatedConfig.defaultPortal;
   }


### PR DESCRIPTION
## Description and Context
During testing, I discovered a bug in the `hs config migrate` flow: If the `force` flag was used, the `defaultAccount` property was not being properly updated if conflicting. This PR addresses that. 

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback 

## Who to Notify
@brandenrodgers @camden11 @joe-yeager 
