### PR TITLE
Add default value option to isConfigFlagEnabled

### DIFF
--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -925,14 +925,17 @@ function loadEnvironmentVariableConfig(options: {
   return setConfig(handleLegacyCmsPublishMode(envConfig));
 }
 
-export function isConfigFlagEnabled(flag: keyof CLIConfig_DEPRECATED): boolean {
+export function isConfigFlagEnabled(
+  flag: keyof CLIConfig_DEPRECATED,
+  defaultValue = false
+): boolean {
   if (!configFileExists() || configFileIsBlank()) {
-    return false;
+    return defaultValue;
   }
 
   const config = getAndLoadConfigIfNeeded();
 
-  return Boolean(config[flag] || false);
+  return Boolean(config[flag] || defaultValue);
 }
 
 function handleLegacyCmsPublishMode(

--- a/config/index.ts
+++ b/config/index.ts
@@ -219,11 +219,14 @@ export function deleteConfigFile(): void {
   }
 }
 
-export function isConfigFlagEnabled(flag: keyof CLIConfig): boolean {
+export function isConfigFlagEnabled(
+  flag: keyof CLIConfig,
+  defaultValue = false
+): boolean {
   if (CLIConfiguration.isActive()) {
-    return CLIConfiguration.isConfigFlagEnabled(flag);
+    return CLIConfiguration.isConfigFlagEnabled(flag, defaultValue);
   }
-  return config_DEPRECATED.isConfigFlagEnabled(flag);
+  return config_DEPRECATED.isConfigFlagEnabled(flag, defaultValue);
 }
 
 export function isTrackingAllowed() {


### PR DESCRIPTION
## Description and Context
`isConfigFlagEnabled` already had a `defaultValue` option for the new `CLIConfiguration` class, but the deprecated one didn't (and the exported config functions didn't either). This adds a `defaultValue` arg so that we can default config flags that don't exist to `true`.


## Who to Notify
@joe-yeager @lkosarpersonal 
