### PR TITLE
feat: Support extracting multiple `sourceDir` locations in `extractZipArchive`

### DIFF
--- a/lib/__tests__/archive.test.ts
+++ b/lib/__tests__/archive.test.ts
@@ -297,5 +297,26 @@ describe('lib/archive', () => {
         collisions: ['path/to/file.txt'],
       });
     });
+
+    it('should deduplicate source directories when sourceDir array contains duplicates', async () => {
+      const sourceDir1 = 'sourceDir1';
+      const sourceDir2 = 'sourceDir2';
+      const sourceDir = [sourceDir1, sourceDir2, sourceDir1, sourceDir2];
+
+      const result = await extractZipArchive(zip, name, dest, {
+        sourceDir,
+      });
+
+      expect(fs.copy).toHaveBeenCalledTimes(2);
+      expect(fs.copy).toHaveBeenCalledWith(
+        `${tmpExtractPath}/${rootDir}/${sourceDir1}`,
+        dest
+      );
+      expect(fs.copy).toHaveBeenCalledWith(
+        `${tmpExtractPath}/${rootDir}/${sourceDir2}`,
+        dest
+      );
+      expect(result).toBe(true);
+    });
   });
 });

--- a/lib/__tests__/archive.test.ts
+++ b/lib/__tests__/archive.test.ts
@@ -4,11 +4,13 @@ jest.mock('fs-extra');
 jest.mock('extract-zip');
 jest.mock('os');
 jest.mock('../logger');
+jest.mock('../fs');
 
 import { extractZipArchive } from '../archive';
 import { logger } from '../logger';
 import fs from 'fs-extra';
 import extract from 'extract-zip';
+import { walk } from '../fs';
 
 const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>;
 const makeDirMock = fs.mkdtemp as jest.MockedFunction<typeof fs.mkdtemp>;
@@ -17,6 +19,10 @@ const osTmpDirMock = os.tmpdir as jest.MockedFunction<typeof os.tmpdir>;
 const extractMock = extract as jest.MockedFunction<typeof extract>;
 const fsCopyMock = fs.copy as jest.MockedFunction<typeof fs.copy>;
 const fsRemoveMock = fs.remove as jest.MockedFunction<typeof fs.remove>;
