### PR TITLE
Fix migration bug p2

### DIFF
--- a/config/migrate.ts
+++ b/config/migrate.ts
@@ -1,5 +1,3 @@
-import fs from 'fs';
-
 import * as config_DEPRECATED from './config_DEPRECATED';
 import { CLIConfiguration } from './CLIConfiguration';
 import {
@@ -52,8 +50,7 @@ export function configFileExists(
 ): boolean {
   return useHiddenConfig
     ? newConfigFileExists()
-    : Boolean(configPath && fs.existsSync(configPath)) ||
-        Boolean(config_DEPRECATED.loadConfig(configPath));
+    : Boolean(config_DEPRECATED.getConfigPath(configPath));
 }
 
 export function getConfigPath(


### PR DESCRIPTION
## Description and Context
This impacts the migration flow for global config. I was using the `Boolean(config_DEPRECATED.loadConfig(configPath))` function in the `configFileExists` function to check whether the deprecated config exists. The deprecated config function is working as designed and throws an error that says `A hubspot.config.yml file could not be found. To create a new config file, use the "hs init" command.` But we don't need that error with global config, and it might lead to confusion with customers.

I've replaced that function with `config_DEPRECATED.getConfigPath(configPath)`. As @camden11 pointed out, however, when a `configPath` is provided as argument, the function simply returns it. I've protected against that by checking whether the config path exists before running the command.  

## Screenshots
BEFORE (Yucky error):

<img width="1174" alt="Screenshot 2025-04-02 at 2 27 40 PM" src="https://github.com/user-attachments/assets/142487f5-2f53-42c9-ae02-f613016a70b1" />

AFTER (With no error):

<img width="912" alt="Screenshot 2025-04-02 at 2 26 07 PM" src="https://github.com/user-attachments/assets/f1aaa1f9-67e0-4dff-8631-914a54b2de50" />

## TODO

- [ ] Address feedback

## Who to Notify
@brandenrodgers @camden11 @joe-yeager 
