### PR TITLE
Removing unnecessary behavior in the config file read util

### DIFF
--- a/config/config_DEPRECATED.ts
+++ b/config/config_DEPRECATED.ts
@@ -17,7 +17,6 @@ import {
 import { CMS_PUBLISH_MODE } from '../constants/files';
 import { getValidEnv } from '../lib/environment';
 import { logger } from '../lib/logger';
-import { isConfigPathInGitRepo } from '../utils/git';
 import {
   logErrorInstance,
   logFileSystemErrorInstance,
@@ -242,11 +241,10 @@ function readConfigFile(): { source?: string; error?: BaseError } {
     return { source, error };
   }
   try {
-    isConfigPathInGitRepo(_configPath);
     source = fs.readFileSync(_configPath);
   } catch (err) {
     error = err as BaseError;
-    logger.error('Config file could not be read "%s"', _configPath);
+    logger.error(`Config file could not be read: ${_configPath}`);
     logFileSystemErrorInstance(error, {
       filepath: _configPath,
       operation: 'read',
@@ -268,7 +266,7 @@ function parseConfig(configSource?: string): {
     parsed = yaml.load(configSource) as CLIConfig_DEPRECATED;
   } catch (err) {
     error = err as BaseError;
-    logger.error('Config file could not be parsed "%s"', _configPath);
+    logger.error(`Config file could not be parsed: ${_configPath}`);
     logErrorInstance(err as BaseError);
   }
   return { parsed, error };


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

From what I can tell there's no reason for us to be calling `isConfigPathInGitRepo` here. That util returns a boolean and always has, so it's doing nothing. [Here's the commit where it was initially adde for context](https://github.com/HubSpot/hubspot-cli/commit/b80acbfbe8ed2accf9d22771a27a13d8090ed78d#diff-d71973eeeaa7f10917f7688acc4c7e3d12d29743be4a92878758e199d89229d9R194). I'm guessing it was a mistake.

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
