### PR TITLE
fix: Write to parent settings file if exists

### DIFF
--- a/config/__tests__/hsSettings.test.ts
+++ b/config/__tests__/hsSettings.test.ts
@@ -71,8 +71,80 @@ describe('hsSettings', () => {
   });
 
   describe('writeHsSettingsFile()', () => {
-    it('creates .hs folder and writes settings file', () => {
+    it('creates .hs folder, settings file, and README when no settings file exists', () => {
+      mockFindupSync.mockReturnValueOnce(null);
       mockFs.existsSync.mockReturnValueOnce(false);
+      mockFs.mkdirSync.mockReturnValueOnce(undefined);
+      mockFs.writeFileSync.mockImplementation(() => undefined);
+
+      writeHsSettingsFile(SETTINGS);
+
+      expect(mockFs.mkdirSync).toHaveBeenCalledWith('/mock/project/.hs', {
+        recursive: true,
+      });
+      expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+        '/mock/project/.hs/settings.json',
+        JSON.stringify(SETTINGS, null, 2),
+        'utf8'
+      );
+      const readmeCall = mockFs.writeFileSync.mock.calls.find(
+        call => typeof call[0] === 'string' && call[0].includes('README.txt')
+      );
+      expect(readmeCall).toBeDefined();
+    });
+
+    it('writes to existing settings file path when one exists', () => {
+      mockFindupSync.mockReturnValueOnce('/parent/.hs/settings.json');
+      mockFs.existsSync.mockReturnValueOnce(true);
+      mockFs.mkdirSync.mockReturnValueOnce(undefined);
+      mockFs.writeFileSync.mockImplementation(() => undefined);
+
+      writeHsSettingsFile(SETTINGS);
+
+      expect(mockFs.mkdirSync).toHaveBeenCalledWith('/parent/.hs', {
+        recursive: true,
+      });
+      expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+        '/parent/.hs/settings.json',
+        JSON.stringify(SETTINGS, null, 2),
+        'utf8'
+      );
+    });
+
+    it('does not write README when updating existing settings file', () => {
+      mockFindupSync.mockReturnValueOnce('/parent/.hs/settings.json');
+      mockFs.existsSync.mockReturnValueOnce(true);
+      mockFs.mkdirSync.mockReturnValueOnce(undefined);
+      mockFs.writeFileSync.mockImplementation(() => undefined);
+
+      writeHsSettingsFile(SETTINGS);
+
+      const readmeCall = mockFs.writeFileSync.mock.calls.find(
+        call => typeof call[0] === 'string' && call[0].includes('README.txt')
+      );
+      expect(readmeCall).toBeUndefined();
+    });
+
+    it('targets parent .hs folder and does not create .hs in cwd when settings exist in parent directory', () => {
+      mockFindupSync.mockReturnValueOnce('/parent/.hs/settings.json');
+      mockFs.existsSync.mockReturnValueOnce(true);
+      mockFs.mkdirSync.mockReturnValueOnce(undefined);
+      mockFs.writeFileSync.mockImplementation(() => undefined);
+
+      writeHsSettingsFile(SETTINGS);
+
+      expect(mockFs.mkdirSync).not.toHaveBeenCalledWith(
+        '/mock/project/.hs',
+        expect.anything()
+      );
+      expect(mockFs.mkdirSync).toHaveBeenCalledWith('/parent/.hs', {
+        recursive: true,
+      });
+    });
+
+    it('writes to cwd .hs when settings file is in the same directory', () => {
+      mockFindupSync.mockReturnValueOnce('/mock/project/.hs/settings.json');
+      mockFs.existsSync.mockReturnValueOnce(true);
       mockFs.mkdirSync.mockReturnValueOnce(undefined);
       mockFs.writeFileSync.mockImplementation(() => undefined);
 
@@ -88,35 +160,8 @@ describe('hsSettings', () => {
       );
     });
 
-    it('writes README.txt on first scaffold', () => {
-      mockFs.existsSync.mockReturnValueOnce(false);
-      mockFs.mkdirSync.mockReturnValueOnce(undefined);
-      mockFs.writeFileSync.mockImplementation(() => undefined);
-
-      writeHsSettingsFile(SETTINGS);
-
-      const writeFileCalls = mockFs.writeFileSync.mock.calls;
-      const readmeCall = writeFileCalls.find(
-        call => typeof call[0] === 'string' && call[0].includes('README.txt')
-      );
-      expect(readmeCall).toBeDefined();
-    });
-
-    it('does not write README.txt when .hs folder already exists', () => {
-      mockFs.existsSync.mockReturnValueOnce(true);
-      mockFs.mkdirSync.mockReturnValueOnce(undefined);
-      mockFs.writeFileSync.mockImplementation(() => undefined);
-
-      writeHsSettingsFile(SETTINGS);
-
-      const writeFileCalls = mockFs.writeFileSync.mock.calls;
-      const readmeCall = writeFileCalls.find(
-        call => typeof call[0] === 'string' && call[0].includes('README.txt')
-      );
-      expect(readmeCall).toBeUndefined();
-    });
-
     it('throws FileSystemError when write fails', () => {
+      mockFindupSync.mockReturnValueOnce(null);
       mockFs.existsSync.mockReturnValueOnce(false);
       mockFs.mkdirSync.mockImplementation(() => {
         throw new Error('EACCES');

--- a/config/hsSettings.ts
+++ b/config/hsSettings.ts
@@ -49,14 +49,17 @@ export function getHsSettingsFileIfExists(): HsSettingsFile | null {
 }
 
 export function writeHsSettingsFile(settingsFile: HsSettingsFile): void {
+  const existingFilePath = getHsSettingsFilePath();
   const dir = getCwd();
-  const hsFolderPath = path.join(dir, HS_FOLDER);
+  const hsFolderPath = existingFilePath
+    ? path.dirname(existingFilePath)
+    : path.join(dir, HS_FOLDER);
   const isFirstScaffold = !fs.existsSync(hsFolderPath);
 
   try {
     fs.mkdirSync(hsFolderPath, { recursive: true });
     fs.writeFileSync(
-      path.join(dir, HS_FOLDER, HS_SETTINGS_FILENAME),
+      path.join(hsFolderPath, HS_SETTINGS_FILENAME),
       JSON.stringify(settingsFile, null, 2),
       'utf8'
     );


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
`writeHsSettingsFile` was resolving the `.hs` directory relative to `cwd` even when an existing settings file was found in a parent directory via `findup-sync`. This caused a new `.hs` folder to be created in the current working directory instead of writing to the already-existing one up the directory tree.

The fix uses `path.dirname(existingFilePath)` to derive the target directory from the found settings file path, falling back to `cwd` only when no existing file is found.

Tests updated to cover the parent-directory scenario and verify that writes target the correct `.hs` folder.
## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
@brandenrodgers @camden11 @joe-yeager 