+const fsExistsSyncMock = fs.existsSync as jest.MockedFunction<
+  typeof fs.existsSync
+>;
+const walkMock = walk as jest.MockedFunction<typeof walk>;
 
 describe('lib/archive', () => {
   const rootDir = 'rootdir';
@@ -156,6 +162,140 @@ describe('lib/archive', () => {
         dest
       );
       expect(result).toBe(true);
+    });
+
+    it('should call handleCollision when destination exists and collisions are detected', async () => {
+      const sourceDir = 'sourceDir';
+      const handleCollisionMock = jest.fn();
+
+      fsExistsSyncMock.mockReturnValue(true);
+      walkMock
+        .mockResolvedValueOnce([
+          `${dest}/file1.txt`,
+          `${dest}/subfolder/file2.js`,
+          `${dest}/README.md`,
+        ])
+        .mockResolvedValueOnce([
+          `${tmpExtractPath}/${rootDir}/${sourceDir}/file1.txt`,
+          `${tmpExtractPath}/${rootDir}/${sourceDir}/different.txt`,
+          `${tmpExtractPath}/${rootDir}/${sourceDir}/README.md`,
+        ]);
+
+      await extractZipArchive(zip, name, dest, {
+        sourceDir,
+        handleCollision: handleCollisionMock,
+      });
+
+      expect(handleCollisionMock).toHaveBeenCalledWith({
+        dest,
+        src: `${tmpExtractPath}/${rootDir}/${sourceDir}`,
+        collisions: ['file1.txt', 'README.md'],
+      });
+      expect(fs.copy).not.toHaveBeenCalled();
+    });
+
+    it('should call handleCollision for each source directory when multiple dirs have collisions', async () => {
+      const sourceDir = ['sourceDir1', 'sourceDir2'];
+      const handleCollisionMock = jest.fn();
+
+      fsExistsSyncMock.mockReturnValue(true);
+      walkMock
+        .mockResolvedValueOnce([`${dest}/shared.txt`])
+        .mockResolvedValueOnce([
+          `${tmpExtractPath}/${rootDir}/sourceDir1/shared.txt`,
+        ])
+        .mockResolvedValueOnce([`${dest}/shared.txt`])
+        .mockResolvedValueOnce([
+          `${tmpExtractPath}/${rootDir}/sourceDir2/other.txt`,
+        ]);
+
+      await extractZipArchive(zip, name, dest, {
+        sourceDir,
+        handleCollision: handleCollisionMock,
+      });
+
+      expect(handleCollisionMock).toHaveBeenCalledTimes(1);
+      expect(handleCollisionMock).toHaveBeenCalledWith({
+        dest,
+        src: `${tmpExtractPath}/${rootDir}/sourceDir1`,
+        collisions: ['shared.txt'],
+      });
+    });
+
+    it('should not call handleCollision when destination does not exist', async () => {
+      const sourceDir = 'sourceDir';
+      const handleCollisionMock = jest.fn();
+
+      fsExistsSyncMock.mockReturnValue(false);
+
+      await extractZipArchive(zip, name, dest, {
+        sourceDir,
+        handleCollision: handleCollisionMock,
+      });
+
+      expect(handleCollisionMock).not.toHaveBeenCalled();
+      expect(fs.copy).toHaveBeenCalledWith(
+        `${tmpExtractPath}/${rootDir}/${sourceDir}`,
+        dest
+      );
+    });
+
+    it('should not call handleCollision when no collision handler is provided', async () => {
+      const sourceDir = 'sourceDir';
+
+      fsExistsSyncMock.mockReturnValue(true);
+
+      await extractZipArchive(zip, name, dest, {
+        sourceDir,
+      });
+
+      expect(walkMock).not.toHaveBeenCalled();
+      expect(fs.copy).toHaveBeenCalledWith(
+        `${tmpExtractPath}/${rootDir}/${sourceDir}`,
+        dest
+      );
+    });
+
+    it('should not call handleCollisions where there are no collisions', async () => {
+      const sourceDir = 'sourceDir';
+      const handleCollisionMock = jest.fn();
+
+      fsExistsSyncMock.mockReturnValue(true);
+      walkMock
+        .mockResolvedValueOnce([`${dest}/existing.txt`])
+        .mockResolvedValueOnce([
+          `${tmpExtractPath}/${rootDir}/${sourceDir}/new.txt`,
+        ]);
+
+      await extractZipArchive(zip, name, dest, {
+        sourceDir,
+        handleCollision: handleCollisionMock,
+      });
+
+      expect(handleCollisionMock).not.toHaveBeenCalled();
+    });
+
+    it('should normalize paths when detecting collisions', async () => {
+      const sourceDir = 'sourceDir';
+      const handleCollisionMock = jest.fn();
+
+      fsExistsSyncMock.mockReturnValue(true);
+      walkMock
+        .mockResolvedValueOnce([`${dest}/path/to/file.txt`])
+        .mockResolvedValueOnce([
+          `${tmpExtractPath}/${rootDir}/${sourceDir}/path/to/file.txt`,
+        ]);
+
+      await extractZipArchive(zip, name, dest, {
+        sourceDir,
+        handleCollision: handleCollisionMock,
+      });
+
+      expect(handleCollisionMock).toHaveBeenCalledWith({
+        dest,
+        src: `${tmpExtractPath}/${rootDir}/${sourceDir}`,
+        collisions: ['path/to/file.txt'],
+      });
     });
   });
 });

