### PR TITLE
Dynamic config migrations

### DIFF
--- a/config/__tests__/migrate.test.ts
+++ b/config/__tests__/migrate.test.ts
@@ -1,0 +1,392 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import {
+  getConfigAtPath,
+  migrateConfigAtPath,
+  mergeConfigProperties,
+  mergeConfigAccounts,
+} from '../migrate';
+import { HubSpotConfig } from '../../types/Config';
+import {
+  getGlobalConfigFilePath,
+  readConfigFile,
+  writeConfigFile,
+} from '../utils';
+import {
+  DEFAULT_CMS_PUBLISH_MODE,
+  HTTP_TIMEOUT,
+  ENV,
+  HTTP_USE_LOCALHOST,
+  ALLOW_USAGE_TRACKING,
+  DEFAULT_ACCOUNT,
+} from '../../constants/config';
+import { ENVIRONMENTS } from '../../constants/environments';
+import { PERSONAL_ACCESS_KEY_AUTH_METHOD } from '../../constants/auth';
+import { PersonalAccessKeyConfigAccount } from '../../types/Accounts';
+import { createEmptyConfigFile } from '../index';
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  unlinkSync: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  readConfigFile: jest.fn(),
+  writeConfigFile: jest.fn(),
+  getGlobalConfigFilePath: jest.fn(),
+}));
+
+jest.mock('../index', () => ({
+  ...jest.requireActual('../index'),
+  createEmptyConfigFile: jest.fn(),
+}));
+
+describe('config/migrate', () => {
+  let mockConfig: HubSpotConfig;
+  let mockConfigSource: string;
+  let mockConfigPath: string;
+  let mockGlobalConfigPath: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockConfig = {
+      accounts: [
+        {
+          accountId: 123456,
+          name: 'Test Account',
+          authType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+          personalAccessKey: 'test-key',
+          env: ENVIRONMENTS.PROD,
+          auth: {
+            tokenInfo: {},
+          },
+        } as PersonalAccessKeyConfigAccount,
+      ],
+      defaultCmsPublishMode: 'draft',
+      httpTimeout: 5000,
+      env: ENVIRONMENTS.PROD,
+      httpUseLocalhost: false,
+      allowUsageTracking: true,
+      defaultAccount: 123456,
+    };
+
+    mockConfigSource = JSON.stringify(mockConfig);
+    mockConfigPath = '/path/to/config.yml';
+    mockGlobalConfigPath = path.join(os.homedir(), '.hscli', 'config.yml');
+
+    (readConfigFile as jest.Mock).mockReturnValue(mockConfigSource);
+    (getGlobalConfigFilePath as jest.Mock).mockReturnValue(
+      mockGlobalConfigPath
+    );
+  });
+
+  describe('getConfigAtPath', () => {
+    it('should read and parse config from the given path', () => {
+      const result = getConfigAtPath(mockConfigPath);
+
+      expect(readConfigFile).toHaveBeenCalledWith(mockConfigPath);
+      expect(result).toEqual(mockConfig);
+    });
+  });
+
+  describe('migrateConfigAtPath', () => {
+    it('should migrate config from the given path to the global config path', () => {
+      (createEmptyConfigFile as jest.Mock).mockImplementation(() => undefined);
+      migrateConfigAtPath(mockConfigPath);
+
+      expect(createEmptyConfigFile).toHaveBeenCalledWith(true);
+      expect(readConfigFile).toHaveBeenCalledWith(mockConfigPath);
+      expect(writeConfigFile).toHaveBeenCalledWith(
+        mockConfig,
+        mockGlobalConfigPath
+      );
+      expect(fs.unlinkSync).toHaveBeenCalledWith(mockConfigPath);
+    });
+  });
+
+  describe('mergeConfigProperties', () => {
+    it('should merge properties from fromConfig to toConfig without conflicts when force is false', () => {
+      // Arrange
+      const toConfig: HubSpotConfig = {
+        accounts: [],
+        defaultCmsPublishMode: 'publish',
+        httpTimeout: 3000,
+        env: ENVIRONMENTS.QA,
+        httpUseLocalhost: true,
+        allowUsageTracking: false,
+        defaultAccount: 654321,
+      };
+
+      const fromConfig: HubSpotConfig = {
+        accounts: [],
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+        httpUseLocalhost: false,
+        allowUsageTracking: true,
+        defaultAccount: 123456,
+      };
+
+      const result = mergeConfigProperties(toConfig, fromConfig);
+
+      expect(result.configWithMergedProperties).toEqual(toConfig);
+      expect(result.conflicts).toHaveLength(6);
+      expect(result.conflicts).toContainEqual({
+        property: DEFAULT_CMS_PUBLISH_MODE,
+        oldValue: 'draft',
+        newValue: 'publish',
+      });
+      expect(result.conflicts).toContainEqual({
+        property: HTTP_TIMEOUT,
+        oldValue: 5000,
+        newValue: 3000,
+      });
+      expect(result.conflicts).toContainEqual({
+        property: ENV,
+        oldValue: ENVIRONMENTS.PROD,
+        newValue: ENVIRONMENTS.QA,
+      });
+      expect(result.conflicts).toContainEqual({
+        property: HTTP_USE_LOCALHOST,
+        oldValue: false,
+        newValue: true,
+      });
+      expect(result.conflicts).toContainEqual({
+        property: ALLOW_USAGE_TRACKING,
+        oldValue: true,
+        newValue: false,
+      });
+      expect(result.conflicts).toContainEqual({
+        property: DEFAULT_ACCOUNT,
+        oldValue: 123456,
+        newValue: 654321,
+      });
+    });
+
+    it('should merge properties from fromConfig to toConfig without conflicts when force is true', () => {
+      const toConfig: HubSpotConfig = {
+        accounts: [],
+        defaultCmsPublishMode: 'publish',
+        httpTimeout: 3000,
+        env: ENVIRONMENTS.QA,
+        httpUseLocalhost: true,
+        allowUsageTracking: false,
+        defaultAccount: 654321,
+      };
+
+      const fromConfig: HubSpotConfig = {
+        accounts: [],
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+        httpUseLocalhost: false,
+        allowUsageTracking: true,
+        defaultAccount: 123456,
+      };
+
+      const result = mergeConfigProperties(toConfig, fromConfig, true);
+
+      expect(result.configWithMergedProperties).toEqual({
+        ...toConfig,
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+        httpUseLocalhost: false,
+        allowUsageTracking: true,
+        defaultAccount: 123456,
+      });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it('should merge properties from fromConfig to toConfig when toConfig has missing properties', () => {
+      const toConfig: HubSpotConfig = {
+        accounts: [],
+      };
+
+      const fromConfig: HubSpotConfig = {
+        accounts: [],
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+        httpUseLocalhost: false,
+        allowUsageTracking: true,
+        defaultAccount: 123456,
+      };
+
+      const result = mergeConfigProperties(toConfig, fromConfig);
+
+      expect(result.configWithMergedProperties).toEqual({
+        ...toConfig,
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+        httpUseLocalhost: false,
+        allowUsageTracking: true,
+        defaultAccount: 123456,
+      });
+      expect(result.conflicts).toHaveLength(0);
+    });
+  });
+
+  describe('mergeConfigAccounts', () => {
+    it('should merge accounts from fromConfig to toConfig and skip existing accounts', () => {
+      const existingAccount = {
+        accountId: 123456,
+        name: 'Existing Account',
+        authType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+        personalAccessKey: 'existing-key',
+        env: ENVIRONMENTS.PROD,
+        auth: {
+          tokenInfo: {},
+        },
+      } as PersonalAccessKeyConfigAccount;
+
+      const newAccount = {
+        accountId: 789012,
+        name: 'New Account',
+        authType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+        personalAccessKey: 'new-key',
+        env: ENVIRONMENTS.PROD,
+        auth: {
+          tokenInfo: {},
+        },
+      } as PersonalAccessKeyConfigAccount;
+
+      const toConfig: HubSpotConfig = {
+        accounts: [existingAccount],
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+      };
+
+      const fromConfig: HubSpotConfig = {
+        accounts: [existingAccount, newAccount],
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+      };
+
+      const result = mergeConfigAccounts(toConfig, fromConfig);
+
+      expect(result.configWithMergedAccounts.accounts).toHaveLength(2);
+      expect(result.configWithMergedAccounts.accounts).toContainEqual(
+        existingAccount
+      );
+      expect(result.configWithMergedAccounts.accounts).toContainEqual(
+        newAccount
+      );
+      expect(result.skippedAccountIds).toEqual([123456]);
+      expect(writeConfigFile).toHaveBeenCalledWith(
+        result.configWithMergedAccounts,
+        mockGlobalConfigPath
+      );
+    });
+
+    it('should handle empty accounts arrays', () => {
+      const toConfig: HubSpotConfig = {
+        accounts: [],
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+      };
+
+      const fromConfig: HubSpotConfig = {
+        accounts: [],
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+      };
+
+      const result = mergeConfigAccounts(toConfig, fromConfig);
+
+      expect(result.configWithMergedAccounts.accounts).toHaveLength(0);
+      expect(result.skippedAccountIds).toEqual([]);
+      expect(writeConfigFile).toHaveBeenCalledWith(
+        result.configWithMergedAccounts,
+        mockGlobalConfigPath
+      );
+    });
+
+    it('should handle case when fromConfig has no accounts', () => {
+      const existingAccount = {
+        accountId: 123456,
+        name: 'Existing Account',
+        authType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+        personalAccessKey: 'existing-key',
+        env: ENVIRONMENTS.PROD,
+        auth: {
+          tokenInfo: {},
+        },
+      } as PersonalAccessKeyConfigAccount;
+
+      const toConfig: HubSpotConfig = {
+        accounts: [existingAccount],
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+      };
+
+      const fromConfig: HubSpotConfig = {
+        accounts: [],
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+      };
+
+      const result = mergeConfigAccounts(toConfig, fromConfig);
+
+      expect(result.configWithMergedAccounts.accounts).toHaveLength(1);
+      expect(result.configWithMergedAccounts.accounts).toContainEqual(
+        existingAccount
+      );
+      expect(result.skippedAccountIds).toEqual([]);
+      expect(writeConfigFile).toHaveBeenCalledWith(
+        result.configWithMergedAccounts,
+        mockGlobalConfigPath
+      );
+    });
+
+    it('should handle case when toConfig has no accounts', () => {
+      const newAccount = {
+        accountId: 789012,
+        name: 'New Account',
+        authType: PERSONAL_ACCESS_KEY_AUTH_METHOD.value,
+        personalAccessKey: 'new-key',
+        env: ENVIRONMENTS.PROD,
+        auth: {
+          tokenInfo: {},
+        },
+      } as PersonalAccessKeyConfigAccount;
+
+      const toConfig: HubSpotConfig = {
+        accounts: [],
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+      };
+
+      const fromConfig: HubSpotConfig = {
+        accounts: [newAccount],
+        defaultCmsPublishMode: 'draft',
+        httpTimeout: 5000,
+        env: ENVIRONMENTS.PROD,
+      };
+
+      const result = mergeConfigAccounts(toConfig, fromConfig);
+
+      expect(result.configWithMergedAccounts.accounts).toHaveLength(1);
+      expect(result.configWithMergedAccounts.accounts).toContainEqual(
+        newAccount
+      );
+      expect(result.skippedAccountIds).toEqual([]);
+      expect(writeConfigFile).toHaveBeenCalledWith(
+        result.configWithMergedAccounts,
+        mockGlobalConfigPath
+      );
+    });
+  });
+});

