### PR TITLE
Fix bug when merging configs (global config work)

### DIFF
--- a/config/migrate.ts
+++ b/config/migrate.ts
@@ -130,8 +130,12 @@ export function mergeConfigProperties(
   const conflicts: Array<ConflictProperty> = [];
 
   propertiesToCheck.forEach(prop => {
-    if (prop in globalConfig && prop in deprecatedConfig) {
-      if (force || globalConfig[prop] === deprecatedConfig[prop]) {
+    if (prop in deprecatedConfig) {
+      if (
+        force ||
+        !(prop in globalConfig) ||
+        globalConfig[prop] === deprecatedConfig[prop]
+      ) {
         // @ts-expect-error Cannot reconcile CLIConfig_NEW and CLIConfig_DEPRECATED types
         globalConfig[prop] = deprecatedConfig[prop];
       } else {


### PR DESCRIPTION
## Description and Context
@camden11 discovered a bug when merging deprecated and global configs in the `hs config migrate` command: Properties that existed in the deprecated config but not in the global were not being properly migrated to the global config.  This PR fixes that bug. 

## TODO

- [ ] Address feedback 

## Who to Notify
@brandenrodgers @camden11 @joe-yeager 