--- a/lib/__tests__/archive.test.ts
+++ b/lib/__tests__/archive.test.ts
@@ -135,5 +135,27 @@ describe('lib/archive', () => {
         `Failed to clean up temp dir: ${tmpDirName}`
       );
     });
+
+    it('should copy multiple source directories when sourceDir is an array', async () => {
+      const sourceDir1 = 'sourceDir1';
+      const sourceDir2 = 'sourceDir2';
+
+      const sourceDir = [sourceDir1, sourceDir2];
+
+      const result = await extractZipArchive(zip, name, dest, {
+        sourceDir,
+      });
+
+      expect(fs.copy).toHaveBeenCalledTimes(sourceDir.length);
+      expect(fs.copy).toHaveBeenCalledWith(
+        `${tmpExtractPath}/${rootDir}/${sourceDir1}`,
+        dest
+      );
+      expect(fs.copy).toHaveBeenCalledWith(
+        `${tmpExtractPath}/${rootDir}/${sourceDir2}`,
+        dest
+      );
+      expect(result).toBe(true);
+    });
   });
 });

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -93,7 +93,9 @@ async function copySourceToDest(
     const sourceDirs = [];
 
     if (sourceDir) {
-      sourceDirs.push(...(Array.isArray(sourceDir) ? sourceDir : [sourceDir]));
+      sourceDirs.push(
+        ...(Array.isArray(sourceDir) ? new Set(sourceDir) : [sourceDir])
+      );
     }
 
     if (sourceDirs.length === 0) {
@@ -116,7 +118,7 @@ async function copySourceToDest(
             file => path.relative(projectSrcDir, file)
           );
 
-          // Files that exist in the same positions in both the
+          // Find files that exist in the same positions in both directories
           collisions = existingFiles.filter(currentFile =>
             newFiles.includes(currentFile)
           );

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -88,13 +88,22 @@ async function copySourceToDest(
       srcDirPath.push(rootDir);
     }
 
+    const foo = [];
+
     if (sourceDir) {
-      srcDirPath.push(sourceDir);
+      foo.push(...(Array.isArray(sourceDir) ? sourceDir : [sourceDir]));
     }
 
-    const projectSrcDir = join(...srcDirPath);
+    if (foo.length === 0) {
+      const projectSrcDir = join(...srcDirPath);
+      await fs.copy(projectSrcDir, dest);
+    } else {
+      for (let i = 0; i < foo.length; i++) {
+        const projectSrcDir = join(...srcDirPath, foo[i]);
+        await fs.copy(projectSrcDir, dest);
+      }
+    }
 
-    await fs.copy(projectSrcDir, dest);
     logger.debug(i18n(`${i18nKey}.copySourceToDest.success`));
     return true;
   } catch (err) {

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -128,7 +128,7 @@ async function copySourceToDest(
           handleCollision &&
           typeof handleCollision === 'function'
         ) {
-          handleCollision({
+          await handleCollision({
             dest,
             src: projectSrcDir,
             collisions,

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -103,6 +103,7 @@ async function copySourceToDest(
       for (let i = 0; i < sourceDirs.length; i++) {
         const projectSrcDir = join(...srcDirPath, sourceDirs[i]);
 
+        let collisions: string[] = [];
         if (
           fs.existsSync(dest) &&
           handleCollision &&
@@ -116,10 +117,15 @@ async function copySourceToDest(
           );
 
           // Files that exist in the same positions in both the
-          const collisions = existingFiles.filter(currentFile =>
+          collisions = existingFiles.filter(currentFile =>
             newFiles.includes(currentFile)
           );
-
+        }
+        if (
+          collisions.length &&
+          handleCollision &&
+          typeof handleCollision === 'function'
+        ) {
           handleCollision({
             dest,
             src: projectSrcDir,

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -88,18 +88,18 @@ async function copySourceToDest(
       srcDirPath.push(rootDir);
     }
 
-    const foo = [];
+    const sourceDirs = [];
 
     if (sourceDir) {
-      foo.push(...(Array.isArray(sourceDir) ? sourceDir : [sourceDir]));
+      sourceDirs.push(...(Array.isArray(sourceDir) ? sourceDir : [sourceDir]));
     }
 
-    if (foo.length === 0) {
+    if (sourceDirs.length === 0) {
       const projectSrcDir = join(...srcDirPath);
       await fs.copy(projectSrcDir, dest);
     } else {
-      for (let i = 0; i < foo.length; i++) {
-        const projectSrcDir = join(...srcDirPath, foo[i]);
+      for (let i = 0; i < sourceDirs.length; i++) {
+        const projectSrcDir = join(...srcDirPath, sourceDirs[i]);
         await fs.copy(projectSrcDir, dest);
       }
     }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -116,7 +116,8 @@ export async function cloneGithubRepo(
   dest: string,
   options: CloneGithubRepoOptions = {}
 ): Promise<boolean> {
-  const { tag, isRelease, branch, sourceDir, type, hideLogs } = options;
+  const { tag, isRelease, branch, sourceDir, type, hideLogs, handleCollision } =
+    options;
   const zip = await downloadGithubRepoZip(repoPath, isRelease, {
     tag,
     branch,
@@ -125,6 +126,7 @@ export async function cloneGithubRepo(
   const success = await extractZipArchive(zip, repoName, dest, {
     sourceDir,
     hideLogs,
+    handleCollision,
   });
 
   if (success && !hideLogs) {

--- a/types/Archive.ts
+++ b/types/Archive.ts
@@ -1,3 +1,9 @@
+export interface Collision {
+  dest: string;
+  src: string;
+  collisions: string[];
+}
+
 export type ZipData = {
   extractDir: string;
   tmpDir: string;
@@ -7,4 +13,5 @@ export type CopySourceToDestOptions = {
   sourceDir?: string | string[];
   includesRootDir?: boolean;
   hideLogs?: boolean;
+  handleCollision?: (collision: Collision) => void;
 };

--- a/types/Archive.ts
+++ b/types/Archive.ts
@@ -4,7 +4,7 @@ export type ZipData = {
 };
 
 export type CopySourceToDestOptions = {
-  sourceDir?: string;
+  sourceDir?: string | string[];
   includesRootDir?: boolean;
   hideLogs?: boolean;
 };

--- a/types/Archive.ts
+++ b/types/Archive.ts
@@ -13,5 +13,5 @@ export type CopySourceToDestOptions = {
   sourceDir?: string | string[];
   includesRootDir?: boolean;
   hideLogs?: boolean;
-  handleCollision?: (collision: Collision) => void;
+  handleCollision?: (collision: Collision) => void | Promise<void>;
 };

--- a/types/Github.ts
+++ b/types/Github.ts
@@ -77,6 +77,6 @@ export type CloneGithubRepoOptions = {
   type?: string; // The type of asset being downloaded. Used for logging
   branch?: string; // Repo branch
   tag?: string; // Repo tag
-  sourceDir?: string; // The directory within the downloaded repo to write after extraction
+  sourceDir?: string | string[]; // The directory within the downloaded repo to write after extraction
   hideLogs?: boolean; // Hide logs from the console
 };

--- a/types/Github.ts
+++ b/types/Github.ts
@@ -1,3 +1,5 @@
+import { Collision } from './Archive';
+
 type GithubAuthor = {
   login: string;
   id: number;
@@ -79,4 +81,5 @@ export type CloneGithubRepoOptions = {
   tag?: string; // Repo tag
   sourceDir?: string | string[]; // The directory within the downloaded repo to write after extraction
   hideLogs?: boolean; // Hide logs from the console
+  handleCollision?: (collision: Collision) => void;
 };


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Update `extractZipArchive` method to take a array of `sourceDir` and copy all of the locations to the destination directoy.
