### PR TITLE
Add endpoint to install static auth apps on test accounts

### DIFF
--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -8,6 +8,7 @@ import {
 import { HubSpotPromise } from '../types/Http';
 
 const APPS_DEV_API_PATH = 'apps-dev/external/public/v3';
+const APPS_HUBLETS_API_PATH = 'apps-hublets/external/static-token/v3';
 
 export function fetchPublicAppsForPortal(
   accountId: number
@@ -41,5 +42,20 @@ export function fetchPublicAppMetadata(
 ): HubSpotPromise<PublicApp> {
   return http.get<PublicApp>(accountId, {
     url: `${APPS_DEV_API_PATH}/${appId}/full`,
+  });
+}
+
+export function installStaticAuthAppOnTestAccount(
+  appId: number,
+  accountId: number,
+  scopeGroupIds: number[]
+) {
+  return http.post<void>(accountId, {
+    url: APPS_HUBLETS_API_PATH,
+    data: {
+      appId,
+      targetInstallPortalId: accountId,
+      scopeGroupIds,
+    },
   });
 }


### PR DESCRIPTION
## Description and Context
This adds a new function to hit `apps-hublets/external/static-token/v3`, which is used to install static auth apps in test accounts. This will be used in `hs project dev`.

## Who to Notify

@brandenrodgers @joe-yeager 
