### PR TITLE
Fix the return type of the create dev test account api

### DIFF
--- a/api/developerTestAccounts.ts
+++ b/api/developerTestAccounts.ts
@@ -4,6 +4,7 @@ import { getAxiosConfig } from '../http/getAxiosConfig';
 import { ENVIRONMENTS } from '../constants/environments';
 import {
   DeveloperTestAccount,
+  CreateDeveloperTestAccountResponse,
   FetchDeveloperTestAccountsResponse,
 } from '../types/developerTestAccounts';
 import { SANDBOX_TIMEOUT } from '../constants/api';
@@ -23,8 +24,8 @@ export function fetchDeveloperTestAccounts(
 export function createDeveloperTestAccount(
   accountId: number,
   accountName: string
-): HubSpotPromise<DeveloperTestAccount> {
-  return http.post<DeveloperTestAccount>(accountId, {
+): HubSpotPromise<CreateDeveloperTestAccountResponse> {
+  return http.post<CreateDeveloperTestAccountResponse>(accountId, {
     url: TEST_ACCOUNTS_API_PATH,
     data: { accountName, generatePersonalAccessKey: true }, // For CLI, generatePersonalAccessKey will always be true since we'll be saving the entry to the config
     timeout: SANDBOX_TIMEOUT,

--- a/types/developerTestAccounts.ts
+++ b/types/developerTestAccounts.ts
@@ -8,6 +8,17 @@ export type DeveloperTestAccount = {
   id: number;
 };
 
+export type CreateDeveloperTestAccountResponse = {
+  id: number;
+  accountName: string;
+  createdAt: string;
+  updatedAt: string;
+  trialEndsAt: string;
+  status: string;
+  currentUserHasAccess: boolean;
+  personalAccessKey: string;
+};
+
 export type FetchDeveloperTestAccountsResponse = {
   results: DeveloperTestAccount[];
   maxTestPortals: number;


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

The return type isn't the same as the dev test account shape. It includes a personal access key that we can immediately store in the CLI config. This prevents us from having to prompt the user for the key after creating the account.

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
