### PR TITLE
Ensure newly uploaded module at /path have their meta.json files uploaded first

### DIFF
--- a/lib/__tests__/uploadFolder.test.ts
+++ b/lib/__tests__/uploadFolder.test.ts
@@ -97,9 +97,9 @@ describe('lib/cms/uploadFolder', () => {
       upload.mockResolvedValue(mockAxiosResponse());
 
       const uploadedFilesInOrder = [
+        'folder/sample.module/meta.json',
         'folder/images/image.png',
         'folder/images/image.jpg',
-        'folder/sample.module/meta.json',
         'folder/sample.module/module.css',
         'folder/sample.module/module.js',
         'folder/sample.module/module.html',

--- a/lib/__tests__/uploadFolder.test.ts
+++ b/lib/__tests__/uploadFolder.test.ts
@@ -99,9 +99,9 @@ describe('lib/cms/uploadFolder', () => {
       const uploadedFilesInOrder = [
         'folder/images/image.png',
         'folder/images/image.jpg',
+        'folder/sample.module/meta.json',
         'folder/sample.module/module.css',
         'folder/sample.module/module.js',
-        'folder/sample.module/meta.json',
         'folder/sample.module/module.html',
         'folder/css/file.css',
         'folder/js/file.js',

--- a/lib/__tests__/uploadFolder.test.ts
+++ b/lib/__tests__/uploadFolder.test.ts
@@ -96,6 +96,7 @@ describe('lib/cms/uploadFolder', () => {
       walk.mockResolvedValue(filesProto);
       upload.mockResolvedValue(mockAxiosResponse());
 
+      // meta.json should be uploaded first, then the rest of the files
       const uploadedFilesInOrder = [
         'folder/sample.module/meta.json',
         'folder/images/image.png',

--- a/lib/cms/uploadFolder.ts
+++ b/lib/cms/uploadFolder.ts
@@ -298,7 +298,7 @@ export async function uploadFolder(
   );
   const failures: Array<{ file: string; destPath: string }> = [];
   let fieldsJsPaths: Array<Partial<FieldsJs>> = [];
-  let tmpDirRegex: RegExp;
+  const tmpDirRegex = new RegExp(`^${escapeRegExp(tmpDir || '')}`);
 
   const [filesByType, fieldsJsObjects] = await getFilesByType(
     filePaths,
@@ -311,7 +311,6 @@ export async function uploadFolder(
     fieldsJsPaths = fieldsJsObjects.map(fieldsJs => {
       return { outputPath: fieldsJs.outputPath, filePath: fieldsJs.filePath };
     });
-    tmpDirRegex = new RegExp(`^${escapeRegExp(tmpDir || '')}`);
   }
 
   function uploadFile(file: string): () => Promise<void> {

--- a/lib/cms/uploadFolder.ts
+++ b/lib/cms/uploadFolder.ts
@@ -185,6 +185,81 @@ const defaultUploadFinalErrorCallback = (
     }
   );
 };
+
+async function processNewModulesMetaFiles(
+  accountId: number,
+  moduleFiles: string[],
+  fieldsJsPaths: Array<Partial<FieldsJs>>,
+  tmpDirRegex: RegExp,
+  regex: RegExp,
+  dest: string,
+  apiOptions: any,
+  _onAttemptCallback: (file: string | undefined, destPath: string) => void,
+  _onSuccessCallback: (file: string | undefined, destPath: string) => void,
+  _onFirstErrorCallback: (
+    file: string,
+    destPath: string,
+    error: unknown
+  ) => void,
+  failures: Array<{ file: string; destPath: string }>
+): Promise<string[]> {
+  const moduleMetaJsonFiles = moduleFiles.filter(isMetaJsonFile);
+  const remainingMetaJsonFiles: string[] = [];
+
+  // Batch check which modules are new - parallelize API calls for better performance
+  const moduleChecks = await Promise.allSettled(
+    moduleMetaJsonFiles.map(async metaFile => {
+      const pathInfo = resolveUploadPath(
+        metaFile,
+        fieldsJsPaths,
+        tmpDirRegex,
+        regex,
+        dest
+      );
+      const modulePath = path.dirname(pathInfo.destPath);
+      const isNew = await isModuleNew(accountId, modulePath, apiOptions);
+      return { metaFile, isNew, pathInfo };
+    })
+  );
+
+  // Process results and upload net-new meta.json files sequentially
+  for (let i = 0; i < moduleChecks.length; i++) {
+    const result = moduleChecks[i];
+    const metaFile = moduleMetaJsonFiles[i];
+
+    if (result.status === 'fulfilled') {
+      const { isNew, pathInfo } = result.value;
+
+      if (isNew) {
+        // Upload net-new meta.json file immediately using cached path info
+        const { originalFilePath, destPath } = pathInfo;
+        _onAttemptCallback(originalFilePath, destPath);
+
+        try {
+          await upload(accountId, metaFile, destPath, apiOptions);
+          _onSuccessCallback(originalFilePath, destPath);
+        } catch (err) {
+          if (isAuthError(err)) {
+            throw err;
+          }
+          _onFirstErrorCallback(metaFile, destPath, err);
+          failures.push({ file: metaFile, destPath });
+        }
+      } else {
+        // Add existing module meta.json to regular upload queue
+        remainingMetaJsonFiles.push(metaFile);
+      }
+    } else {
+      // If module check failed, add to regular queue to be safe
+      logger.debug(
+        `Module existence check failed for ${path.basename(metaFile)}: ${result.reason}`
+      );
+      remainingMetaJsonFiles.push(metaFile);
+    }
+  }
+
+  return remainingMetaJsonFiles;
+}
 export async function uploadFolder(
   accountId: number,
   src: string,
@@ -265,76 +340,37 @@ export async function uploadFolder(
     };
   }
 
-  // Find and upload net-new module meta.json files first
-  const moduleMetaJsonFiles =
-    filesByType[FILE_TYPES.module]?.filter(isMetaJsonFile) || [];
-  const filesToUploadLater: string[] = [];
-
-  // Batch check which modules are new - parallelize API calls for better performance
-  const moduleChecks = await Promise.allSettled(
-    moduleMetaJsonFiles.map(async metaFile => {
-      const pathInfo = resolveUploadPath(
-        metaFile,
-        fieldsJsPaths,
-        tmpDirRegex,
-        regex,
-        dest
-      );
-      const modulePath = path.dirname(pathInfo.destPath);
-      const isNew = await isModuleNew(accountId, modulePath, apiOptions);
-      return { metaFile, isNew, pathInfo };
-    })
+  // Process new modules first, then collect remaining files to upload
+  const remainingMetaJsonFiles = await processNewModulesMetaFiles(
+    accountId,
+    filesByType[FILE_TYPES.module] || [],
+    fieldsJsPaths,
+    tmpDirRegex,
+    regex,
+    dest,
+    apiOptions,
+    _onAttemptCallback,
+    _onSuccessCallback,
+    _onFirstErrorCallback,
+    failures
   );
-
-  // Process results and upload net-new meta.json files sequentially
-  for (let i = 0; i < moduleChecks.length; i++) {
-    const result = moduleChecks[i];
-    const metaFile = moduleMetaJsonFiles[i];
-
-    if (result.status === 'fulfilled') {
-      const { isNew, pathInfo } = result.value;
-
-      if (isNew) {
-        // Upload net-new meta.json file immediately using cached path info
-        const { originalFilePath, destPath } = pathInfo;
-        _onAttemptCallback(originalFilePath, destPath);
-
-        try {
-          await upload(accountId, metaFile, destPath, apiOptions);
-          _onSuccessCallback(originalFilePath, destPath);
-        } catch (err) {
-          if (isAuthError(err)) {
-            throw err;
-          }
-          _onFirstErrorCallback(metaFile, destPath, err);
-          failures.push({ file: metaFile, destPath });
-        }
-      } else {
-        // Add existing module meta.json to regular upload queue
-        filesToUploadLater.push(metaFile);
-      }
-    } else {
-      // If module check failed, add to regular queue to be safe
-      logger.debug(
-        `Module existence check failed for ${path.basename(metaFile)}: ${result.reason}`
-      );
-      filesToUploadLater.push(metaFile);
-    }
-  }
+  const deferredFiles: string[] = [];
 
   // Upload all remaining files concurrently
   Object.entries(filesByType).forEach(([fileType, files]) => {
     if (fileType === FILE_TYPES.module) {
+      // Add meta.json files that weren't uploaded as new modules
+      deferredFiles.push(...remainingMetaJsonFiles);
       // Add non-meta.json module files
-      filesToUploadLater.push(...files.filter(f => !isMetaJsonFile(f)));
+      deferredFiles.push(...files.filter(f => !isMetaJsonFile(f)));
     } else {
       // Add all non-module files
-      filesToUploadLater.push(...files);
+      deferredFiles.push(...files);
     }
   });
 
-  if (filesToUploadLater.length > 0) {
-    await queue.addAll(filesToUploadLater.map(uploadFile));
+  if (deferredFiles.length > 0) {
+    await queue.addAll(deferredFiles.map(uploadFile));
   }
 
   const results = await queue

--- a/lib/cms/uploadFolder.ts
+++ b/lib/cms/uploadFolder.ts
@@ -8,8 +8,8 @@ import {
   cleanupTmpDirSync,
 } from './handleFieldsJS';
 import { getFileMapperQueryValues } from '../fileMapper';
-import { upload, download } from '../../api/fileMapper';
-import { isModuleFolderChild } from '../../utils/cms/modules';
+import { upload } from '../../api/fileMapper';
+import { isModuleFolderChild, isModuleNew } from '../../utils/cms/modules';
 import { escapeRegExp } from '../escapeRegExp';
 import { convertToUnixPath, getExt } from '../path';
 import { isAuthError, isHubSpotHttpError } from '../../errors';
@@ -54,22 +54,6 @@ function isMetaJsonFile(filePath: string): boolean {
   return path.basename(filePath).toLowerCase() === 'meta.json';
 }
 
-async function isModuleNew(
-  accountId: number, 
-  modulePath: string,
-  apiOptions: any
-): Promise<boolean> {
-  try {
-    await download(accountId, modulePath, apiOptions);
-    return false; // Module exists
-  } catch (error: any) {
-    if (error.response?.status === 404 || error.status === 404) {
-      return true; // Module doesn't exist (net-new)
-    }
-    // For other errors, assume module exists to be safe
-    return false;
-  }
-}
 
 export async function getFilesByType(
   filePaths: Array<string>,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "3.16.1",
+  "version": "3.16.0",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/local-dev-lib",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "Provides library functionality for HubSpot local development tooling, including the HubSpot CLI",
   "repository": {
     "type": "git",

--- a/utils/cms/modules.ts
+++ b/utils/cms/modules.ts
@@ -62,7 +62,7 @@ export function isModuleFolderChild(
  * @returns Promise<boolean> - true if module is new (doesn't exist), false if it exists
  */
 export async function isModuleNew(
-  accountId: number, 
+  accountId: number,
   modulePath: string,
   apiOptions: any
 ): Promise<boolean> {

--- a/utils/cms/modules.ts
+++ b/utils/cms/modules.ts
@@ -3,6 +3,7 @@ import { getExt, splitHubSpotPath, splitLocalPath } from '../../lib/path';
 import { MODULE_EXTENSION } from '../../constants/extensions';
 import { PathInput } from '../../types/Modules';
 import { i18n } from '../lang';
+import { download } from '../../api/fileMapper';
 
 const i18nKey = 'utils.cms.modules';
 
@@ -51,4 +52,28 @@ export function isModuleFolderChild(
   return pathParts
     .slice(0, length - 1)
     .some(part => isModuleFolder({ ...pathInput, path: part }));
+}
+
+/**
+ * Checks if a module is new (doesn't exist on the server yet) by attempting to download it.
+ * @param accountId The HubSpot account ID
+ * @param modulePath The module path to check
+ * @param apiOptions API options for the request
+ * @returns Promise<boolean> - true if module is new (doesn't exist), false if it exists
+ */
+export async function isModuleNew(
+  accountId: number, 
+  modulePath: string,
+  apiOptions: any
+): Promise<boolean> {
+  try {
+    await download(accountId, modulePath, apiOptions);
+    return false; // Module exists
+  } catch (error: any) {
+    if (error.response?.status === 404 || error.status === 404) {
+      return true; // Module doesn't exist (net-new)
+    }
+    // For other errors, assume module exists to be safe
+    return false;
+  }
 }


### PR DESCRIPTION
## Description and Context

 - Upload new module meta.json files sequentially before other files in order to ensure that the module's meta information set locally is persisted correctly when it makes to the creation process and BE model generation.

There is a current bug where, when a customer uploads files from their local development, the module_id and other properties are not actually being set correctly if the module is net-new. So, a customer working with version control, or fetching those modules back down, will see incorrect information in the meta.json including the `module_id` property -- which is set dynamically on the BE if not present in the meta.json (something it can check for prematurely to the local meta.json actually being processed).

This PR pushed meta.json files into their own queue and batch uploads those first, and then processes the other files to a separate queue for upload afterwards.