### PR TITLE
Add timeout to HubSpotHttpError

### DIFF
--- a/models/HubSpotHttpError.ts
+++ b/models/HubSpotHttpError.ts
@@ -18,7 +18,7 @@ export class HubSpotHttpError<T = any> extends Error {
   public detailedMessage?: string;
   private divider = `\n- `;
   public cause: ErrorOptions['cause'];
-
+  public timeout?: number;
   constructor(
     message?: string,
     options?: ErrorOptions,
@@ -42,6 +42,7 @@ export class HubSpotHttpError<T = any> extends Error {
 
       this.code = code;
       this.method = config?.method;
+      this.timeout = config?.timeout;
 
       // Pull the request fields to the top level
       if (response) {


### PR DESCRIPTION
## Description and Context
This adds the `timeout` field from `AxiosError` to `HubSpotHttpError`, so that the CLI can check it and determine if timeouts were caused by the config default timeout.

## Who to Notify

@brandenrodgers @joe-yeager @kemmerle 
