### PR TITLE
Retry github requests without tokens

### DIFF
--- a/api/github.ts
+++ b/api/github.ts
@@ -2,6 +2,7 @@ import axios, { ResponseType } from 'axios';
 import { getDefaultUserAgentHeader } from '../http/getAxiosConfig';
 import { GithubReleaseData, GithubRepoFile, RepoPath } from '../types/Github';
 import { HubSpotPromise } from '../types/Http';
+import { isSpecifiedError } from '../errors';
 
 const GITHUB_REPOS_API = 'https://api.github.com/repos';
 const GITHUB_RAW_CONTENT_API_PATH = 'https://raw.githubusercontent.com';
@@ -41,7 +42,7 @@ function githubRequestWithFallback<T>(
       .get<T>(url, { headers: headersWithAuth, responseType })
       .catch(error => {
         // 404 with an auth token might mean an SSO issue so retry without the authorization header
-        if (error.response?.status === 404) {
+        if (isSpecifiedError(error, { statusCode: 404 })) {
           return axios.get<T>(url, {
             headers: { ...getDefaultUserAgentHeader() },
             responseType,
@@ -83,7 +84,7 @@ export function fetchRepoFile<T = Buffer>(
   filePath: string,
   ref: string
 ): HubSpotPromise<T> {
-  const url = `${GITHUB_RAW_CONTENT_API_PATH}/${repoPath}/${ref}/${filePath}`;
+  const url = `${GITHUB_RAW_CONTENT_API_PATH}/${repoPath}/${ref}/${filePath}dd`;
   return githubRequestWithFallback<T>(url);
 }
 


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Fixes: https://github.com/HubSpot/hubspot-cli/issues/1553

We had a user run into an issue where a user was running into what was likely an SSO-related error with the cli's github requests. The fix was to omit the GITHUB_TOKEN env variable.

This updates the gh logic to retry the requests without the tokens if we hit a 404 (which is the status code for the SSO issues)

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
