### PR TITLE
Refactor: Improve migration flow

### DIFF
--- a/config/migrate.ts
+++ b/config/migrate.ts
@@ -26,8 +26,11 @@ import {
   ALLOW_USAGE_TRACKING,
   DEFAULT_ACCOUNT,
   DEFAULT_PORTAL,
+  ARCHIVED_HUBSPOT_CONFIG_YAML_FILE_NAME,
 } from '../constants/config';
 import { i18n } from '../utils/lang';
+import fs from 'fs';
+import path from 'path';
 
 const i18nKey = 'config.migrate';
 
@@ -75,7 +78,15 @@ function writeGlobalConfigFile(
 
   try {
     writeConfig({ source: updatedConfigJson });
-    config_DEPRECATED.deleteConfigFile();
+    const oldConfigPath = config_DEPRECATED.getConfigPath();
+    if (oldConfigPath) {
+      const dir = path.dirname(oldConfigPath);
+      const newConfigPath = path.join(
+        dir,
+        ARCHIVED_HUBSPOT_CONFIG_YAML_FILE_NAME
+      );
+      fs.renameSync(oldConfigPath, newConfigPath);
+    }
   } catch (error) {
     deleteEmptyConfigFile();
     throw new Error(

--- a/constants/config.ts
+++ b/constants/config.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import os from 'os';
 
 export const DEFAULT_HUBSPOT_CONFIG_YAML_FILE_NAME = 'hubspot.config.yml';
+export const ARCHIVED_HUBSPOT_CONFIG_YAML_FILE_NAME =
+  'archived.hubspot.config.yml';
 
 export const HUBSPOT_CONFIGURATION_FOLDER = '.hscli';
 export const HUBSPOT_CONFIGURATION_FILE = 'config.yml';


### PR DESCRIPTION
## Description and Context
This PR supports another PR (link forthcoming) that improves the migration flow in `hs config migrate` and `hs account auth`. The main change we're making is that we no longer delete the deprecated config file during the migration/merge flow. Instead, we rename it to `archived.hubspot.config.yml`, so that the user will have it as a resource. 

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

- [ ] Address feedback

## Who to Notify

<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 
