### PR TITLE
fix: Check if string is defined before attempting to access string methods

### DIFF
--- a/lib/__tests__/text.test.ts
+++ b/lib/__tests__/text.test.ts
@@ -1,4 +1,4 @@
-import { commaSeparatedValues } from '../text';
+import { commaSeparatedValues, toKebabCase } from '../text';
 
 describe('lib/text', () => {
   describe('commaSeparatedValues()', () => {
@@ -18,6 +18,51 @@ describe('lib/text', () => {
       const res = commaSeparatedValues([], null, 'input is empty');
 
       expect(res).toBe('input is empty');
+    });
+
+    it('handles a single item array', () => {
+      const res = commaSeparatedValues(['only']);
+
+      expect(res).toBe('only');
+    });
+
+    it('handles a two item array', () => {
+      const res = commaSeparatedValues(['first', 'second']);
+
+      expect(res).toBe('first and second');
+    });
+  });
+
+  describe('toKebabCase()', () => {
+    it('converts a string to kebab case', () => {
+      expect(toKebabCase('testString')).toBe('test-string');
+    });
+
+    it('handles capitalized words', () => {
+      expect(toKebabCase('TestString')).toBe('test-string');
+    });
+
+    it('handles spaces', () => {
+      expect(toKebabCase('test string')).toBe('test-string');
+    });
+
+    it('handles special characters', () => {
+      expect(toKebabCase('test!@#$%^&*()string')).toBe('test-string');
+    });
+
+    it('handles multiple uppercase letters in sequence', () => {
+      expect(toKebabCase('testAPIString')).toBe('test-api-string');
+    });
+
+    it('handles empty string', () => {
+      expect(toKebabCase('')).toBe('');
+    });
+
+    it('handles null or undefined input by returning empty string', () => {
+      // @ts-expect-error - Testing null input even though type is string
+      expect(toKebabCase(null)).toBe('');
+      // @ts-expect-error - Testing undefined input even though type is string
+      expect(toKebabCase(undefined)).toBe('');
     });
   });
 });

--- a/lib/__tests__/text.test.ts
+++ b/lib/__tests__/text.test.ts
@@ -59,9 +59,7 @@ describe('lib/text', () => {
     });
 
     it('handles null or undefined input by returning empty string', () => {
-      // @ts-expect-error - Testing null input even though type is string
       expect(toKebabCase(null)).toBe('');
-      // @ts-expect-error - Testing undefined input even though type is string
       expect(toKebabCase(undefined)).toBe('');
     });
   });

--- a/lib/text.ts
+++ b/lib/text.ts
@@ -12,7 +12,7 @@ export function commaSeparatedValues(
   return arr.join(', ');
 }
 
-export function toKebabCase(str: string): string {
+export function toKebabCase(str: string | null | undefined): string {
   if (!str) {
     return '';
   }

--- a/lib/text.ts
+++ b/lib/text.ts
@@ -13,6 +13,10 @@ export function commaSeparatedValues(
 }
 
 export function toKebabCase(str: string): string {
+  if (!str) {
+    return '';
+  }
+
   return (
     str
       .replace(/[.,/#!$%^&*;:{}=\-_'"`~()]/g, '')


### PR DESCRIPTION
## Description and Context
Check if the string is defined before calling `str.replace`