### PR TITLE
Add config flag functionality

### DIFF
--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -695,6 +695,36 @@ class _CLIConfiguration {
     }
     return config;
   }
+
+  hasStateFlag(flag: string): boolean {
+    if (!this.config) {
+      return false;
+    }
+
+    return this.config.flags?.includes(flag) || false;
+  }
+
+  addStateFlag(flag: string): void {
+    if (!this.config) {
+      throw new Error(i18n(`${i18nKey}.errors.noConfigLoaded`));
+    }
+
+    if (!this.hasStateFlag(flag)) {
+      this.config.flags = [...(this.config.flags || []), flag];
+    }
+
+    this.write();
+  }
+
+  removeStateFlag(flag: string): void {
+    if (!this.config) {
+      throw new Error(i18n(`${i18nKey}.errors.noConfigLoaded`));
+    }
+
+    this.config.flags = this.config.flags?.filter(f => f !== flag) || [];
+
+    this.write();
+  }
 }
 
 export const CLIConfiguration = new _CLIConfiguration();

--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -696,7 +696,7 @@ class _CLIConfiguration {
     return config;
   }
 
-  hasStateFlag(flag: string): boolean {
+  hasLocalStateFlag(flag: string): boolean {
     if (!this.config) {
       return false;
     }
@@ -704,19 +704,19 @@ class _CLIConfiguration {
     return this.config.flags?.includes(flag) || false;
   }
 
-  addStateFlag(flag: string): void {
+  addLocalStateFlag(flag: string): void {
     if (!this.config) {
       throw new Error(i18n(`${i18nKey}.errors.noConfigLoaded`));
     }
 
-    if (!this.hasStateFlag(flag)) {
+    if (!this.hasLocalStateFlag(flag)) {
       this.config.flags = [...(this.config.flags || []), flag];
     }
 
     this.write();
   }
 
-  removeStateFlag(flag: string): void {
+  removeLocalStateFlag(flag: string): void {
     if (!this.config) {
       throw new Error(i18n(`${i18nKey}.errors.noConfigLoaded`));
     }

--- a/config/__tests__/CLIConfiguration.test.ts
+++ b/config/__tests__/CLIConfiguration.test.ts
@@ -141,4 +141,88 @@ describe('config/CLIConfiguration', () => {
       expect(config.isTrackingAllowed()).toBe(true);
     });
   });
+
+  describe('hasLocalStateFlag()', () => {
+    it('returns false when no config is loaded', () => {
+      expect(config.hasLocalStateFlag('test-flag')).toBe(false);
+    });
+
+    it('returns false when flag is not in config flags array', () => {
+      config.config = { accounts: [], flags: ['other-flag'] };
+      expect(config.hasLocalStateFlag('test-flag')).toBe(false);
+    });
+
+    it('returns true when flag is in config flags array', () => {
+      config.config = { accounts: [], flags: ['test-flag', 'other-flag'] };
+      expect(config.hasLocalStateFlag('test-flag')).toBe(true);
+    });
+  });
+
+  describe('addLocalStateFlag()', () => {
+    beforeEach(() => {
+      // Mock the write method to prevent actual file operations
+      jest.spyOn(config, 'write').mockImplementation(() => null);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('throws when no config is loaded', () => {
+      config.config = null;
+      expect(() => {
+        config.addLocalStateFlag('test-flag');
+      }).toThrow();
+    });
+
+    it('adds flag when flags array does not exist', () => {
+      config.config = { accounts: [] };
+      config.addLocalStateFlag('test-flag');
+
+      expect(config.config.flags).toEqual(['test-flag']);
+      expect(config.write).toHaveBeenCalled();
+    });
+
+    it('adds flag to existing flags array', () => {
+      config.config = { accounts: [], flags: ['existing-flag'] };
+      config.addLocalStateFlag('test-flag');
+
+      expect(config.config.flags).toEqual(['existing-flag', 'test-flag']);
+      expect(config.write).toHaveBeenCalled();
+    });
+  });
+
+  describe('removeLocalStateFlag()', () => {
+    beforeEach(() => {
+      // Mock the write method to prevent actual file operations
+      jest.spyOn(config, 'write').mockImplementation(() => null);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('throws when no config is loaded', () => {
+      config.config = null;
+      expect(() => {
+        config.removeLocalStateFlag('test-flag');
+      }).toThrow();
+    });
+
+    it('removes flag from flags array', () => {
+      config.config = { accounts: [], flags: ['test-flag', 'other-flag'] };
+      config.removeLocalStateFlag('test-flag');
+
+      expect(config.config.flags).toEqual(['other-flag']);
+      expect(config.write).toHaveBeenCalled();
+    });
+
+    it('handles removing non-existent flag gracefully', () => {
+      config.config = { accounts: [], flags: ['existing-flag'] };
+      config.removeLocalStateFlag('non-existent-flag');
+
+      expect(config.config.flags).toEqual(['existing-flag']);
+      expect(config.write).toHaveBeenCalled();
+    });
+  });
 });

--- a/config/__tests__/migrate.test.ts
+++ b/config/__tests__/migrate.test.ts
@@ -1,0 +1,540 @@
+import * as migrate from '../migrate';
+import * as config_DEPRECATED from '../config_DEPRECATED';
+import { CLIConfiguration } from '../CLIConfiguration';
+import * as configIndex from '../index';
+import * as configFile from '../configFile';
+import { CLIConfig_DEPRECATED, CLIConfig_NEW } from '../../types/Config';
+import { ENVIRONMENTS } from '../../constants/environments';
+import { OAUTH_AUTH_METHOD } from '../../constants/auth';
+import { ARCHIVED_HUBSPOT_CONFIG_YAML_FILE_NAME } from '../../constants/config';
+import { i18n } from '../../utils/lang';
+import fs from 'fs';
+import path from 'path';
+
+// Mock dependencies
+jest.mock('../config_DEPRECATED');
+jest.mock('../CLIConfiguration');
+jest.mock('../index');
+jest.mock('../configFile');
+jest.mock('../../utils/lang');
+jest.mock('fs');
+jest.mock('path');
+
+const mockConfig_DEPRECATED = config_DEPRECATED as jest.Mocked<
+  typeof config_DEPRECATED
+>;
+const mockCLIConfiguration = CLIConfiguration as jest.Mocked<
+  typeof CLIConfiguration
+>;
+const mockConfigIndex = configIndex as jest.Mocked<typeof configIndex>;
+const mockConfigFile = configFile as jest.Mocked<typeof configFile>;
+const mockI18n = i18n as jest.MockedFunction<typeof i18n>;
+const mockFs = fs as jest.Mocked<typeof fs>;
+const mockPath = path as jest.Mocked<typeof path>;
+
+describe('migrate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getDeprecatedConfig', () => {
+    it('should return deprecated config when loadConfig succeeds', () => {
+      const mockDeprecatedConfig: CLIConfig_DEPRECATED = {
+        defaultPortal: 'test-portal',
+        portals: [],
+      };
+      mockConfig_DEPRECATED.loadConfig.mockReturnValue(mockDeprecatedConfig);
+
+      const result = migrate.getDeprecatedConfig('/test/path');
+
+      expect(mockConfig_DEPRECATED.loadConfig).toHaveBeenCalledWith(
+        '/test/path'
+      );
+      expect(result).toBe(mockDeprecatedConfig);
+    });
+
+    it('should return null when loadConfig fails', () => {
+      mockConfig_DEPRECATED.loadConfig.mockReturnValue(null);
+
+      const result = migrate.getDeprecatedConfig();
+
+      expect(mockConfig_DEPRECATED.loadConfig).toHaveBeenCalledWith(undefined);
+      expect(result).toBeNull();
+    });
+
+    it('should call loadConfig with undefined when no configPath provided', () => {
+      mockConfig_DEPRECATED.loadConfig.mockReturnValue(null);
+
+      migrate.getDeprecatedConfig();
+
+      expect(mockConfig_DEPRECATED.loadConfig).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('getGlobalConfig', () => {
+    it('should return CLIConfiguration config when active', () => {
+      const mockConfig: CLIConfig_NEW = {
+        defaultAccount: 'test-account',
+        accounts: [],
+      };
+      mockCLIConfiguration.isActive.mockReturnValue(true);
+      mockCLIConfiguration.config = mockConfig;
+
+      const result = migrate.getGlobalConfig();
+
+      expect(mockCLIConfiguration.isActive).toHaveBeenCalled();
+      expect(result).toBe(mockConfig);
+    });
+
+    it('should return null when CLIConfiguration is not active', () => {
+      mockCLIConfiguration.isActive.mockReturnValue(false);
+
+      const result = migrate.getGlobalConfig();
+
+      expect(mockCLIConfiguration.isActive).toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('configFileExists', () => {
+    it('should check new config file when useHiddenConfig is true', () => {
+      mockConfigFile.configFileExists.mockReturnValue(true);
+
+      const result = migrate.configFileExists(true);
+
+      expect(mockConfigFile.configFileExists).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('should check deprecated config file when useHiddenConfig is false', () => {
+      const mockConfigPath = '/test/config.yml';
+      mockConfig_DEPRECATED.getConfigPath.mockReturnValue(mockConfigPath);
+
+      const result = migrate.configFileExists(false, '/test/path');
+
+      expect(mockConfig_DEPRECATED.getConfigPath).toHaveBeenCalledWith(
+        '/test/path'
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should return false when deprecated config path is null', () => {
+      mockConfig_DEPRECATED.getConfigPath.mockReturnValue(null);
+
+      const result = migrate.configFileExists(false);
+
+      expect(result).toBe(false);
+    });
+
+    it('should default useHiddenConfig to false', () => {
+      mockConfig_DEPRECATED.getConfigPath.mockReturnValue(null);
+
+      migrate.configFileExists();
+
+      expect(mockConfig_DEPRECATED.getConfigPath).toHaveBeenCalledWith(
+        undefined
+      );
+    });
+  });
+
+  describe('getConfigPath', () => {
+    it('should return new config file path when useHiddenConfig is true', () => {
+      const mockPath = '/test/new/config';
+      mockConfigFile.getConfigFilePath.mockReturnValue(mockPath);
+
+      const result = migrate.getConfigPath('/test/path', true);
+
+      expect(mockConfigFile.getConfigFilePath).toHaveBeenCalled();
+      expect(result).toBe(mockPath);
+    });
+
+    it('should return deprecated config path when useHiddenConfig is false', () => {
+      const mockPath = '/test/deprecated/config';
+      mockConfig_DEPRECATED.getConfigPath.mockReturnValue(mockPath);
+
+      const result = migrate.getConfigPath('/test/path', false);
+
+      expect(mockConfig_DEPRECATED.getConfigPath).toHaveBeenCalledWith(
+        '/test/path'
+      );
+      expect(result).toBe(mockPath);
+    });
+
+    it('should default useHiddenConfig to false', () => {
+      const mockPath = '/test/deprecated/config';
+      mockConfig_DEPRECATED.getConfigPath.mockReturnValue(mockPath);
+
+      const result = migrate.getConfigPath('/test/path');
+
+      expect(mockConfig_DEPRECATED.getConfigPath).toHaveBeenCalledWith(
+        '/test/path'
+      );
+      expect(result).toBe(mockPath);
+    });
+  });
+
+  describe('migrateConfig', () => {
+    beforeEach(() => {
+      mockI18n.mockImplementation(key => `translated-${key}`);
+      mockConfigIndex.createEmptyConfigFile.mockImplementation();
+      mockConfigIndex.loadConfig.mockImplementation();
+      mockConfigIndex.writeConfig.mockImplementation();
+      mockConfigIndex.deleteEmptyConfigFile.mockImplementation();
+      mockConfig_DEPRECATED.getConfigPath.mockReturnValue('/old/config/path');
+      mockPath.dirname.mockReturnValue('/old/config');
+      mockPath.join.mockReturnValue(
+        `/old/config/${ARCHIVED_HUBSPOT_CONFIG_YAML_FILE_NAME}`
+      );
+      mockFs.renameSync.mockImplementation();
+    });
+
+    it('should throw error when deprecatedConfig is null', () => {
+      expect(() => migrate.migrateConfig(null)).toThrow(
+        'translated-config.migrate.errors.noDeprecatedConfig'
+      );
+      expect(mockI18n).toHaveBeenCalledWith(
+        'config.migrate.errors.noDeprecatedConfig'
+      );
+    });
+
+    it('should migrate config successfully', () => {
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        defaultPortal: 'test-portal',
+        portals: [
+          {
+            portalId: 123,
+            name: 'test-account',
+            authType: OAUTH_AUTH_METHOD.value,
+            env: ENVIRONMENTS.PROD,
+          },
+        ],
+        httpTimeout: 30000,
+        allowUsageTracking: true,
+      };
+
+      migrate.migrateConfig(deprecatedConfig);
+
+      expect(mockConfigIndex.createEmptyConfigFile).toHaveBeenCalledWith(
+        {},
+        true
+      );
+      expect(mockConfigIndex.loadConfig).toHaveBeenCalledWith('');
+      expect(mockConfigIndex.writeConfig).toHaveBeenCalledWith({
+        source: JSON.stringify({
+          httpTimeout: 30000,
+          allowUsageTracking: true,
+          defaultAccount: 'test-portal',
+          accounts: [
+            {
+              name: 'test-account',
+              authType: OAUTH_AUTH_METHOD.value,
+              env: ENVIRONMENTS.PROD,
+              accountId: 123,
+            },
+          ],
+        }),
+      });
+    });
+
+    it('should handle portals with undefined portalId', () => {
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        defaultPortal: 'test-portal',
+        portals: [
+          {
+            portalId: 123,
+            name: 'valid-account',
+            env: ENVIRONMENTS.PROD,
+          },
+          {
+            portalId: undefined,
+            name: 'invalid-account',
+            env: ENVIRONMENTS.PROD,
+          },
+        ],
+      };
+
+      migrate.migrateConfig(deprecatedConfig);
+
+      const writeConfigCall = mockConfigIndex.writeConfig.mock.calls[0]?.[0];
+      expect(writeConfigCall).toBeDefined();
+      expect(writeConfigCall?.source).toBeDefined();
+      const parsedConfig = JSON.parse(writeConfigCall!.source!);
+
+      expect(parsedConfig.accounts).toHaveLength(1);
+      expect(parsedConfig.accounts[0]).toEqual({
+        name: 'valid-account',
+        accountId: 123,
+        env: ENVIRONMENTS.PROD,
+      });
+    });
+
+    it('should rename old config file after successful migration', () => {
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        defaultPortal: 'test-portal',
+        portals: [],
+      };
+
+      migrate.migrateConfig(deprecatedConfig);
+
+      expect(mockConfig_DEPRECATED.getConfigPath).toHaveBeenCalled();
+      expect(mockPath.dirname).toHaveBeenCalledWith('/old/config/path');
+      expect(mockPath.join).toHaveBeenCalledWith(
+        '/old/config',
+        ARCHIVED_HUBSPOT_CONFIG_YAML_FILE_NAME
+      );
+      expect(mockFs.renameSync).toHaveBeenCalledWith(
+        '/old/config/path',
+        `/old/config/${ARCHIVED_HUBSPOT_CONFIG_YAML_FILE_NAME}`
+      );
+    });
+
+    it('should handle writeConfig error and clean up', () => {
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        defaultPortal: 'test-portal',
+        portals: [],
+      };
+      const writeError = new Error('Write failed');
+      mockConfigIndex.writeConfig.mockImplementation(() => {
+        throw writeError;
+      });
+
+      expect(() => migrate.migrateConfig(deprecatedConfig)).toThrow(
+        'translated-config.migrate.errors.writeConfig'
+      );
+      expect(mockConfigIndex.deleteEmptyConfigFile).toHaveBeenCalled();
+    });
+  });
+
+  describe('mergeConfigProperties', () => {
+    it('should merge properties without conflicts when force is true', () => {
+      const globalConfig: CLIConfig_NEW = {
+        defaultAccount: 'global-account',
+        accounts: [],
+        httpTimeout: 10000,
+      };
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        defaultPortal: 'deprecated-portal',
+        portals: [],
+        httpTimeout: 20000,
+        allowUsageTracking: false,
+      };
+
+      const result = migrate.mergeConfigProperties(
+        globalConfig,
+        deprecatedConfig,
+        true
+      );
+
+      expect(result.initialConfig).toEqual({
+        defaultAccount: 'deprecated-portal',
+        accounts: [],
+        httpTimeout: 20000,
+        allowUsageTracking: false,
+      });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it('should detect conflicts when force is false and values differ', () => {
+      const globalConfig: CLIConfig_NEW = {
+        defaultAccount: 'global-account',
+        accounts: [],
+        httpTimeout: 10000,
+      };
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        defaultPortal: 'deprecated-portal',
+        portals: [],
+        httpTimeout: 20000,
+      };
+
+      const result = migrate.mergeConfigProperties(
+        globalConfig,
+        deprecatedConfig,
+        false
+      );
+
+      expect(result.conflicts).toHaveLength(2);
+      expect(result.conflicts).toContainEqual({
+        property: 'httpTimeout',
+        oldValue: 20000,
+        newValue: 10000,
+      });
+      expect(result.conflicts).toContainEqual({
+        property: 'defaultAccount',
+        oldValue: 'deprecated-portal',
+        newValue: 'global-account',
+      });
+    });
+
+    it('should merge flags from both configs', () => {
+      const globalConfig: CLIConfig_NEW = {
+        accounts: [],
+        flags: ['flag1', 'flag2'],
+      };
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        portals: [],
+        flags: ['flag2', 'flag3'],
+      };
+
+      const result = migrate.mergeConfigProperties(
+        globalConfig,
+        deprecatedConfig
+      );
+
+      expect(result.initialConfig.flags).toEqual(['flag1', 'flag2', 'flag3']);
+    });
+
+    it('should handle missing properties gracefully', () => {
+      const globalConfig: CLIConfig_NEW = {
+        accounts: [],
+      };
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        portals: [],
+        httpTimeout: 15000,
+      };
+
+      const result = migrate.mergeConfigProperties(
+        globalConfig,
+        deprecatedConfig
+      );
+
+      expect(result.initialConfig.httpTimeout).toBe(15000);
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it('should not create conflicts when values are the same', () => {
+      const globalConfig: CLIConfig_NEW = {
+        accounts: [],
+        httpTimeout: 15000,
+        allowUsageTracking: true,
+      };
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        portals: [],
+        httpTimeout: 15000,
+        allowUsageTracking: true,
+      };
+
+      const result = migrate.mergeConfigProperties(
+        globalConfig,
+        deprecatedConfig
+      );
+
+      expect(result.conflicts).toHaveLength(0);
+    });
+  });
+
+  describe('mergeExistingConfigs', () => {
+    beforeEach(() => {
+      mockConfigIndex.writeConfig.mockImplementation();
+    });
+
+    it('should merge accounts and return skipped account IDs', () => {
+      const globalConfig: CLIConfig_NEW = {
+        accounts: [
+          {
+            accountId: 123,
+            name: 'existing-account',
+            env: ENVIRONMENTS.PROD,
+          },
+        ],
+      };
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        portals: [
+          {
+            portalId: 123,
+            name: 'duplicate-account',
+            env: ENVIRONMENTS.PROD,
+          },
+          {
+            portalId: 456,
+            name: 'new-account',
+            env: ENVIRONMENTS.PROD,
+          },
+        ],
+      };
+
+      const result = migrate.mergeExistingConfigs(
+        globalConfig,
+        deprecatedConfig
+      );
+
+      expect(result.finalConfig.accounts).toHaveLength(2);
+      expect(result.finalConfig.accounts).toContainEqual({
+        accountId: 123,
+        name: 'existing-account',
+        env: ENVIRONMENTS.PROD,
+      });
+      expect(result.finalConfig.accounts).toContainEqual({
+        accountId: 456,
+        name: 'new-account',
+        env: ENVIRONMENTS.PROD,
+      });
+      expect(result.skippedAccountIds).toEqual([123]);
+    });
+
+    it('should handle config without existing accounts', () => {
+      const globalConfig: CLIConfig_NEW = {
+        accounts: [],
+      };
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        portals: [
+          {
+            portalId: 123,
+            name: 'new-account',
+            env: ENVIRONMENTS.PROD,
+          },
+        ],
+      };
+
+      const result = migrate.mergeExistingConfigs(
+        globalConfig,
+        deprecatedConfig
+      );
+
+      expect(result.finalConfig.accounts).toHaveLength(1);
+      expect(result.finalConfig.accounts[0]).toEqual({
+        name: 'new-account',
+        accountId: 123,
+        env: ENVIRONMENTS.PROD,
+      });
+      expect(result.skippedAccountIds).toHaveLength(0);
+    });
+
+    it('should handle config without deprecated portals', () => {
+      const globalConfig: CLIConfig_NEW = {
+        accounts: [
+          {
+            accountId: 123,
+            name: 'existing-account',
+            env: ENVIRONMENTS.PROD,
+          },
+        ],
+      };
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        portals: [],
+      };
+
+      const result = migrate.mergeExistingConfigs(
+        globalConfig,
+        deprecatedConfig
+      );
+
+      expect(result.finalConfig.accounts).toHaveLength(1);
+      expect(result.skippedAccountIds).toHaveLength(0);
+    });
+
+    it('should write the final config', () => {
+      const globalConfig: CLIConfig_NEW = {
+        accounts: [],
+      };
+      const deprecatedConfig: CLIConfig_DEPRECATED = {
+        portals: [],
+      };
+
+      migrate.mergeExistingConfigs(globalConfig, deprecatedConfig);
+
+      expect(mockConfigIndex.writeConfig).toHaveBeenCalledWith({
+        source: JSON.stringify(globalConfig),
+      });
+    });
+  });
+});

--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -931,7 +931,7 @@ function handleLegacyCmsPublishMode(
   return config;
 }
 
-export function hasStateFlag(flag: string): boolean {
+export function hasLocalStateFlag(flag: string): boolean {
   if (!_config) {
     return false;
   }
@@ -939,19 +939,19 @@ export function hasStateFlag(flag: string): boolean {
   return _config.flags?.includes(flag) || false;
 }
 
-export function addStateFlag(flag: string): void {
+export function addLocalStateFlag(flag: string): void {
   if (!_config) {
     throw new Error('No config loaded');
   }
 
-  if (!hasStateFlag(flag)) {
+  if (!hasLocalStateFlag(flag)) {
     _config.flags = [...(_config.flags || []), flag];
   }
 
   writeConfig();
 }
 
-export function removeStateFlag(flag: string): void {
+export function removeLocalStateFlag(flag: string): void {
   if (!_config) {
     throw new Error('No config loaded');
   }

--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -930,3 +930,33 @@ function handleLegacyCmsPublishMode(
   }
   return config;
 }
+
+export function hasStateFlag(flag: string): boolean {
+  if (!_config) {
+    return false;
+  }
+
+  return _config.flags?.includes(flag) || false;
+}
+
+export function addStateFlag(flag: string): void {
+  if (!_config) {
+    throw new Error('No config loaded');
+  }
+
+  if (!hasStateFlag(flag)) {
+    _config.flags = [...(_config.flags || []), flag];
+  }
+
+  writeConfig();
+}
+
+export function removeStateFlag(flag: string): void {
+  if (!_config) {
+    throw new Error('No config loaded');
+  }
+
+  _config.flags = _config.flags?.filter(f => f !== flag) || [];
+
+  writeConfig();
+}

--- a/config/index.ts
+++ b/config/index.ts
@@ -288,26 +288,26 @@ export function getDefaultAccountOverrideFilePath() {
   }
 }
 
-export function hasStateFlag(flag: string): boolean {
+export function hasLocalStateFlag(flag: string): boolean {
   if (CLIConfiguration.isActive()) {
-    return CLIConfiguration.hasStateFlag(flag);
+    return CLIConfiguration.hasLocalStateFlag(flag);
   }
-  return config_DEPRECATED.hasStateFlag(flag);
+  return config_DEPRECATED.hasLocalStateFlag(flag);
 }
 
-export function addStateFlag(flag: string): void {
+export function addLocalStateFlag(flag: string): void {
   if (CLIConfiguration.isActive()) {
-    CLIConfiguration.addStateFlag(flag);
+    CLIConfiguration.addLocalStateFlag(flag);
   } else {
-    config_DEPRECATED.addStateFlag(flag);
+    config_DEPRECATED.addLocalStateFlag(flag);
   }
 }
 
-export function removeStateFlag(flag: string): void {
+export function removeLocalStateFlag(flag: string): void {
   if (CLIConfiguration.isActive()) {
-    CLIConfiguration.removeStateFlag(flag);
+    CLIConfiguration.removeLocalStateFlag(flag);
   } else {
-    config_DEPRECATED.removeStateFlag(flag);
+    config_DEPRECATED.removeLocalStateFlag(flag);
   }
 }
 

--- a/config/index.ts
+++ b/config/index.ts
@@ -288,6 +288,29 @@ export function getDefaultAccountOverrideFilePath() {
   }
 }
 
+export function hasStateFlag(flag: string): boolean {
+  if (CLIConfiguration.isActive()) {
+    return CLIConfiguration.hasStateFlag(flag);
+  }
+  return config_DEPRECATED.hasStateFlag(flag);
+}
+
+export function addStateFlag(flag: string): void {
+  if (CLIConfiguration.isActive()) {
+    CLIConfiguration.addStateFlag(flag);
+  } else {
+    config_DEPRECATED.addStateFlag(flag);
+  }
+}
+
+export function removeStateFlag(flag: string): void {
+  if (CLIConfiguration.isActive()) {
+    CLIConfiguration.removeStateFlag(flag);
+  } else {
+    config_DEPRECATED.removeStateFlag(flag);
+  }
+}
+
 // These functions are not supported with the new config setup
 export const getConfigAccountId = config_DEPRECATED.getConfigAccountId;
 export const getOrderedAccount = config_DEPRECATED.getOrderedAccount;

--- a/config/migrate.ts
+++ b/config/migrate.ts
@@ -131,7 +131,7 @@ export function mergeConfigProperties(
   initialConfig: CLIConfig_NEW;
   conflicts: Array<ConflictProperty>;
 } {
-  const propertiesToCheck: Array<keyof Partial<CLIConfig>> = [
+  const propertiesToCheck: Array<keyof Omit<CLIConfig, 'flags'>> = [
     DEFAULT_CMS_PUBLISH_MODE,
     HTTP_TIMEOUT,
     ENV,
@@ -158,6 +158,15 @@ export function mergeConfigProperties(
       }
     }
   });
+
+  if (globalConfig.flags || deprecatedConfig.flags) {
+    globalConfig.flags = Array.from(
+      new Set([
+        ...(globalConfig.flags || []),
+        ...(deprecatedConfig.flags || []),
+      ])
+    );
+  }
 
   if (
     DEFAULT_ACCOUNT in globalConfig &&

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -13,6 +13,7 @@ export interface CLIConfig_NEW {
   httpTimeout?: number;
   env?: Environment;
   httpUseLocalhost?: boolean;
+  flags?: Array<string>;
 }
 
 export interface CLIConfig_DEPRECATED {
@@ -25,6 +26,7 @@ export interface CLIConfig_DEPRECATED {
   httpTimeout?: number;
   env?: Environment;
   httpUseLocalhost?: boolean;
+  flags?: Array<string>;
 }
 
 export type CLIConfig = CLIConfig_NEW | CLIConfig_DEPRECATED;


### PR DESCRIPTION
## Description and Context
This updates both the new and deprecated config to support a new `flags` field that allows the CLI (and anything else) to set, check, and delete string flags. This will let us easily persist CLI state between runs without the need to modify local-dev-lib in the future. Currently, the field is called `flags` in the config, but referred to as `localStateFlags` otherwise. I'd prefer to just call it flags, but we already have the `isConfigFlagEnabled` function (which really deals more with config _settings_ than flags). It might make sense to rename everything accordingly in the next major release, but didn't want to add a breaking change now.

The impetus for this change was the need to track whether or not a use has _ever_ viewed Local Dev UI, and show them the welcome screen if they haven't. This felt important to track, but not quite deserving of its own field in the config. In the future we can use the flags array for similar things.

Since the flags will be supported in the deprecated config, I also had to account for how disparate flags would be handled in config migrations. There weren't any tests for config migrate functionality so I added some.

## TODO
* Maybe rename some things, either now or before the next major release

## Who to Notify
@brandenrodgers @joe-yeager @lkosarpersonal 
