### PR TITLE
fix: add SANDBOX_TIMEOUT to createV2Sandbox and deleteSandbox

### DIFF
--- a/api/sandboxHubs.ts
+++ b/api/sandboxHubs.ts
@@ -33,6 +33,7 @@ export function deleteSandbox(
 ): HubSpotPromise<void> {
   return http.delete(parentAccountId, {
     url: `${SANDBOX_API_PATH}/${sandboxAccountId}`,
+    timeout: SANDBOX_TIMEOUT,
   });
 }
 
@@ -53,6 +54,7 @@ export function createV2Sandbox(
   return http.post<V2Sandbox>(accountId, {
     url: `${SANDBOX_API_PATH_V2}/sandboxes`,
     data: { name, type, syncObjectRecords },
+    timeout: SANDBOX_TIMEOUT,
   });
 }
 


### PR DESCRIPTION
## Description and Context

`createV2Sandbox` and `deleteSandbox` were the only sandbox endpoints in `api/sandboxHubs.ts` not setting `timeout: SANDBOX_TIMEOUT` (60s). That let them fall back to the global `httpTimeout` (15s default; lower if the user has configured it), which is too short for v2 development sandbox creation.

Symptom in the CLI: `hs sandbox create` fails with `code: ETIMEDOUT` while the backend successfully creates the sandbox. Surfaced via [hubspot-cli#1593](https://github.com/HubSpot/hubspot-cli/issues/1593) — the reporter originally hit a now-fixed server-side regression, but retesting today showed the timeout bug as a separate blocker.

This aligns `createV2Sandbox` and `deleteSandbox` with the pattern the deprecated v1 `createSandbox` and `getSandboxPersonalAccessKey` already use.

## Screenshots

N/A — no user-visible UI change.

## TODO

None.

## Who to Notify
@brandenrodgers @camden11 @joe-yeager 