--- a/config/migrate.ts
+++ b/config/migrate.ts
@@ -18,7 +18,7 @@ import {
 } from './utils';
 import { ValueOf } from '../types/Utils';
 
-function getConfigAtPath(path: string): HubSpotConfig {
+export function getConfigAtPath(path: string): HubSpotConfig {
   const configFileSource = readConfigFile(path);
 
   return parseConfig(configFileSource);

--- a/config/migrate.ts
+++ b/config/migrate.ts
@@ -1,218 +1,119 @@
-import * as config_DEPRECATED from './config_DEPRECATED';
-import { CLIConfiguration } from './CLIConfiguration';
+import fs from 'fs';
+
+import { HubSpotConfig } from '../types/Config';
+import { createEmptyConfigFile } from './index';
 import {
-  CLIConfig,
-  CLIConfig_DEPRECATED,
-  CLIConfig_NEW,
-  Environment,
-} from '../types/Config';
-import { CmsPublishMode } from '../types/Files';
-import {
-  writeConfig,
-  createEmptyConfigFile,
-  loadConfig,
-  deleteEmptyConfigFile,
-} from './index';
-import {
-  getConfigFilePath,
-  configFileExists as newConfigFileExists,
-} from './configFile';
-import {
-  GLOBAL_CONFIG_PATH,
   DEFAULT_CMS_PUBLISH_MODE,
   HTTP_TIMEOUT,
   ENV,
   HTTP_USE_LOCALHOST,
   ALLOW_USAGE_TRACKING,
   DEFAULT_ACCOUNT,
-  DEFAULT_PORTAL,
 } from '../constants/config';
-import { i18n } from '../utils/lang';
+import {
+  getGlobalConfigFilePath,
+  parseConfig,
+  readConfigFile,
+  writeConfigFile,
+} from './utils';
+import { ValueOf } from '../types/Utils';
 
-const i18nKey = 'config.migrate';
+function getConfigAtPath(path: string): HubSpotConfig {
+  const configFileSource = readConfigFile(path);
 
-export function getDeprecatedConfig(
-  configPath?: string
-): CLIConfig_DEPRECATED | null {
-  return config_DEPRECATED.loadConfig(configPath);
+  return parseConfig(configFileSource);
 }
 
-export function getGlobalConfig(): CLIConfig_NEW | null {
-  if (CLIConfiguration.isActive()) {
-    return CLIConfiguration.config;
-  }
-  return null;
+export function migrateConfigAtPath(path: string): void {
+  createEmptyConfigFile(true);
+  const configToMigrate = getConfigAtPath(path);
+  writeConfigFile(configToMigrate, getGlobalConfigFilePath());
+  fs.unlinkSync(path);
 }
 
-export function configFileExists(
-  useHiddenConfig = false,
-  configPath?: string
-): boolean {
-  return useHiddenConfig
-    ? newConfigFileExists()
-    : Boolean(config_DEPRECATED.getConfigPath(configPath));
-}
-
-export function getConfigPath(
-  configPath?: string,
-  useHiddenConfig = false
-): string | null {
-  if (useHiddenConfig) {
-    return getConfigFilePath();
-  }
-  return config_DEPRECATED.getConfigPath(configPath);
-}
-
-function writeGlobalConfigFile(
-  updatedConfig: CLIConfig_NEW,
-  isMigrating = false
-): void {
-  const updatedConfigJson = JSON.stringify(updatedConfig);
-  if (isMigrating) {
-    createEmptyConfigFile({}, true);
-  }
-  loadConfig('');
-
-  try {
-    writeConfig({ source: updatedConfigJson });
-    config_DEPRECATED.deleteConfigFile();
-  } catch (error) {
-    deleteEmptyConfigFile();
-    throw new Error(
-      i18n(`${i18nKey}.errors.writeConfig`, { configPath: GLOBAL_CONFIG_PATH }),
-      { cause: error }
-    );
-  }
-}
-
-export function migrateConfig(
-  deprecatedConfig: CLIConfig_DEPRECATED | null
-): void {
-  if (!deprecatedConfig) {
-    throw new Error(i18n(`${i18nKey}.errors.noDeprecatedConfig`));
-  }
-  const { defaultPortal, portals, ...rest } = deprecatedConfig;
-  const updatedConfig = {
-    ...rest,
-    defaultAccount: defaultPortal,
-    accounts: portals
-      .filter(({ portalId }) => portalId !== undefined)
-      .map(({ portalId, ...rest }) => ({
-        ...rest,
-        accountId: portalId!,
-      })),
-  };
-  writeGlobalConfigFile(updatedConfig, true);
-}
-
-type ConflictValue = boolean | string | number | CmsPublishMode | Environment;
 export type ConflictProperty = {
-  property: keyof CLIConfig_NEW;
-  oldValue: ConflictValue;
-  newValue: ConflictValue;
+  property: keyof HubSpotConfig;
+  oldValue: ValueOf<HubSpotConfig>;
+  newValue: ValueOf<HubSpotConfig>;
 };
 
 export function mergeConfigProperties(
-  globalConfig: CLIConfig_NEW,
-  deprecatedConfig: CLIConfig_DEPRECATED,
+  toConfig: HubSpotConfig,
+  fromConfig: HubSpotConfig,
   force?: boolean
 ): {
-  initialConfig: CLIConfig_NEW;
+  configWithMergedProperties: HubSpotConfig;
   conflicts: Array<ConflictProperty>;
 } {
-  const propertiesToCheck: Array<keyof Partial<CLIConfig>> = [
-    DEFAULT_CMS_PUBLISH_MODE,
-    HTTP_TIMEOUT,
-    ENV,
-    HTTP_USE_LOCALHOST,
-    ALLOW_USAGE_TRACKING,
-  ];
   const conflicts: Array<ConflictProperty> = [];
 
-  propertiesToCheck.forEach(prop => {
-    if (prop in globalConfig && prop in deprecatedConfig) {
-      if (force || globalConfig[prop] === deprecatedConfig[prop]) {
-        // @ts-expect-error Cannot reconcile CLIConfig_NEW and CLIConfig_DEPRECATED types
-        globalConfig[prop] = deprecatedConfig[prop];
-      } else {
+  if (force) {
+    toConfig.defaultCmsPublishMode = fromConfig.defaultCmsPublishMode;
+    toConfig.httpTimeout = fromConfig.httpTimeout;
+    toConfig.env = fromConfig.env;
+    toConfig.httpUseLocalhost = fromConfig.httpUseLocalhost;
+    toConfig.allowUsageTracking = fromConfig.allowUsageTracking;
+    toConfig.defaultAccount = fromConfig.defaultAccount;
+  } else {
+    const propertiesToCheck = [
+      DEFAULT_CMS_PUBLISH_MODE,
+      HTTP_TIMEOUT,
+      ENV,
+      HTTP_USE_LOCALHOST,
+      ALLOW_USAGE_TRACKING,
+      DEFAULT_ACCOUNT,
+    ] as const;
+
+    propertiesToCheck.forEach(prop => {
+      if (toConfig[prop] !== fromConfig[prop]) {
         conflicts.push({
           property: prop,
-          oldValue: deprecatedConfig[prop]!,
-          newValue: globalConfig[prop]!,
+          oldValue: fromConfig[prop],
+          newValue: toConfig[prop],
         });
       }
+    });
+  }
+
+  return { configWithMergedProperties: toConfig, conflicts };
+}
+
+function buildConfigWithMergedAccounts(
+  toConfig: HubSpotConfig,
+  fromConfig: HubSpotConfig
+): {
+  configWithMergedAccounts: HubSpotConfig;
+  skippedAccountIds: Array<number>;
+} {
+  const existingAccountIds = toConfig.accounts.map(
+    ({ accountId }) => accountId
+  );
+  const skippedAccountIds: Array<number> = [];
+
+  fromConfig.accounts.forEach(account => {
+    if (existingAccountIds.includes(account.accountId)) {
+      skippedAccountIds.push(account.accountId);
+    } else {
+      toConfig.accounts.push(account);
     }
   });
 
-  if (
-    DEFAULT_ACCOUNT in globalConfig &&
-    DEFAULT_PORTAL in deprecatedConfig &&
-    globalConfig.defaultAccount !== deprecatedConfig.defaultPortal
-  ) {
-    if (force) {
-      globalConfig.defaultAccount = deprecatedConfig.defaultPortal;
-    } else {
-      conflicts.push({
-        property: DEFAULT_ACCOUNT,
-        oldValue: deprecatedConfig.defaultPortal!,
-        newValue: globalConfig.defaultAccount!,
-      });
-    }
-  } else if (DEFAULT_PORTAL in deprecatedConfig) {
-    globalConfig.defaultAccount = deprecatedConfig.defaultPortal;
-  }
-
-  return { initialConfig: globalConfig, conflicts };
-}
-
-function mergeAccounts(
-  globalConfig: CLIConfig_NEW,
-  deprecatedConfig: CLIConfig_DEPRECATED
-): {
-  finalConfig: CLIConfig_NEW;
-  skippedAccountIds: Array<string | number>;
-} {
-  let existingAccountIds: Array<string | number> = [];
-  const skippedAccountIds: Array<string | number> = [];
-
-  if (globalConfig.accounts && deprecatedConfig.portals) {
-    existingAccountIds = globalConfig.accounts.map(
-      account => account.accountId
-    );
-
-    const newAccounts = deprecatedConfig.portals
-      .filter(portal => {
-        const isExisting = existingAccountIds.includes(portal.portalId!);
-        if (isExisting) {
-          skippedAccountIds.push(portal.portalId!);
-        }
-        return !isExisting;
-      })
-      .map(({ portalId, ...rest }) => ({
-        ...rest,
-        accountId: portalId!,
-      }));
-
-    if (newAccounts.length > 0) {
-      globalConfig.accounts.push(...newAccounts);
-    }
-  }
-
   return {
-    finalConfig: globalConfig,
+    configWithMergedAccounts: toConfig,
     skippedAccountIds,
   };
 }
 
-export function mergeExistingConfigs(
-  globalConfig: CLIConfig_NEW,
-  deprecatedConfig: CLIConfig_DEPRECATED
-): { finalConfig: CLIConfig_NEW; skippedAccountIds: Array<string | number> } {
-  const { finalConfig, skippedAccountIds } = mergeAccounts(
-    globalConfig,
-    deprecatedConfig
-  );
+export function mergeConfigAccounts(
+  toConfig: HubSpotConfig,
+  fromConfig: HubSpotConfig
+): {
+  configWithMergedAccounts: HubSpotConfig;
+  skippedAccountIds: Array<string | number>;
+} {
+  const { configWithMergedAccounts, skippedAccountIds } =
+    buildConfigWithMergedAccounts(toConfig, fromConfig);
 
-  writeGlobalConfigFile(finalConfig);
-  return { finalConfig, skippedAccountIds };
+  writeConfigFile(configWithMergedAccounts, getGlobalConfigFilePath());
+  return { configWithMergedAccounts, skippedAccountIds };
 }

--- a/config/migrate.ts
+++ b/config/migrate.ts
@@ -58,8 +58,14 @@ export function mergeConfigProperties(
     toConfig.defaultCmsPublishMode ||= fromConfig.defaultCmsPublishMode;
     toConfig.httpTimeout ||= fromConfig.httpTimeout;
     toConfig.env ||= fromConfig.env;
-    toConfig.httpUseLocalhost ||= fromConfig.httpUseLocalhost;
-    toConfig.allowUsageTracking ||= fromConfig.allowUsageTracking;
+    toConfig.httpUseLocalhost =
+      toConfig.httpUseLocalhost === undefined
+        ? fromConfig.httpUseLocalhost
+        : toConfig.httpUseLocalhost;
+    toConfig.allowUsageTracking =
+      toConfig.allowUsageTracking === undefined
+        ? fromConfig.allowUsageTracking
+        : toConfig.allowUsageTracking;
     toConfig.defaultAccount ||= fromConfig.defaultAccount;
 
     const propertiesToCheck = [
@@ -72,7 +78,7 @@ export function mergeConfigProperties(
     ] as const;
 
     propertiesToCheck.forEach(prop => {
-      if (toConfig[prop] && toConfig[prop] !== fromConfig[prop]) {
+      if (toConfig[prop] !== undefined && toConfig[prop] !== fromConfig[prop]) {
         conflicts.push({
           property: prop,
           oldValue: fromConfig[prop],

--- a/config/migrate.ts
+++ b/config/migrate.ts
@@ -55,6 +55,13 @@ export function mergeConfigProperties(
     toConfig.allowUsageTracking = fromConfig.allowUsageTracking;
     toConfig.defaultAccount = fromConfig.defaultAccount;
   } else {
+    toConfig.defaultCmsPublishMode ||= fromConfig.defaultCmsPublishMode;
+    toConfig.httpTimeout ||= fromConfig.httpTimeout;
+    toConfig.env ||= fromConfig.env;
+    toConfig.httpUseLocalhost ||= fromConfig.httpUseLocalhost;
+    toConfig.allowUsageTracking ||= fromConfig.allowUsageTracking;
+    toConfig.defaultAccount ||= fromConfig.defaultAccount;
+
     const propertiesToCheck = [
       DEFAULT_CMS_PUBLISH_MODE,
       HTTP_TIMEOUT,
@@ -65,7 +72,7 @@ export function mergeConfigProperties(
     ] as const;
 
     propertiesToCheck.forEach(prop => {
-      if (toConfig[prop] !== fromConfig[prop]) {
+      if (toConfig[prop] && toConfig[prop] !== fromConfig[prop]) {
         conflicts.push({
           property: prop,
           oldValue: fromConfig[prop],

--- a/lang/en.json
+++ b/lang/en.json
@@ -305,8 +305,7 @@
     },
     "migrate": {
       "errors": {
-        "writeConfig": "Unable to write global configuration file at {{ configPath }}.",
-        "noDeprecatedConfig": "No deprecated configuration file found. Skipping migration to global config."
+        "writeConfig": "Unable to write global configuration file at {{ configPath }}."
       }
     }
   },

--- a/lang/en.json
+++ b/lang/en.json
@@ -302,11 +302,6 @@
         "errorHeader": "Error in {{ hsAccountFile }}",
         "readFileError": "Error reading account override file."
       }
-    },
-    "migrate": {
-      "errors": {
-        "writeConfig": "Unable to write global configuration file at {{ configPath }}."
-      }
     }
   },
   "models": {


### PR DESCRIPTION
## Description and Context
In an attempt to not let the config revamp work get too stale, I've updated the `dynamic-config` branch to apply the new config logic to @kemmerle's migration work. The fact that the global and deprecated config are both converted to the same object shape makes merging them much simpler. Like the rest of the config revamp work, this will be breaking for the CLI, but we'll cross that bridge when we get there

Note: merging this into my `dynamic-config` branch, not main

## Who to Notify

@kemmerle @brandenrodgers @joe-yeager 
