### PR TITLE
fix: make sure response.data is an object before using `in` operator

### DIFF
--- a/models/HubSpotHttpError.ts
+++ b/models/HubSpotHttpError.ts
@@ -51,7 +51,11 @@ export class HubSpotHttpError<T = any> extends Error {
         this.status = response.status;
         this.statusText = response.statusText;
         this.data = response.data;
-        if (response.data && 'correlationId' in response.data) {
+        if (
+          response.data &&
+          typeof response.data === 'object' &&
+          'correlationId' in response.data
+        ) {
           this.correlationId = response.data.correlationId;
         }
         this.headers = response.headers;


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Fixes a runtime issue when `response.data` is html
