### PR TITLE
Ts/fix module upload order batch meta

### DIFF
--- a/lib/cms/uploadFolder.ts
+++ b/lib/cms/uploadFolder.ts
@@ -192,11 +192,8 @@ async function uploadMetaJsonFiles(
 ): Promise<void> {
   const moduleMetaJsonFiles = moduleFiles.filter(isMetaJsonFile);
   
-  console.log(`Found ${moduleMetaJsonFiles.length} meta.json files to upload first`);
   if (moduleMetaJsonFiles.length > 0) {
-    console.log('Uploading meta.json files:', moduleMetaJsonFiles.map(f => path.basename(f)));
     await queue.addAll(moduleMetaJsonFiles.map(uploadFile));
-    console.log('Completed uploading all meta.json files');
   }
 }
 export async function uploadFolder(
@@ -279,7 +276,6 @@ export async function uploadFolder(
   }
 
   // Upload all meta.json files first
-  console.log('Starting meta.json file upload phase...');
   await uploadMetaJsonFiles(filesByType[FILE_TYPES.module] || [], uploadFile);
 
   // Collect all remaining files for upload
@@ -287,21 +283,16 @@ export async function uploadFolder(
   Object.entries(filesByType).forEach(([fileType, files]) => {
     if (fileType === FILE_TYPES.module) {
       // Add non-meta.json module files
-      const nonMetaModuleFiles = files.filter(f => !isMetaJsonFile(f));
-      console.log(`Adding ${nonMetaModuleFiles.length} non-meta.json module files to deferred queue`);
-      deferredFiles.push(...nonMetaModuleFiles);
+      deferredFiles.push(...files.filter(f => !isMetaJsonFile(f)));
     } else {
       // Add all non-module files
-      console.log(`Adding ${files.length} ${fileType} files to deferred queue`);
       deferredFiles.push(...files);
     }
   });
 
   // Upload all remaining files concurrently
-  console.log(`Starting concurrent upload of ${deferredFiles.length} remaining files...`);
   if (deferredFiles.length > 0) {
     await queue.addAll(deferredFiles.map(uploadFile));
-    console.log('Completed uploading all remaining files');
   }
 
   const results = await queue

--- a/utils/cms/modules.ts
+++ b/utils/cms/modules.ts
@@ -3,8 +3,6 @@ import { getExt, splitHubSpotPath, splitLocalPath } from '../../lib/path';
 import { MODULE_EXTENSION } from '../../constants/extensions';
 import { PathInput } from '../../types/Modules';
 import { i18n } from '../lang';
-import { download } from '../../api/fileMapper';
-
 const i18nKey = 'utils.cms.modules';
 
 const isBool = (x: boolean | undefined) => !!x === x;
@@ -54,26 +52,3 @@ export function isModuleFolderChild(
     .some(part => isModuleFolder({ ...pathInput, path: part }));
 }
 
-/**
- * Checks if a module is new (doesn't exist on the server yet) by attempting to download it.
- * @param accountId The HubSpot account ID
- * @param modulePath The module path to check
- * @param apiOptions API options for the request
- * @returns Promise<boolean> - true if module is new (doesn't exist), false if it exists
- */
-export async function isModuleNew(
-  accountId: number,
-  modulePath: string,
-  apiOptions: any
-): Promise<boolean> {
-  try {
-    await download(accountId, modulePath, apiOptions);
-    return false; // Module exists
-  } catch (error: any) {
-    if (error.response?.status === 404 || error.status === 404) {
-      return true; // Module doesn't exist (net-new)
-    }
-    // For other errors, assume module exists to be safe
-    return false;
-  }
-}


### PR DESCRIPTION
## Description and Context

Adjusts some of the code on the previous fix in isolation for testing -- Batch process on all meta.json files without checking for net new. Then process 'other' (calling deferred) files second in a different upload.