### PR TITLE
fix: avoid double-stringifying already-serialized payloads in HubSpot HttpError

### DIFF
--- a/models/HubSpotHttpError.ts
+++ b/models/HubSpotHttpError.ts
@@ -140,7 +140,13 @@ export class HubSpotHttpError<T = any> extends Error {
     }
 
     generatedContext.accountId = cause.config?.params?.portalId;
-    generatedContext.payload = JSON.stringify(cause.config?.data);
+    // Axios serializes request bodies before the error fires, so `config.data`
+    // is often already a JSON string. Avoid re-stringifying so debug output is
+    // readable instead of escape-soup.
+    generatedContext.payload =
+      typeof cause.config?.data === 'string'
+        ? cause.config.data
+        : JSON.stringify(cause.config?.data);
     // This will just be the url path
     generatedContext.request = cause.config?.url;
 

--- a/models/__tests__/HubSpotHttpError.test.ts
+++ b/models/__tests__/HubSpotHttpError.test.ts
@@ -279,9 +279,27 @@ describe('models/HubSpotHttpError', () => {
       hubspotHttpError.extractDerivedContext(newCause);
       expect(hubspotHttpError.derivedContext).toStrictEqual({
         accountId: 888888,
-        payload: '"Yooooooo"',
+        payload: 'Yooooooo',
         request: '/some/different/path',
       });
+    });
+
+    it('should not re-stringify a payload that is already a string', () => {
+      const hubspotHttpError = new HubSpotHttpError();
+      const serializedBody = JSON.stringify({ foo: 'bar', nested: { n: 1 } });
+      const cause = new AxiosError(
+        '',
+        '',
+        // @ts-expect-error test double
+        {
+          params: { portalId: 123 },
+          data: serializedBody,
+          url: '/x',
+        }
+      );
+      // @ts-expect-error private method
+      hubspotHttpError.extractDerivedContext(cause);
+      expect(hubspotHttpError.derivedContext?.payload).toBe(serializedBody);
     });
   });
 


### PR DESCRIPTION
## Description and Context

`extractDerivedContext` at `models/HubSpotHttpError.ts:143` always ran `JSON.stringify(cause.config?.data)` when building the `payload` field. By the time the error is constructed, axios has typically mutated `config.data` to a serialized string (its default `transformRequest` serializes objects before sending). Re-stringifying a string produces:

    "payload": "\"{\\\"name\\\":\\\"qa_personal_sandbox\\\",\\\"type\\\":\\\"DEVELOPER\\\"}\""

This misled past investigation on [hubspot-cli#1593](https://github.com/HubSpot/hubspot-cli/issues/1593) as users suspected a double-JSON-encoding bug in the request body itself, when in fact the wire payload was fine and only the debug display was wrong.

Fix: guard against strings, emit them verbatim.

Test updates:
- Updated the existing `'should update the context from the cause provided'` case (which asserted the old buggy behavior of `'"Yooooooo"'`) to match the new verbatim output.
- Added a new case verifying a serialized JSON string passes through unmodified.

## Screenshots

N/A.

## TODO

None.

## Who to Notify

@brandenrodgers @camden11 @joe-yeager