### PR TITLE
chore: bump axios to 1.15.2

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -155,7 +155,7 @@ export async function fetchGitHubRepoContentFromDownloadUrl(
   const contentType = resp.headers['content-type'];
   let fileContents;
 
-  if (contentType.startsWith('text')) {
+  if (typeof contentType === 'string' && contentType.startsWith('text')) {
     fileContents = Buffer.from(resp.data).toString('utf8');
   } else {
     fileContents = resp.data;

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "address": "2.0.2",
-    "axios": "1.12.0",
+    "axios": "1.15.2",
     "chalk": "5.6.2",
     "chokidar": "3.6.0",
     "content-disposition": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "content-disposition": "0.5.4",
     "cors": "2.8.5",
     "debounce": "1.2.1",
-    "express": "4.21.2",
+    "express": "4.22.1",
     "extract-zip": "2.0.1",
     "findup-sync": "5.0.0",
     "form-data": "^4.0.4",


### PR DESCRIPTION
## Description and Context

Bumps `axios` from `1.12.0` to `1.15.2` to patch:

- [GHSA-43fc-jf86-j433](https://github.com/advisories/GHSA-43fc-jf86-j433) — DoS via `__proto__` key in `mergeConfig`
- [GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5) — `NO_PROXY` hostname normalization bypass leading to SSRF
- [GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx) — Cloud metadata exfiltration via header injection

Surfaced via [hubspot-cli#1554](https://github.com/HubSpot/hubspot-cli/issues/1554).

Includes a small type guard fix in `lib/github.ts` — axios 1.15 widened response-header types, so `contentType.startsWith('text')` no longer compiles without narrowing to string first.

## Screenshots

N/A.

## TODO

None.

## Who to Notify

@brandenrodgers @camden11 @joe-yeager 