### PR TITLE
Add override for retrieveDefaultModule

### DIFF
--- a/lib/cms/modules.ts
+++ b/lib/cms/modules.ts
@@ -14,6 +14,7 @@ import {
   ValidationResult,
   ModuleDefinition,
 } from '../../types/Modules';
+import { GithubRepoFile } from '../../types/Github';
 import { i18n } from '../../utils/lang';
 
 const i18nKey = 'lib.cms.modules';
@@ -271,10 +272,15 @@ export async function createModule(
   }
 }
 
+export async function retrieveDefaultModule(): Promise<GithubRepoFile[]>;
 export async function retrieveDefaultModule(
-  name: string | undefined,
+  name: string,
   dest: string
-) {
+): Promise<void>;
+export async function retrieveDefaultModule(
+  name?: string,
+  dest?: string
+): Promise<GithubRepoFile[] | void> {
   if (!name) {
     const defaultReactModules = await listGithubRepoContents(
       'HubSpot/cms-react',
@@ -284,9 +290,11 @@ export async function retrieveDefaultModule(
     return defaultReactModules;
   }
 
-  await cloneGithubRepo('HubSpot/cms-react', dest, {
-    sourceDir: `default-react-modules/src/components/modules/${name}`,
-  });
+  if (dest) {
+    await cloneGithubRepo('HubSpot/cms-react', dest, {
+      sourceDir: `default-react-modules/src/components/modules/${name}`,
+    });
+  }
 }
 
 const MODULE_HTML_EXTENSION_REGEX = new RegExp(


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

This function is kind of odd. It returns void if you pass a name and dest, and it returns a list of github files if you pass it nothing. I added an overload to it so the return type is more useful. This is helpful in the `cms get-react-module` command in the CLI

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
