### PR TITLE
fix: Check if errors is an array before attempting to iterate it

### DIFF
--- a/models/HubSpotHttpError.ts
+++ b/models/HubSpotHttpError.ts
@@ -138,7 +138,7 @@ export class HubSpotHttpError<T = any> extends Error {
 
   private parseValidationErrors(
     responseData: {
-      errors?: Array<ValidationError>;
+      errors?: Array<ValidationError> | string;
       message?: string;
     } = { errors: [], message: '' }
   ): void {
@@ -154,7 +154,7 @@ export class HubSpotHttpError<T = any> extends Error {
       errorMessages.push(message);
     }
 
-    if (errors) {
+    if (Array.isArray(errors)) {
       const specificErrors = errors.map(error => {
         let errorMessage = error.message;
 
@@ -170,6 +170,8 @@ export class HubSpotHttpError<T = any> extends Error {
         return errorMessage;
       });
       errorMessages.push(...specificErrors);
+    } else if (typeof errors === 'string') {
+      errorMessages.push(errors);
     }
 
     this.validationErrors = errorMessages;

--- a/models/HubSpotHttpError.ts
+++ b/models/HubSpotHttpError.ts
@@ -138,7 +138,7 @@ export class HubSpotHttpError<T = any> extends Error {
 
   private parseValidationErrors(
     responseData: {
-      errors?: Array<ValidationError> | string;
+      errors?: Array<ValidationError>;
       message?: string;
     } = { errors: [], message: '' }
   ): void {
@@ -157,7 +157,6 @@ export class HubSpotHttpError<T = any> extends Error {
     if (Array.isArray(errors)) {
       const specificErrors = errors.map(error => {
         let errorMessage = error.message;
-
         if (error.context?.requiredScopes) {
           // Sometimes the scopes come back with duplicates
           const scopes = new Set<string>(error.context.requiredScopes);
@@ -170,8 +169,6 @@ export class HubSpotHttpError<T = any> extends Error {
         return errorMessage;
       });
       errorMessages.push(...specificErrors);
-    } else if (typeof errors === 'string') {
-      errorMessages.push(errors);
     }
 
     this.validationErrors = errorMessages;

--- a/models/HubSpotHttpError.ts
+++ b/models/HubSpotHttpError.ts
@@ -146,7 +146,7 @@ export class HubSpotHttpError<T = any> extends Error {
       return;
     }
 
-    const errorMessages = [];
+    const errorMessages: string[] = [];
 
     const { errors, message } = responseData;
 


### PR DESCRIPTION
## Description and Context
Fixes an issue when the upload endpoint sometimes returns a `string` instead an array of `ErrorDetails`