### PR TITLE
fix: default CMS serverless function runtime to nodejs20.x

### DIFF
--- a/lib/__tests__/functions.test.ts
+++ b/lib/__tests__/functions.test.ts
@@ -151,7 +151,7 @@ describe('lib/cms/functions', () => {
       });
 
       expect(result).toEqual({
-        runtime: 'nodejs18.x',
+        runtime: 'nodejs20.x',
         version: '1.0',
         environment: {},
         secrets: [],

--- a/lib/cms/functions.ts
+++ b/lib/cms/functions.ts
@@ -36,7 +36,7 @@ export function createConfig({
   functionFile,
 }: FunctionConfigInfo): FunctionConfig {
   return {
-    runtime: 'nodejs18.x',
+    runtime: 'nodejs20.x',
     version: '1.0',
     environment: {},
     secrets: [],


### PR DESCRIPTION
## Description and Context

Bumps the hardcoded default runtime in `createConfig` from `nodejs18.x` to `nodejs20.x`. This is the value written to `serverless.json` when a user runs `hs cms create function`.

We keep hardcoding a value (rather than letting the user own it) because the backend requires `runtime` at upload time — dropping it would break every new function scaffolded by `hs cms create function` on first upload. Ideally the backend would make the field optional with a server-side default so we could stop hand-rolling this every deprecation cycle.

- **Node 18 support for CMS serverless functions ended Oct 1, 2025** ([docs](https://developers.hubspot.com/docs/cms/reference/serverless-functions/serverless-functions)).
- Confirmed Node 20 backend support: [CMS-Developer-Infrastructure#1016](https://github.com/HubSpotEngineering/CMS-Developer-Infrastructure/issues/1016).

Surfaced via [hubspot-cli#1543](https://github.com/HubSpot/hubspot-cli/issues/1543). 

## Screenshots

N/A.

## TODO

None.

## Who to Notify
@brandenrodgers @camden11 @joe-yeager 