### PR TITLE
Fix field options type

### DIFF
--- a/lib/cms/handleFieldsJS.ts
+++ b/lib/cms/handleFieldsJS.ts
@@ -15,7 +15,7 @@ export class FieldsJs {
   filePath: string;
   rootWriteDir: string;
   rejected: boolean;
-  fieldOptions: string;
+  fieldOptions: string | string[];
   outputPath?: string;
   toJSON?: () => JSON;
 
@@ -23,7 +23,7 @@ export class FieldsJs {
     projectDir: string,
     filePath: string,
     rootWriteDir?: string | null,
-    fieldOptions = ''
+    fieldOptions: string | string[] = ''
   ) {
     this.projectDir = projectDir;
     this.filePath = filePath;
@@ -48,6 +48,10 @@ export class FieldsJs {
     const dirName = path.dirname(filePath);
 
     return new Promise<string>((resolve, reject) => {
+      const fieldOptionsAsString = Array.isArray(this.fieldOptions)
+        ? this.fieldOptions.join(',')
+        : this.fieldOptions;
+
       const convertFieldsProcess = fork(
         path.join(__dirname, './processFieldsJs.js'),
         [],
@@ -55,7 +59,7 @@ export class FieldsJs {
           cwd: dirName,
           env: {
             dirName,
-            fieldOptions: this.fieldOptions,
+            fieldOptions: fieldOptionsAsString,
             filePath,
             writeDir,
           },


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

I'm porting `cms convert-fields` to TS and ran into a type issue. All the commands take `fieldOptions` as an array of strings.

I checked what it was back in cli-lib and it looks like it was an array there too: https://github.com/HubSpot/cli-lib/blob/main/lib/handleFieldsJs.js#L22

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
