### PR TITLE
Add endpoint to get app by UID

### DIFF
--- a/api/appsDev.ts
+++ b/api/appsDev.ts
@@ -59,3 +59,15 @@ export function installStaticAuthAppOnTestAccount(
     },
   });
 }
+
+export function fetchAppMetadataByUid(
+  appUid: string,
+  accountId: number
+): HubSpotPromise<PublicApp> {
+  return http.get<PublicApp>(accountId, {
+    url: `${APPS_DEV_API_PATH}/full/portal/sourceId`,
+    params: {
+      sourceId: appUid,
+    },
+  });
+}


### PR DESCRIPTION
## Description and Context
This adds a function for the new `apps-dev/external/public/v3/full/portal/sourceId` to LDL. This endpoint allows the CLI to fetch app metadata directly by UID, which is much faster than the previous setup, where it had to fetch _every_ app in a users portal and then filter by UID. This will be used to speed up `hs project dev`

## Who to Notify
@brandenrodgers @joe-yeager @chiragchadha1 