### PR TITLE
Add autoOpenLocalDevSessionInBrowser option to config

### DIFF
--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -679,6 +679,28 @@ class _CLIConfiguration {
     return this.write();
   }
 
+  updateAutoOpenLocalDevSessionInBrowser(
+    isEnabled: boolean
+  ): CLIConfig_NEW | null {
+    if (!this.config) {
+      throw new Error(i18n(`${i18nKey}.errors.noConfigLoaded`));
+    }
+
+    if (typeof isEnabled !== 'boolean') {
+      throw new Error(
+        i18n(
+          `${i18nKey}.updateAutoOpenLocalDevSessionInBrowser.errors.invalidInput`,
+          {
+            isEnabled: `${isEnabled}`,
+          }
+        )
+      );
+    }
+
+    this.config.autoOpenLocalDevSessionInBrowser = isEnabled;
+    return this.write();
+  }
+
   isTrackingAllowed(): boolean {
     if (!this.config) {
       return true;

--- a/config/CLIConfiguration.ts
+++ b/config/CLIConfiguration.ts
@@ -679,25 +679,20 @@ class _CLIConfiguration {
     return this.write();
   }
 
-  updateAutoOpenLocalDevSessionInBrowser(
-    isEnabled: boolean
-  ): CLIConfig_NEW | null {
+  updateAutoOpenBrowser(isEnabled: boolean): CLIConfig_NEW | null {
     if (!this.config) {
       throw new Error(i18n(`${i18nKey}.errors.noConfigLoaded`));
     }
 
     if (typeof isEnabled !== 'boolean') {
       throw new Error(
-        i18n(
-          `${i18nKey}.updateAutoOpenLocalDevSessionInBrowser.errors.invalidInput`,
-          {
-            isEnabled: `${isEnabled}`,
-          }
-        )
+        i18n(`${i18nKey}.updateAutoOpenBrowser.errors.invalidInput`, {
+          isEnabled: `${isEnabled}`,
+        })
       );
     }
 
-    this.config.autoOpenLocalDevSessionInBrowser = isEnabled;
+    this.config.autoOpenBrowser = isEnabled;
     return this.write();
   }
 

--- a/config/__tests__/config.test.ts
+++ b/config/__tests__/config.test.ts
@@ -9,7 +9,7 @@ import {
   getAccountId,
   updateDefaultAccount,
   updateAccountConfig,
-  updateAutoOpenLocalDevSessionInBrowser,
+  updateAutoOpenBrowser,
   validateConfig,
   deleteEmptyConfigFile,
   setConfigPath,
@@ -186,7 +186,7 @@ describe('config/config', () => {
     });
   });
 
-  describe('updateAutoOpenLocalDevSessionInBrowser()', () => {
+  describe('updateAutoOpenBrowser()', () => {
     beforeEach(() => {
       setConfig({
         defaultPortal: 'test',
@@ -194,31 +194,31 @@ describe('config/config', () => {
       });
     });
 
-    it('sets autoOpenLocalDevSessionInBrowser to true in the config', () => {
-      updateAutoOpenLocalDevSessionInBrowser(true);
+    it('sets autoOpenBrowser to true in the config', () => {
+      updateAutoOpenBrowser(true);
       const config = getConfig();
-      expect(config?.autoOpenLocalDevSessionInBrowser).toBe(true);
+      expect(config?.autoOpenBrowser).toBe(true);
     });
 
-    it('sets autoOpenLocalDevSessionInBrowser to false in the config', () => {
-      updateAutoOpenLocalDevSessionInBrowser(false);
+    it('sets autoOpenBrowser to false in the config', () => {
+      updateAutoOpenBrowser(false);
       const config = getConfig();
-      expect(config?.autoOpenLocalDevSessionInBrowser).toBe(false);
+      expect(config?.autoOpenBrowser).toBe(false);
     });
 
-    it('overwrites existing autoOpenLocalDevSessionInBrowser value', () => {
+    it('overwrites existing autoOpenBrowser value', () => {
       // First set to true
-      updateAutoOpenLocalDevSessionInBrowser(true);
+      updateAutoOpenBrowser(true);
       let config = getConfig();
-      expect(config?.autoOpenLocalDevSessionInBrowser).toBe(true);
+      expect(config?.autoOpenBrowser).toBe(true);
 
       // Then set to false
-      updateAutoOpenLocalDevSessionInBrowser(false);
+      updateAutoOpenBrowser(false);
       config = getConfig();
-      expect(config?.autoOpenLocalDevSessionInBrowser).toBe(false);
+      expect(config?.autoOpenBrowser).toBe(false);
     });
 
-    it('maintains other config properties when updating autoOpenLocalDevSessionInBrowser', () => {
+    it('maintains other config properties when updating autoOpenBrowser', () => {
       const testConfig = {
         defaultPortal: 'test-portal',
         portals: PORTALS,
@@ -226,11 +226,11 @@ describe('config/config', () => {
       };
       setConfig(testConfig);
 
-      updateAutoOpenLocalDevSessionInBrowser(true);
+      updateAutoOpenBrowser(true);
 
       const updatedConfig = getConfig();
       expect(updatedConfig?.allowUsageTracking).toBe(false);
-      expect(updatedConfig?.autoOpenLocalDevSessionInBrowser).toBe(true);
+      expect(updatedConfig?.autoOpenBrowser).toBe(true);
     });
   });
 

--- a/config/__tests__/config.test.ts
+++ b/config/__tests__/config.test.ts
@@ -9,6 +9,7 @@ import {
   getAccountId,
   updateDefaultAccount,
   updateAccountConfig,
+  updateAutoOpenLocalDevSessionInBrowser,
   validateConfig,
   deleteEmptyConfigFile,
   setConfigPath,
@@ -182,6 +183,54 @@ describe('config/config', () => {
     it('sets the defaultPortal in the config', () => {
       const config = getConfig();
       expect(config ? getDefaultAccount(config) : null).toEqual(myPortalName);
+    });
+  });
+
+  describe('updateAutoOpenLocalDevSessionInBrowser()', () => {
+    beforeEach(() => {
+      setConfig({
+        defaultPortal: 'test',
+        portals: [],
+      });
+    });
+
+    it('sets autoOpenLocalDevSessionInBrowser to true in the config', () => {
+      updateAutoOpenLocalDevSessionInBrowser(true);
+      const config = getConfig();
+      expect(config?.autoOpenLocalDevSessionInBrowser).toBe(true);
+    });
+
+    it('sets autoOpenLocalDevSessionInBrowser to false in the config', () => {
+      updateAutoOpenLocalDevSessionInBrowser(false);
+      const config = getConfig();
+      expect(config?.autoOpenLocalDevSessionInBrowser).toBe(false);
+    });
+
+    it('overwrites existing autoOpenLocalDevSessionInBrowser value', () => {
+      // First set to true
+      updateAutoOpenLocalDevSessionInBrowser(true);
+      let config = getConfig();
+      expect(config?.autoOpenLocalDevSessionInBrowser).toBe(true);
+
+      // Then set to false
+      updateAutoOpenLocalDevSessionInBrowser(false);
+      config = getConfig();
+      expect(config?.autoOpenLocalDevSessionInBrowser).toBe(false);
+    });
+
+    it('maintains other config properties when updating autoOpenLocalDevSessionInBrowser', () => {
+      const testConfig = {
+        defaultPortal: 'test-portal',
+        portals: PORTALS,
+        allowUsageTracking: false,
+      };
+      setConfig(testConfig);
+
+      updateAutoOpenLocalDevSessionInBrowser(true);
+
+      const updatedConfig = getConfig();
+      expect(updatedConfig?.allowUsageTracking).toBe(false);
+      expect(updatedConfig?.autoOpenLocalDevSessionInBrowser).toBe(true);
     });
   });
 

--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -662,6 +662,22 @@ export function updateAllowUsageTracking(isEnabled: boolean): void {
   writeConfig();
 }
 
+export function updateAutoOpenLocalDevSessionInBrowser(
+  isEnabled: boolean
+): void {
+  if (typeof isEnabled !== 'boolean') {
+    throw new Error(
+      `Unable to update autoOpenLocalDevSessionInBrowser. The value ${isEnabled} is invalid. The value must be a boolean.`
+    );
+  }
+
+  const config = getAndLoadConfigIfNeeded();
+  config.autoOpenLocalDevSessionInBrowser = isEnabled;
+
+  setDefaultConfigPathIfUnset();
+  writeConfig();
+}
+
 /**
  * @throws {Error}
  */

--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -662,17 +662,15 @@ export function updateAllowUsageTracking(isEnabled: boolean): void {
   writeConfig();
 }
 
-export function updateAutoOpenLocalDevSessionInBrowser(
-  isEnabled: boolean
-): void {
+export function updateAutoOpenBrowser(isEnabled: boolean): void {
   if (typeof isEnabled !== 'boolean') {
     throw new Error(
-      `Unable to update autoOpenLocalDevSessionInBrowser. The value ${isEnabled} is invalid. The value must be a boolean.`
+      `Unable to update autoOpenBrowser. The value ${isEnabled} is invalid. The value must be a boolean.`
     );
   }
 
   const config = getAndLoadConfigIfNeeded();
-  config.autoOpenLocalDevSessionInBrowser = isEnabled;
+  config.autoOpenBrowser = isEnabled;
 
   setDefaultConfigPathIfUnset();
   writeConfig();

--- a/config/index.ts
+++ b/config/index.ts
@@ -203,6 +203,16 @@ export function updateAllowUsageTracking(isEnabled: boolean): void {
   }
 }
 
+export function updateAutoOpenLocalDevSessionInBrowser(
+  isEnabled: boolean
+): void {
+  if (CLIConfiguration.isActive()) {
+    CLIConfiguration.updateAutoOpenLocalDevSessionInBrowser(isEnabled);
+  } else {
+    config_DEPRECATED.updateAutoOpenLocalDevSessionInBrowser(isEnabled);
+  }
+}
+
 export function deleteConfigFile(): void {
   if (CLIConfiguration.isActive()) {
     newDeleteConfigFile();

--- a/config/index.ts
+++ b/config/index.ts
@@ -203,13 +203,11 @@ export function updateAllowUsageTracking(isEnabled: boolean): void {
   }
 }
 
-export function updateAutoOpenLocalDevSessionInBrowser(
-  isEnabled: boolean
-): void {
+export function updateAutoOpenBrowser(isEnabled: boolean): void {
   if (CLIConfiguration.isActive()) {
-    CLIConfiguration.updateAutoOpenLocalDevSessionInBrowser(isEnabled);
+    CLIConfiguration.updateAutoOpenBrowser(isEnabled);
   } else {
-    config_DEPRECATED.updateAutoOpenLocalDevSessionInBrowser(isEnabled);
+    config_DEPRECATED.updateAutoOpenBrowser(isEnabled);
   }
 }
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -293,6 +293,11 @@
         "errors": {
           "invalidInput": "Unable to update allowUsageTracking. The value {{ isEnabled }} is invalid. The value must be a boolean."
         }
+      },
+      "updateAutoOpenLocalDevSessionInBrowser": {
+        "errors": {
+          "invalidInput": "Unable to update autoOpenLocalDevSessionInBrowser. The value {{ isEnabled }} is invalid. The value must be a boolean."
+        }
       }
     },
     "configFile": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -294,9 +294,9 @@
           "invalidInput": "Unable to update allowUsageTracking. The value {{ isEnabled }} is invalid. The value must be a boolean."
         }
       },
-      "updateAutoOpenLocalDevSessionInBrowser": {
+      "updateAutoOpenBrowser": {
         "errors": {
-          "invalidInput": "Unable to update autoOpenLocalDevSessionInBrowser. The value {{ isEnabled }} is invalid. The value must be a boolean."
+          "invalidInput": "Unable to update autoOpenBrowser. The value {{ isEnabled }} is invalid. The value must be a boolean."
         }
       }
     },

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -13,6 +13,7 @@ export interface CLIConfig_NEW {
   httpTimeout?: number;
   env?: Environment;
   httpUseLocalhost?: boolean;
+  autoOpenLocalDevSessionInBrowser?: boolean;
 }
 
 export interface CLIConfig_DEPRECATED {
@@ -25,6 +26,7 @@ export interface CLIConfig_DEPRECATED {
   httpTimeout?: number;
   env?: Environment;
   httpUseLocalhost?: boolean;
+  autoOpenLocalDevSessionInBrowser?: boolean;
 }
 
 export type CLIConfig = CLIConfig_NEW | CLIConfig_DEPRECATED;

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -13,7 +13,7 @@ export interface CLIConfig_NEW {
   httpTimeout?: number;
   env?: Environment;
   httpUseLocalhost?: boolean;
-  autoOpenLocalDevSessionInBrowser?: boolean;
+  autoOpenBrowser?: boolean;
   flags?: Array<string>;
 }
 
@@ -27,7 +27,7 @@ export interface CLIConfig_DEPRECATED {
   httpTimeout?: number;
   env?: Environment;
   httpUseLocalhost?: boolean;
-  autoOpenLocalDevSessionInBrowser?: boolean;
+  autoOpenBrowser?: boolean;
   flags?: Array<string>;
 }
 


### PR DESCRIPTION
## Description and Context
This adds a new config setting/flag `autoOpenLocalDevSessionInBrowser`. This will be used by the CLI to allow users to prevent Local Dev UI from opening automatically when they run `hs project dev`

## Who to Notify
@brandenrodgers @joe-yeager @lkosarpersonal 
