### PR TITLE
chore: bump express to 4.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "content-disposition": "0.5.4",
     "cors": "2.8.5",
     "debounce": "1.2.1",
-    "express": "4.21.2",
+    "express": "4.22.1",
     "extract-zip": "2.0.1",
     "findup-sync": "5.0.0",
     "form-data": "^4.0.4",


### PR DESCRIPTION
## Description and Context

Bumps `express` from `4.21.2` to `4.22.1` (latest 4.x). Clears transitive CVEs in `path-to-regexp`, `qs`, and `body-parser` via express's dependency updates:

- [GHSA-37ch-88jc-xwx2](https://github.com/advisories/GHSA-37ch-88jc-xwx2) — path-to-regexp ReDoS
- [GHSA-w7fw-mjwx-w883](https://github.com/advisories/GHSA-w7fw-mjwx-w883) — qs arrayLimit bypass DoS
- [GHSA-6rw7-vpxm-498p](https://github.com/advisories/GHSA-6rw7-vpxm-498p) — qs arrayLimit memory exhaustion

Kept on 4.x intentionally — express 5.x is a major version bump with breaking changes that deserves a separate migration.

**Depends on [axios bump PR](https://github.com/HubSpot/hubspot-local-dev-lib/pull/new/cc/bump-axios):** this branch is rebased on top of `cc/bump-axios` because the axios 1.15 response-header type widening requires a TS guard in `lib/github.ts`. Merging axios first, then this one on top keeps main building cleanly at every step.

Surfaced via [hubspot-cli#1554](https://github.com/HubSpot/hubspot-cli/issues/1554). All 616 tests pass.

## Screenshots

N/A.

## TODO
None

## Who to Notify
@brandenrodgers @camden11 @joe-yeager