### PR TITLE
Fix: Account names cannot be numbers

### DIFF
--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -204,12 +204,10 @@ class _CLIConfiguration {
       return null;
     }
 
-    if (typeof nameOrIdToCheck === 'number') {
-      accountId = nameOrIdToCheck;
-    } else if (/^\d+$/.test(nameOrIdToCheck)) {
-      accountId = parseInt(nameOrIdToCheck, 10);
-    } else {
+    if (typeof nameOrIdToCheck === 'string') {
       name = nameOrIdToCheck;
+    } else if (typeof nameOrIdToCheck === 'number') {
+      accountId = nameOrIdToCheck;
     }
 
     if (name) {

--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -206,12 +206,19 @@ class _CLIConfiguration {
 
     if (typeof nameOrIdToCheck === 'string') {
       name = nameOrIdToCheck;
+      if (/^\d+$/.test(nameOrIdToCheck)) {
+        accountId = parseInt(nameOrIdToCheck, 10);
+      }
     } else if (typeof nameOrIdToCheck === 'number') {
       accountId = nameOrIdToCheck;
     }
 
     if (name) {
-      return this.config.accounts.find(a => a.name === name) || null;
+      return (
+        this.config.accounts.find(a => a.name === name) ||
+        this.config.accounts.find(a => accountId === a.accountId) ||
+        null
+      );
     } else if (accountId) {
       return this.config.accounts.find(a => accountId === a.accountId) || null;
     }

--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -213,17 +213,17 @@ class _CLIConfiguration {
       accountId = nameOrIdToCheck;
     }
 
+    let account = null;
     if (name) {
-      return (
-        this.config.accounts.find(a => a.name === name) ||
-        this.config.accounts.find(a => accountId === a.accountId) ||
-        null
-      );
-    } else if (accountId) {
-      return this.config.accounts.find(a => accountId === a.accountId) || null;
+      account = this.config.accounts.find(a => a.name === name) || null;
     }
 
-    return null;
+    if (accountId && !account) {
+      account =
+        this.config.accounts.find(a => accountId === a.accountId) || null;
+    }
+
+    return account;
   }
 
   isConfigFlagEnabled(

--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -213,7 +213,7 @@ class _CLIConfiguration {
       accountId = nameOrIdToCheck;
     }
 
-    let account = null;
+    let account: CLIAccount_NEW | null = null;
     if (name) {
       account = this.config.accounts.find(a => a.name === name) || null;
     }

--- a/config/__tests__/config.test.ts
+++ b/config/__tests__/config.test.ts
@@ -143,12 +143,6 @@ describe('config/config', () => {
       expect(getAccountId(OAUTH2_CONFIG.name)).toEqual(OAUTH2_CONFIG.portalId);
     });
 
-    it('returns portalId from config when a string id is passed', () => {
-      expect(getAccountId((OAUTH2_CONFIG.portalId || '').toString())).toEqual(
-        OAUTH2_CONFIG.portalId
-      );
-    });
-
     it('returns portalId from config when a numeric id is passed', () => {
       expect(getAccountId(OAUTH2_CONFIG.portalId)).toEqual(
         OAUTH2_CONFIG.portalId

--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -410,6 +410,9 @@ export function getAccountId(nameOrId?: string | number): number | undefined {
   ): void {
     if (typeof suppliedValue === 'string') {
       name = suppliedValue;
+      if (/^\d+$/.test(suppliedValue)) {
+        accountId = parseInt(suppliedValue, 10);
+      }
     } else if (typeof suppliedValue === 'number') {
       accountId = suppliedValue;
     }
@@ -428,7 +431,8 @@ export function getAccountId(nameOrId?: string | number): number | undefined {
   const accounts = getConfigAccounts(config);
   if (name && accounts) {
     account = accounts.find(p => p.name === name);
-  } else if (accountId && accounts) {
+  }
+  if (accountId && accounts && !account) {
     account = accounts.find(p => accountId === p.portalId);
   }
 

--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -429,15 +429,16 @@ export function getAccountId(nameOrId?: string | number): number | undefined {
   }
 
   const accounts = getConfigAccounts(config);
-  if (name && accounts) {
-    account = accounts.find(p => p.name === name);
-  }
-  if (accountId && accounts && !account) {
-    account = accounts.find(p => accountId === p.portalId);
-  }
-
-  if (account) {
-    return account.portalId;
+  if (accounts) {
+    if (name) {
+      account = accounts.find(p => p.name === name);
+    }
+    if (accountId && !account) {
+      account = accounts.find(p => accountId === p.portalId);
+    }
+    if (account) {
+      return account.portalId;
+    }
   }
 
   return undefined;

--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -408,12 +408,10 @@ export function getAccountId(nameOrId?: string | number): number | undefined {
   function setNameOrAccountFromSuppliedValue(
     suppliedValue: string | number
   ): void {
-    if (typeof suppliedValue === 'number') {
-      accountId = suppliedValue;
-    } else if (/^\d+$/.test(suppliedValue)) {
-      accountId = parseInt(suppliedValue, 10);
-    } else {
+    if (typeof suppliedValue === 'string') {
       name = suppliedValue;
+    } else if (typeof suppliedValue === 'number') {
+      accountId = suppliedValue;
     }
   }
 


### PR DESCRIPTION
## Description and Context
The DevRel team discovered a bug, where they could not name accounts numbers, (ie. `2024`, `57`, etc). This was because we were using a regular expression to check with the `nameOrId` was a number--if it was, we then converted it to a number and treated it as the account ID. Now that we've implemented TypeScript in LDL and the CLI, we no longer need to perform this kind of check. We always know that the account name will be a string and the account ID is a number. 

## Screenshots
Before:

<img width="1045" alt="Screenshot 2025-05-12 at 10 34 21 AM" src="https://github.com/user-attachments/assets/36d356c1-a3b1-4b96-849b-db4d17cbd504" />


<img width="1070" alt="Screenshot 2025-05-12 at 10 33 28 AM" src="https://github.com/user-attachments/assets/0f30203d-88fa-46b9-80a0-571542b4d90f" />

After:

<img width="614" alt="Screenshot 2025-05-12 at 10 49 22 AM" src="https://github.com/user-attachments/assets/70e41cba-0eeb-499c-9421-a3890fad6568" />

<img width="755" alt="Screenshot 2025-05-12 at 10 50 49 AM" src="https://github.com/user-attachments/assets/69345c00-d5b6-4dfc-844e-77a11595a2d1" />

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [x] Address feedback

## Who to Notify
@brandenrodgers @camden11 @joe-yeager 
