### PR TITLE
feat: add log buffer + writeBufferedLogsToFile to logger

### DIFF
--- a/lib/LogBuffer.ts
+++ b/lib/LogBuffer.ts
@@ -1,0 +1,117 @@
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_BYTE_LIMIT = 128 * 1024 * 1024;
+const DEFAULT_MAX_LOG_FILES = 3;
+
+export type LogBufferOptions = {
+  byteLimit?: number;
+};
+
+export type WriteBufferedLogsOptions = {
+  dir: string;
+  commandName: string;
+  maxFiles?: number;
+};
+
+function sanitizeFilenamePart(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, '-');
+}
+
+function timestampForFilename(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function rotateLogFiles(dir: string, maxFiles: number): void {
+  const entries = fs
+    .readdirSync(dir)
+    .map(name => {
+      const full = path.join(dir, name);
+      const stat = fs.statSync(full);
+      return { full, mtimeMs: stat.mtimeMs, isFile: stat.isFile() };
+    })
+    .filter(entry => entry.isFile)
+    .sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+  while (entries.length >= maxFiles) {
+    const oldest = entries.shift();
+    if (oldest) {
+      fs.unlinkSync(oldest.full);
+    }
+  }
+}
+
+/**
+ * In-memory ring buffer of log entries with a byte cap. Designed to be
+ * composed into a logger so that recent log output can be flushed to a file
+ * after a failure. Each record is timestamped and tagged with the level the
+ * caller provides.
+ */
+export class LogBuffer {
+  private entries: string[] = [];
+  private bytes = 0;
+  private byteLimit: number;
+
+  constructor(options: LogBufferOptions = {}) {
+    this.byteLimit = options.byteLimit ?? DEFAULT_BYTE_LIMIT;
+  }
+
+  // +1 accounts for the '\n' separator that join('\n') will insert between entries.
+  private static entrySize(entry: string): number {
+    return Buffer.byteLength(entry, 'utf8') + 1;
+  }
+
+  // Drop oldest entries until under the cap. Always retains at least the most
+  // recent entry so a single oversized message is still captured.
+  private trimToByteLimit(): void {
+    while (this.bytes > this.byteLimit && this.entries.length > 1) {
+      const removed = this.entries.shift() as string;
+      this.bytes -= LogBuffer.entrySize(removed);
+    }
+  }
+
+  record(level: string, args: unknown[]): void {
+    const message = args.map(arg => String(arg)).join(' ');
+    const entry = `[${new Date().toISOString()}] [${level}] ${message}`;
+    this.entries.push(entry);
+    this.bytes += LogBuffer.entrySize(entry);
+    this.trimToByteLimit();
+  }
+
+  view(): string {
+    return this.entries.join('\n');
+  }
+
+  flush(): string {
+    const out = this.entries.join('\n');
+    this.entries.length = 0;
+    this.bytes = 0;
+    return out;
+  }
+
+  setByteLimit(bytes: number): void {
+    this.byteLimit = bytes;
+    this.trimToByteLimit();
+  }
+
+  // Flush the buffer to a rotating log file. Always clears the buffer (even
+  // on write failure). Returns the written file path on success, or null if
+  // the buffer was empty or the write failed.
+  writeToFile(options: WriteBufferedLogsOptions): string | null {
+    const { dir, commandName, maxFiles = DEFAULT_MAX_LOG_FILES } = options;
+    const contents = this.flush();
+    if (!contents) {
+      return null;
+    }
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      rotateLogFiles(dir, maxFiles);
+      const filename = `${sanitizeFilenamePart(commandName)}-${timestampForFilename()}.log`;
+      const filePath = path.join(dir, filename);
+      fs.writeFileSync(filePath, contents, 'utf8');
+      return filePath;
+    } catch (_e) {
+      return null;
+    }
+  }
+}

--- a/lib/LogBuffer.ts
+++ b/lib/LogBuffer.ts
@@ -19,7 +19,11 @@ function sanitizeFilenamePart(name: string): string {
 }
 
 function timestampForFilename(): string {
-  return new Date().toISOString().replace(/[:.]/g, '-');
+  const d = new Date();
+  const pad = (n: number, w = 2) => String(n).padStart(w, '0');
+  const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  const time = `${pad(d.getHours())}-${pad(d.getMinutes())}-${pad(d.getSeconds())}`;
+  return `${date}T${time}-${pad(d.getMilliseconds(), 3)}`;
 }
 
 function rotateLogFiles(dir: string, maxFiles: number): void {

--- a/lib/LogBuffer.ts
+++ b/lib/LogBuffer.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
+// 128 MiB
 const DEFAULT_BYTE_LIMIT = 128 * 1024 * 1024;
 const DEFAULT_MAX_LOG_FILES = 3;
 

--- a/lib/LogBuffer.ts
+++ b/lib/LogBuffer.ts
@@ -10,7 +10,7 @@ export type LogBufferOptions = {
 
 export type WriteBufferedLogsOptions = {
   dir: string;
-  commandName: string;
+  filenamePrefix: string;
   maxFiles?: number;
 };
 
@@ -98,7 +98,7 @@ export class LogBuffer {
   // on write failure). Returns the written file path on success, or null if
   // the buffer was empty or the write failed.
   writeToFile(options: WriteBufferedLogsOptions): string | null {
-    const { dir, commandName, maxFiles = DEFAULT_MAX_LOG_FILES } = options;
+    const { dir, filenamePrefix, maxFiles = DEFAULT_MAX_LOG_FILES } = options;
     const contents = this.flush();
     if (!contents) {
       return null;
@@ -106,7 +106,7 @@ export class LogBuffer {
     try {
       fs.mkdirSync(dir, { recursive: true });
       rotateLogFiles(dir, maxFiles);
-      const filename = `${sanitizeFilenamePart(commandName)}-${timestampForFilename()}.log`;
+      const filename = `${sanitizeFilenamePart(filenamePrefix)}-${timestampForFilename()}.log`;
       const filePath = path.join(dir, filename);
       fs.writeFileSync(filePath, contents, 'utf8');
       return filePath;

--- a/lib/LogBuffer.ts
+++ b/lib/LogBuffer.ts
@@ -89,11 +89,6 @@ export class LogBuffer {
     return out;
   }
 
-  setByteLimit(bytes: number): void {
-    this.byteLimit = bytes;
-    this.trimToByteLimit();
-  }
-
   // Flush the buffer to a rotating log file. Always clears the buffer (even
   // on write failure). Returns the written file path on success, or null if
   // the buffer was empty or the write failed.

--- a/lib/__tests__/LogBuffer.test.ts
+++ b/lib/__tests__/LogBuffer.test.ts
@@ -72,18 +72,6 @@ describe('lib/LogBuffer', () => {
       expect(buf.view()).toContain('huge'.repeat(50));
     });
 
-    it('lowering the limit drops entries already in the buffer', () => {
-      const buf = new LogBuffer({ byteLimit: 10000 });
-      for (let i = 0; i < 5; i++) {
-        buf.record('LOG', ['X'.repeat(200)]);
-      }
-      const before = buf.view().split('\n').length;
-      expect(before).toBe(5);
-
-      buf.setByteLimit(500);
-      expect(buf.view().split('\n').length).toBeLessThan(before);
-    });
-
     it('flush resets the byte counter so the cap applies fresh', () => {
       const buf = new LogBuffer({ byteLimit: 400 });
       buf.record('LOG', ['X'.repeat(120)]);

--- a/lib/__tests__/LogBuffer.test.ts
+++ b/lib/__tests__/LogBuffer.test.ts
@@ -1,0 +1,172 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { vi } from 'vitest';
+import { LogBuffer } from '../LogBuffer.js';
+
+describe('lib/LogBuffer', () => {
+  describe('record / view / flush', () => {
+    it('captures recorded entries with the given level label', () => {
+      const buf = new LogBuffer();
+      buf.record('LOG', ['hello']);
+      buf.record('ERROR', ['boom']);
+
+      const viewed = buf.view();
+      expect(viewed).toContain('[LOG] hello');
+      expect(viewed).toContain('[ERROR] boom');
+    });
+
+    it('view is non-destructive', () => {
+      const buf = new LogBuffer();
+      buf.record('LOG', ['first']);
+      buf.record('LOG', ['second']);
+      expect(buf.view().split('\n')).toHaveLength(2);
+      expect(buf.view().split('\n')).toHaveLength(2);
+    });
+
+    it('flush returns the joined contents and clears the buffer', () => {
+      const buf = new LogBuffer();
+      buf.record('LOG', ['alpha']);
+      buf.record('LOG', ['beta']);
+
+      const flushed = buf.flush();
+      expect(flushed).toContain('alpha');
+      expect(flushed).toContain('beta');
+      expect(buf.view()).toBe('');
+      expect(buf.flush()).toBe('');
+    });
+
+    it('prefixes entries with an ISO timestamp', () => {
+      const buf = new LogBuffer();
+      buf.record('LOG', ['timed']);
+      expect(buf.view()).toMatch(
+        /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[LOG\] timed$/
+      );
+    });
+
+    it('joins multiple args with spaces', () => {
+      const buf = new LogBuffer();
+      buf.record('LOG', ['hello', 'world', 42]);
+      expect(buf.view()).toContain('[LOG] hello world 42');
+    });
+  });
+
+  describe('byte-limited buffer', () => {
+    it('drops oldest entries once the buffer exceeds the byte limit', () => {
+      const buf = new LogBuffer({ byteLimit: 300 });
+      buf.record('LOG', ['A'.repeat(80)]);
+      buf.record('LOG', ['B'.repeat(80)]);
+      buf.record('LOG', ['C'.repeat(80)]);
+
+      const viewed = buf.view();
+      expect(viewed).not.toContain('A'.repeat(80));
+      expect(viewed).toContain('B'.repeat(80));
+      expect(viewed).toContain('C'.repeat(80));
+    });
+
+    it('retains the most recent entry even if it alone exceeds the limit', () => {
+      const buf = new LogBuffer({ byteLimit: 200 });
+      buf.record('LOG', ['A'.repeat(60)]);
+      buf.record('LOG', ['huge'.repeat(50)]);
+
+      expect(buf.view()).toContain('huge'.repeat(50));
+    });
+
+    it('lowering the limit drops entries already in the buffer', () => {
+      const buf = new LogBuffer({ byteLimit: 10000 });
+      for (let i = 0; i < 5; i++) {
+        buf.record('LOG', ['X'.repeat(200)]);
+      }
+      const before = buf.view().split('\n').length;
+      expect(before).toBe(5);
+
+      buf.setByteLimit(500);
+      expect(buf.view().split('\n').length).toBeLessThan(before);
+    });
+
+    it('flush resets the byte counter so the cap applies fresh', () => {
+      const buf = new LogBuffer({ byteLimit: 400 });
+      buf.record('LOG', ['X'.repeat(120)]);
+      buf.record('LOG', ['Y'.repeat(120)]);
+      buf.flush();
+
+      buf.record('LOG', ['Z'.repeat(120)]);
+      buf.record('LOG', ['W'.repeat(120)]);
+
+      const viewed = buf.view();
+      expect(viewed).toContain('Z'.repeat(120));
+      expect(viewed).toContain('W'.repeat(120));
+    });
+  });
+
+  describe('writeToFile()', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'logbuffer-test-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns null and does not write when the buffer is empty', () => {
+      const buf = new LogBuffer();
+      const result = buf.writeToFile({ dir: tmpDir, commandName: 'test' });
+      expect(result).toBeNull();
+      expect(fs.readdirSync(tmpDir)).toHaveLength(0);
+    });
+
+    it('creates the directory and writes a sanitized filename', () => {
+      const buf = new LogBuffer();
+      buf.record('LOG', ['captured']);
+
+      const dir = path.join(tmpDir, 'logs');
+      const filePath = buf.writeToFile({ dir, commandName: 'account list' });
+
+      expect(filePath).not.toBeNull();
+      expect(fs.existsSync(dir)).toBe(true);
+      const filename = path.basename(filePath as string);
+      expect(filename.startsWith('account-list-')).toBe(true);
+      expect(filename.endsWith('.log')).toBe(true);
+      expect(fs.readFileSync(filePath as string, 'utf8')).toContain(
+        '[LOG] captured'
+      );
+    });
+
+    it('always clears the buffer regardless of write success', () => {
+      const buf = new LogBuffer();
+      buf.record('LOG', ['captured']);
+      const writeSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+        throw new Error('disk full');
+      });
+
+      const result = buf.writeToFile({ dir: tmpDir, commandName: 'cmd' });
+      expect(result).toBeNull();
+      expect(buf.view()).toBe('');
+      writeSpy.mockRestore();
+    });
+
+    it('caps the directory at maxFiles by deleting oldest first', () => {
+      const dir = path.join(tmpDir, 'logs');
+      fs.mkdirSync(dir, { recursive: true });
+
+      ['oldest.log', 'middle.log', 'newest.log'].forEach((name, idx) => {
+        const full = path.join(dir, name);
+        fs.writeFileSync(full, name);
+        const t = new Date(2026, 0, idx + 1);
+        fs.utimesSync(full, t, t);
+      });
+
+      const buf = new LogBuffer();
+      buf.record('LOG', ['fresh']);
+      buf.writeToFile({ dir, commandName: 'cmd', maxFiles: 3 });
+
+      const remaining = fs.readdirSync(dir);
+      expect(remaining).toHaveLength(3);
+      expect(remaining).not.toContain('oldest.log');
+      expect(remaining).toContain('middle.log');
+      expect(remaining).toContain('newest.log');
+    });
+  });
+});

--- a/lib/__tests__/LogBuffer.test.ts
+++ b/lib/__tests__/LogBuffer.test.ts
@@ -112,7 +112,7 @@ describe('lib/LogBuffer', () => {
 
     it('returns null and does not write when the buffer is empty', () => {
       const buf = new LogBuffer();
-      const result = buf.writeToFile({ dir: tmpDir, commandName: 'test' });
+      const result = buf.writeToFile({ dir: tmpDir, filenamePrefix: 'test' });
       expect(result).toBeNull();
       expect(fs.readdirSync(tmpDir)).toHaveLength(0);
     });
@@ -122,7 +122,7 @@ describe('lib/LogBuffer', () => {
       buf.record('LOG', ['captured']);
 
       const dir = path.join(tmpDir, 'logs');
-      const filePath = buf.writeToFile({ dir, commandName: 'account list' });
+      const filePath = buf.writeToFile({ dir, filenamePrefix: 'account list' });
 
       expect(filePath).not.toBeNull();
       expect(fs.existsSync(dir)).toBe(true);
@@ -141,7 +141,7 @@ describe('lib/LogBuffer', () => {
         throw new Error('disk full');
       });
 
-      const result = buf.writeToFile({ dir: tmpDir, commandName: 'cmd' });
+      const result = buf.writeToFile({ dir: tmpDir, filenamePrefix: 'cmd' });
       expect(result).toBeNull();
       expect(buf.view()).toBe('');
       writeSpy.mockRestore();
@@ -160,7 +160,7 @@ describe('lib/LogBuffer', () => {
 
       const buf = new LogBuffer();
       buf.record('LOG', ['fresh']);
-      buf.writeToFile({ dir, commandName: 'cmd', maxFiles: 3 });
+      buf.writeToFile({ dir, filenamePrefix: 'cmd', maxFiles: 3 });
 
       const remaining = fs.readdirSync(dir);
       expect(remaining).toHaveLength(3);

--- a/lib/__tests__/LogBuffer.test.ts
+++ b/lib/__tests__/LogBuffer.test.ts
@@ -122,6 +122,33 @@ describe('lib/LogBuffer', () => {
       );
     });
 
+    it('uses local time in the filename timestamp', () => {
+      const buf = new LogBuffer();
+      buf.record('LOG', ['captured']);
+
+      const before = new Date();
+      const filePath = buf.writeToFile({ dir: tmpDir, filenamePrefix: 'cmd' });
+      const after = new Date();
+      const pad = (n: number, w = 2) => String(n).padStart(w, '0');
+      const filename = path.basename(filePath as string);
+
+      // Filename is `cmd-<YYYY>-<MM>-<DD>T<HH>-<MM>-<SS>-<MS>.log` in local time.
+      const m = filename.match(
+        /^cmd-(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})\.log$/
+      );
+      expect(m).not.toBeNull();
+      const [, year, month, day, hours] = m as RegExpMatchArray;
+      const localYear = String(before.getFullYear());
+      const localMonth = pad(before.getMonth() + 1);
+      const localDay = pad(before.getDate());
+      const localHour = pad(before.getHours());
+      const altLocalHour = pad(after.getHours());
+      expect(year).toBe(localYear);
+      expect(month).toBe(localMonth);
+      expect(day).toBe(localDay);
+      expect([localHour, altLocalHour]).toContain(hours);
+    });
+
     it('always clears the buffer regardless of write success', () => {
       const buf = new LogBuffer();
       buf.record('LOG', ['captured']);

--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -257,7 +257,7 @@ describe('lib/logger', () => {
   });
   describe('buffer', () => {
     beforeEach(() => {
-      logger.flushBuffer();
+      logger.flushLogBuffer();
       vi.spyOn(console, 'log').mockImplementation(() => null);
       vi.spyOn(console, 'warn').mockImplementation(() => null);
       vi.spyOn(console, 'info').mockImplementation(() => null);
@@ -277,7 +277,7 @@ describe('lib/logger', () => {
       logger.debug('a-debug');
       logger.group('a-group');
 
-      const buffered = logger.viewBuffer();
+      const buffered = logger.viewLogBuffer();
 
       expect(buffered).toContain('[LOG] a-log');
       expect(buffered).toContain('[ERROR] a-error');
@@ -294,36 +294,36 @@ describe('lib/logger', () => {
       logger.debug('hidden-from-console');
       logger.info('also-hidden');
 
-      const buffered = logger.viewBuffer();
+      const buffered = logger.viewLogBuffer();
 
       expect(buffered).toContain('[DEBUG] hidden-from-console');
       expect(buffered).toContain('[INFO] also-hidden');
     });
 
-    it('viewBuffer returns the joined buffer without clearing it', () => {
+    it('viewLogBuffer returns the joined buffer without clearing it', () => {
       logger.info('first');
       logger.info('second');
 
-      expect(logger.viewBuffer()).toContain('first');
-      expect(logger.viewBuffer()).toContain('second');
-      expect(logger.viewBuffer().split('\n')).toHaveLength(2);
+      expect(logger.viewLogBuffer()).toContain('first');
+      expect(logger.viewLogBuffer()).toContain('second');
+      expect(logger.viewLogBuffer().split('\n')).toHaveLength(2);
     });
 
-    it('flushBuffer returns and clears', () => {
+    it('flushLogBuffer returns and clears', () => {
       logger.info('first');
       logger.info('second');
 
-      const flushed = logger.flushBuffer();
+      const flushed = logger.flushLogBuffer();
       expect(flushed).toContain('first');
       expect(flushed).toContain('second');
 
-      expect(logger.viewBuffer()).toBe('');
-      expect(logger.flushBuffer()).toBe('');
+      expect(logger.viewLogBuffer()).toBe('');
+      expect(logger.flushLogBuffer()).toBe('');
     });
 
     it('prefixes entries with an ISO timestamp', () => {
       logger.info('timed');
-      const buffered = logger.viewBuffer();
+      const buffered = logger.viewLogBuffer();
       expect(buffered).toMatch(
         /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[INFO\] timed$/
       );
@@ -331,7 +331,7 @@ describe('lib/logger', () => {
 
     it('joins multiple args into a single message', () => {
       logger.info('hello', 'world', 42);
-      const buffered = logger.viewBuffer();
+      const buffered = logger.viewLogBuffer();
       expect(buffered).toContain('[INFO] hello world 42');
     });
   });
@@ -340,7 +340,7 @@ describe('lib/logger', () => {
     let tmpDir: string;
 
     beforeEach(() => {
-      logger.flushBuffer();
+      logger.flushLogBuffer();
       tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ldl-logger-test-'));
       vi.spyOn(console, 'log').mockImplementation(() => null);
       vi.spyOn(console, 'info').mockImplementation(() => null);
@@ -386,7 +386,7 @@ describe('lib/logger', () => {
         dir: path.join(tmpDir, 'logs'),
         commandName: 'cmd',
       });
-      expect(logger.viewBuffer()).toBe('');
+      expect(logger.viewLogBuffer()).toBe('');
     });
 
     it('clears the buffer when the write fails', () => {
@@ -401,7 +401,7 @@ describe('lib/logger', () => {
       });
 
       expect(result).toBeNull();
-      expect(logger.viewBuffer()).toBe('');
+      expect(logger.viewLogBuffer()).toBe('');
       writeSpy.mockRestore();
     });
 
@@ -457,7 +457,7 @@ describe('lib/logger', () => {
 
   describe('byte-limited buffer', () => {
     beforeEach(() => {
-      logger.flushBuffer();
+      logger.flushLogBuffer();
       setLogBufferByteLimit(1024);
       vi.spyOn(console, 'log').mockImplementation(() => null);
       vi.spyOn(console, 'info').mockImplementation(() => null);
@@ -474,7 +474,7 @@ describe('lib/logger', () => {
       logger.log('B'.repeat(80));
       logger.log('C'.repeat(80));
 
-      const buffered = logger.viewBuffer();
+      const buffered = logger.viewLogBuffer();
 
       expect(buffered).not.toContain('A'.repeat(80));
       expect(buffered).toContain('B'.repeat(80));
@@ -489,7 +489,7 @@ describe('lib/logger', () => {
       logger.log('D'.repeat(60));
       logger.log('huge'.repeat(50));
 
-      const buffered = logger.viewBuffer();
+      const buffered = logger.viewLogBuffer();
       expect(buffered).not.toContain('A'.repeat(60));
       expect(buffered).not.toContain('B'.repeat(60));
       expect(buffered).toContain('huge'.repeat(50));
@@ -500,25 +500,25 @@ describe('lib/logger', () => {
       for (let i = 0; i < 5; i++) {
         logger.log('X'.repeat(200));
       }
-      const before = logger.viewBuffer().split('\n').length;
+      const before = logger.viewLogBuffer().split('\n').length;
       expect(before).toBe(5);
 
       setLogBufferByteLimit(500);
 
-      const after = logger.viewBuffer().split('\n').length;
+      const after = logger.viewLogBuffer().split('\n').length;
       expect(after).toBeLessThan(before);
     });
 
-    it('flushBuffer resets the byte counter so the cap applies fresh after flush', () => {
+    it('flushLogBuffer resets the byte counter so the cap applies fresh after flush', () => {
       setLogBufferByteLimit(400);
       logger.log('X'.repeat(120));
       logger.log('Y'.repeat(120));
-      expect(logger.flushBuffer()).not.toBe('');
+      expect(logger.flushLogBuffer()).not.toBe('');
 
       logger.log('Z'.repeat(120));
       logger.log('W'.repeat(120));
 
-      const buffered = logger.viewBuffer();
+      const buffered = logger.viewLogBuffer();
       expect(buffered).toContain('Z'.repeat(120));
       expect(buffered).toContain('W'.repeat(120));
     });

--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import chalk from 'chalk';
 import { vi, MockInstance } from 'vitest';
 import {
@@ -249,6 +252,205 @@ describe('lib/logger', () => {
       logger.groupEnd();
       expect(groupSpy).toHaveBeenCalled();
       expect(groupEndSpy).toHaveBeenCalled();
+    });
+  });
+  describe('buffer', () => {
+    beforeEach(() => {
+      logger.flushBuffer();
+      vi.spyOn(console, 'log').mockImplementation(() => null);
+      vi.spyOn(console, 'warn').mockImplementation(() => null);
+      vi.spyOn(console, 'info').mockImplementation(() => null);
+      vi.spyOn(console, 'error').mockImplementation(() => null);
+      vi.spyOn(console, 'debug').mockImplementation(() => null);
+      vi.spyOn(console, 'group').mockImplementation(() => null);
+    });
+
+    it('captures messages from every level into the buffer', () => {
+      setLogLevel(LOG_LEVEL.DEBUG);
+
+      logger.log('a-log');
+      logger.error('a-error');
+      logger.warn('a-warn');
+      logger.success('a-success');
+      logger.info('a-info');
+      logger.debug('a-debug');
+      logger.group('a-group');
+
+      const buffered = logger.viewBuffer();
+
+      expect(buffered).toContain('[LOG] a-log');
+      expect(buffered).toContain('[ERROR] a-error');
+      expect(buffered).toContain('[WARN] a-warn');
+      expect(buffered).toContain('[SUCCESS] a-success');
+      expect(buffered).toContain('[INFO] a-info');
+      expect(buffered).toContain('[DEBUG] a-debug');
+      expect(buffered).toContain('[GROUP] a-group');
+    });
+
+    it('captures messages even when the log level filters them out', () => {
+      setLogLevel(LOG_LEVEL.ERROR);
+
+      logger.debug('hidden-from-console');
+      logger.info('also-hidden');
+
+      const buffered = logger.viewBuffer();
+
+      expect(buffered).toContain('[DEBUG] hidden-from-console');
+      expect(buffered).toContain('[INFO] also-hidden');
+    });
+
+    it('viewBuffer returns the joined buffer without clearing it', () => {
+      logger.info('first');
+      logger.info('second');
+
+      expect(logger.viewBuffer()).toContain('first');
+      expect(logger.viewBuffer()).toContain('second');
+      expect(logger.viewBuffer().split('\n')).toHaveLength(2);
+    });
+
+    it('flushBuffer returns and clears', () => {
+      logger.info('first');
+      logger.info('second');
+
+      const flushed = logger.flushBuffer();
+      expect(flushed).toContain('first');
+      expect(flushed).toContain('second');
+
+      expect(logger.viewBuffer()).toBe('');
+      expect(logger.flushBuffer()).toBe('');
+    });
+
+    it('prefixes entries with an ISO timestamp', () => {
+      logger.info('timed');
+      const buffered = logger.viewBuffer();
+      expect(buffered).toMatch(
+        /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[INFO\] timed$/
+      );
+    });
+
+    it('joins multiple args into a single message', () => {
+      logger.info('hello', 'world', 42);
+      const buffered = logger.viewBuffer();
+      expect(buffered).toContain('[INFO] hello world 42');
+    });
+  });
+
+  describe('writeBufferedLogsToFile()', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      logger.flushBuffer();
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ldl-logger-test-'));
+      vi.spyOn(console, 'log').mockImplementation(() => null);
+      vi.spyOn(console, 'info').mockImplementation(() => null);
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns null and does not write a file when the buffer is empty', () => {
+      const dir = path.join(tmpDir, 'logs');
+      const result = logger.writeBufferedLogsToFile({
+        dir,
+        commandName: 'test',
+      });
+
+      expect(result).toBeNull();
+      expect(fs.existsSync(dir)).toBe(false);
+    });
+
+    it('creates the directory and writes the buffer to a sanitized filename', () => {
+      logger.info('captured');
+      const dir = path.join(tmpDir, 'logs');
+
+      const filePath = logger.writeBufferedLogsToFile({
+        dir,
+        commandName: 'account list',
+      });
+
+      expect(filePath).not.toBeNull();
+      expect(fs.existsSync(dir)).toBe(true);
+      const filename = path.basename(filePath as string);
+      expect(filename.startsWith('account-list-')).toBe(true);
+      expect(filename.endsWith('.log')).toBe(true);
+      expect(fs.readFileSync(filePath as string, 'utf8')).toContain(
+        '[INFO] captured'
+      );
+    });
+
+    it('clears the buffer regardless of whether the write succeeded', () => {
+      logger.info('captured');
+      logger.writeBufferedLogsToFile({
+        dir: path.join(tmpDir, 'logs'),
+        commandName: 'cmd',
+      });
+      expect(logger.viewBuffer()).toBe('');
+    });
+
+    it('clears the buffer when the write fails', () => {
+      logger.info('captured');
+      const writeSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+        throw new Error('disk full');
+      });
+
+      const result = logger.writeBufferedLogsToFile({
+        dir: path.join(tmpDir, 'logs'),
+        commandName: 'cmd',
+      });
+
+      expect(result).toBeNull();
+      expect(logger.viewBuffer()).toBe('');
+      writeSpy.mockRestore();
+    });
+
+    it('rotates files so the directory holds at most maxFiles after writing', () => {
+      const dir = path.join(tmpDir, 'logs');
+      fs.mkdirSync(dir, { recursive: true });
+
+      ['oldest.log', 'middle.log', 'newest.log'].forEach((name, idx) => {
+        const full = path.join(dir, name);
+        fs.writeFileSync(full, name);
+        const t = new Date(2026, 0, idx + 1);
+        fs.utimesSync(full, t, t);
+      });
+
+      logger.info('fresh');
+      logger.writeBufferedLogsToFile({
+        dir,
+        commandName: 'command',
+        maxFiles: 3,
+      });
+
+      const remaining = fs.readdirSync(dir);
+      expect(remaining).toHaveLength(3);
+      expect(remaining).not.toContain('oldest.log');
+      expect(remaining).toContain('middle.log');
+      expect(remaining).toContain('newest.log');
+    });
+
+    it('honors a custom maxFiles', () => {
+      const dir = path.join(tmpDir, 'logs');
+      fs.mkdirSync(dir, { recursive: true });
+
+      ['a.log', 'b.log'].forEach((name, idx) => {
+        const full = path.join(dir, name);
+        fs.writeFileSync(full, name);
+        const t = new Date(2026, 0, idx + 1);
+        fs.utimesSync(full, t, t);
+      });
+
+      logger.info('fresh');
+      logger.writeBufferedLogsToFile({
+        dir,
+        commandName: 'command',
+        maxFiles: 2,
+      });
+
+      const remaining = fs.readdirSync(dir);
+      expect(remaining).toHaveLength(2);
+      expect(remaining).not.toContain('a.log');
+      expect(remaining).toContain('b.log');
     });
   });
 });

--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -13,6 +13,7 @@ import {
   shouldLog,
   getLabels,
   getSymbols,
+  setLogBufferByteLimit,
 } from '../logger.js';
 import { isUnicodeSupported } from '../isUnicodeSupported.js';
 
@@ -451,6 +452,75 @@ describe('lib/logger', () => {
       expect(remaining).toHaveLength(2);
       expect(remaining).not.toContain('a.log');
       expect(remaining).toContain('b.log');
+    });
+  });
+
+  describe('byte-limited buffer', () => {
+    beforeEach(() => {
+      logger.flushBuffer();
+      setLogBufferByteLimit(1024);
+      vi.spyOn(console, 'log').mockImplementation(() => null);
+      vi.spyOn(console, 'info').mockImplementation(() => null);
+      vi.spyOn(console, 'debug').mockImplementation(() => null);
+    });
+
+    afterEach(() => {
+      setLogBufferByteLimit(128 * 1024 * 1024);
+    });
+
+    it('drops oldest entries once the buffer exceeds the byte limit', () => {
+      setLogBufferByteLimit(300);
+      logger.log('A'.repeat(80));
+      logger.log('B'.repeat(80));
+      logger.log('C'.repeat(80));
+
+      const buffered = logger.viewBuffer();
+
+      expect(buffered).not.toContain('A'.repeat(80));
+      expect(buffered).toContain('B'.repeat(80));
+      expect(buffered).toContain('C'.repeat(80));
+    });
+
+    it('drops multiple oldest entries when a single push pushes well past the limit', () => {
+      setLogBufferByteLimit(200);
+      logger.log('A'.repeat(60));
+      logger.log('B'.repeat(60));
+      logger.log('C'.repeat(60));
+      logger.log('D'.repeat(60));
+      logger.log('huge'.repeat(50));
+
+      const buffered = logger.viewBuffer();
+      expect(buffered).not.toContain('A'.repeat(60));
+      expect(buffered).not.toContain('B'.repeat(60));
+      expect(buffered).toContain('huge'.repeat(50));
+    });
+
+    it('lowering the limit drops entries already in the buffer', () => {
+      setLogBufferByteLimit(10000);
+      for (let i = 0; i < 5; i++) {
+        logger.log('X'.repeat(200));
+      }
+      const before = logger.viewBuffer().split('\n').length;
+      expect(before).toBe(5);
+
+      setLogBufferByteLimit(500);
+
+      const after = logger.viewBuffer().split('\n').length;
+      expect(after).toBeLessThan(before);
+    });
+
+    it('flushBuffer resets the byte counter so the cap applies fresh after flush', () => {
+      setLogBufferByteLimit(400);
+      logger.log('X'.repeat(120));
+      logger.log('Y'.repeat(120));
+      expect(logger.flushBuffer()).not.toBe('');
+
+      logger.log('Z'.repeat(120));
+      logger.log('W'.repeat(120));
+
+      const buffered = logger.viewBuffer();
+      expect(buffered).toContain('Z'.repeat(120));
+      expect(buffered).toContain('W'.repeat(120));
     });
   });
 });

--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -354,7 +354,7 @@ describe('lib/logger', () => {
       const dir = path.join(tmpDir, 'logs');
       const result = logger.writeBufferedLogsToFile({
         dir,
-        commandName: 'test',
+        filenamePrefix: 'test',
       });
 
       expect(result).toBeNull();
@@ -367,7 +367,7 @@ describe('lib/logger', () => {
 
       const filePath = logger.writeBufferedLogsToFile({
         dir,
-        commandName: 'account list',
+        filenamePrefix: 'account list',
       });
 
       expect(filePath).not.toBeNull();
@@ -384,7 +384,7 @@ describe('lib/logger', () => {
       logger.info('captured');
       logger.writeBufferedLogsToFile({
         dir: path.join(tmpDir, 'logs'),
-        commandName: 'cmd',
+        filenamePrefix: 'cmd',
       });
       expect(logger.viewLogBuffer()).toBe('');
     });
@@ -397,7 +397,7 @@ describe('lib/logger', () => {
 
       const result = logger.writeBufferedLogsToFile({
         dir: path.join(tmpDir, 'logs'),
-        commandName: 'cmd',
+        filenamePrefix: 'cmd',
       });
 
       expect(result).toBeNull();
@@ -419,7 +419,7 @@ describe('lib/logger', () => {
       logger.info('fresh');
       logger.writeBufferedLogsToFile({
         dir,
-        commandName: 'command',
+        filenamePrefix: 'command',
         maxFiles: 3,
       });
 
@@ -444,7 +444,7 @@ describe('lib/logger', () => {
       logger.info('fresh');
       logger.writeBufferedLogsToFile({
         dir,
-        commandName: 'command',
+        filenamePrefix: 'command',
         maxFiles: 2,
       });
 

--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -13,7 +13,6 @@ import {
   shouldLog,
   getLabels,
   getSymbols,
-  setLogBufferByteLimit,
 } from '../logger.js';
 import { isUnicodeSupported } from '../isUnicodeSupported.js';
 
@@ -452,75 +451,6 @@ describe('lib/logger', () => {
       expect(remaining).toHaveLength(2);
       expect(remaining).not.toContain('a.log');
       expect(remaining).toContain('b.log');
-    });
-  });
-
-  describe('byte-limited buffer', () => {
-    beforeEach(() => {
-      logger.flushLogBuffer();
-      setLogBufferByteLimit(1024);
-      vi.spyOn(console, 'log').mockImplementation(() => null);
-      vi.spyOn(console, 'info').mockImplementation(() => null);
-      vi.spyOn(console, 'debug').mockImplementation(() => null);
-    });
-
-    afterEach(() => {
-      setLogBufferByteLimit(128 * 1024 * 1024);
-    });
-
-    it('drops oldest entries once the buffer exceeds the byte limit', () => {
-      setLogBufferByteLimit(300);
-      logger.log('A'.repeat(80));
-      logger.log('B'.repeat(80));
-      logger.log('C'.repeat(80));
-
-      const buffered = logger.viewLogBuffer();
-
-      expect(buffered).not.toContain('A'.repeat(80));
-      expect(buffered).toContain('B'.repeat(80));
-      expect(buffered).toContain('C'.repeat(80));
-    });
-
-    it('drops multiple oldest entries when a single push pushes well past the limit', () => {
-      setLogBufferByteLimit(200);
-      logger.log('A'.repeat(60));
-      logger.log('B'.repeat(60));
-      logger.log('C'.repeat(60));
-      logger.log('D'.repeat(60));
-      logger.log('huge'.repeat(50));
-
-      const buffered = logger.viewLogBuffer();
-      expect(buffered).not.toContain('A'.repeat(60));
-      expect(buffered).not.toContain('B'.repeat(60));
-      expect(buffered).toContain('huge'.repeat(50));
-    });
-
-    it('lowering the limit drops entries already in the buffer', () => {
-      setLogBufferByteLimit(10000);
-      for (let i = 0; i < 5; i++) {
-        logger.log('X'.repeat(200));
-      }
-      const before = logger.viewLogBuffer().split('\n').length;
-      expect(before).toBe(5);
-
-      setLogBufferByteLimit(500);
-
-      const after = logger.viewLogBuffer().split('\n').length;
-      expect(after).toBeLessThan(before);
-    });
-
-    it('flushLogBuffer resets the byte counter so the cap applies fresh after flush', () => {
-      setLogBufferByteLimit(400);
-      logger.log('X'.repeat(120));
-      logger.log('Y'.repeat(120));
-      expect(logger.flushLogBuffer()).not.toBe('');
-
-      logger.log('Z'.repeat(120));
-      logger.log('W'.repeat(120));
-
-      const buffered = logger.viewLogBuffer();
-      expect(buffered).toContain('Z'.repeat(120));
-      expect(buffered).toContain('W'.repeat(120));
     });
   });
 });

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import fs from 'fs';
+import path from 'path';
 import chalk, { type ChalkInstance } from 'chalk';
 import { isUnicodeSupported } from './isUnicodeSupported.js';
+
+const DEFAULT_MAX_LOG_FILES = 3;
 
 export const LOG_LEVEL = {
   NONE: 0,
@@ -151,41 +155,113 @@ export function getLogLevel(): number {
   }
 }
 
+const logBuffer: string[] = [];
+
+function recordToBuffer(level: string, args: any[]): void {
+  const message = args.map(arg => String(arg)).join(' ');
+  logBuffer.push(`[${new Date().toISOString()}] [${level}] ${message}`);
+}
+
+function sanitizeFilenamePart(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, '-');
+}
+
+function timestampForFilename(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function rotateLogFiles(dir: string, maxFiles: number): void {
+  const entries = fs
+    .readdirSync(dir)
+    .map(name => {
+      const full = path.join(dir, name);
+      const stat = fs.statSync(full);
+      return { full, mtimeMs: stat.mtimeMs, isFile: stat.isFile() };
+    })
+    .filter(entry => entry.isFile)
+    .sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+  while (entries.length >= maxFiles) {
+    const oldest = entries.shift();
+    if (oldest) {
+      fs.unlinkSync(oldest.full);
+    }
+  }
+}
+
+export type WriteBufferedLogsOptions = {
+  dir: string;
+  commandName: string;
+  maxFiles?: number;
+};
+
 export const logger = {
   error(...args: any[]) {
+    recordToBuffer('ERROR', args);
     if (shouldLog(LOG_LEVEL.ERROR)) {
       currentLogger.error(...args);
     }
   },
   warn(...args: any[]) {
+    recordToBuffer('WARN', args);
     if (shouldLog(LOG_LEVEL.WARN)) {
       currentLogger.warn(...args);
     }
   },
   log(...args: any[]) {
+    recordToBuffer('LOG', args);
     if (shouldLog(LOG_LEVEL.LOG)) {
       currentLogger.log(...args);
     }
   },
   success(...args: any[]) {
+    recordToBuffer('SUCCESS', args);
     if (shouldLog(LOG_LEVEL.LOG)) {
       currentLogger.success(...args);
     }
   },
   info(...args: any[]) {
+    recordToBuffer('INFO', args);
     if (shouldLog(LOG_LEVEL.LOG)) {
       currentLogger.info(...args);
     }
   },
   debug(...args: any[]) {
+    recordToBuffer('DEBUG', args);
     if (shouldLog(LOG_LEVEL.DEBUG)) {
       currentLogger.debug(...args);
     }
   },
   group(...args: any[]) {
+    recordToBuffer('GROUP', args);
     currentLogger.group(...args);
   },
   groupEnd() {
     currentLogger.groupEnd();
+  },
+  viewBuffer(): string {
+    return logBuffer.join('\n');
+  },
+  flushBuffer(): string {
+    const out = logBuffer.join('\n');
+    logBuffer.length = 0;
+    return out;
+  },
+  writeBufferedLogsToFile(options: WriteBufferedLogsOptions): string | null {
+    const { dir, commandName, maxFiles = DEFAULT_MAX_LOG_FILES } = options;
+    const contents = this.flushBuffer();
+    if (!contents) {
+      return null;
+    }
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      rotateLogFiles(dir, maxFiles);
+      const filename = `${sanitizeFilenamePart(commandName)}-${timestampForFilename()}.log`;
+      const filePath = path.join(dir, filename);
+      fs.writeFileSync(filePath, contents, 'utf8');
+      return filePath;
+    } catch (_e) {
+      return null;
+    }
   },
 };

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import fs from 'fs';
-import path from 'path';
 import chalk, { type ChalkInstance } from 'chalk';
 import { isUnicodeSupported } from './isUnicodeSupported.js';
+import { LogBuffer, WriteBufferedLogsOptions } from './LogBuffer.js';
 
-const DEFAULT_MAX_LOG_FILES = 3;
+export type { WriteBufferedLogsOptions };
 
 export const LOG_LEVEL = {
   NONE: 0,
@@ -155,138 +154,63 @@ export function getLogLevel(): number {
   }
 }
 
-const DEFAULT_LOG_BUFFER_BYTE_LIMIT = 128 * 1024 * 1024;
-
-const logBuffer: string[] = [];
-let logBufferBytes = 0;
-let logBufferByteLimit = DEFAULT_LOG_BUFFER_BYTE_LIMIT;
-
-function entrySize(entry: string): number {
-  return Buffer.byteLength(entry, 'utf8') + 1;
-}
-
-function trimBufferToByteLimit(): void {
-  // Keep at least one entry so a single large message is still captured.
-  while (logBufferBytes > logBufferByteLimit && logBuffer.length > 1) {
-    const removed = logBuffer.shift() as string;
-    logBufferBytes -= entrySize(removed);
-  }
-}
+const _logBuffer = new LogBuffer();
 
 export function setLogBufferByteLimit(bytes: number): void {
-  logBufferByteLimit = bytes;
-  trimBufferToByteLimit();
+  _logBuffer.setByteLimit(bytes);
 }
-
-function recordToBuffer(level: string, args: any[]): void {
-  const message = args.map(arg => String(arg)).join(' ');
-  const entry = `[${new Date().toISOString()}] [${level}] ${message}`;
-  logBuffer.push(entry);
-  logBufferBytes += entrySize(entry);
-  trimBufferToByteLimit();
-}
-
-function sanitizeFilenamePart(name: string): string {
-  return name.replace(/[^a-zA-Z0-9._-]+/g, '-');
-}
-
-function timestampForFilename(): string {
-  return new Date().toISOString().replace(/[:.]/g, '-');
-}
-
-function rotateLogFiles(dir: string, maxFiles: number): void {
-  const entries = fs
-    .readdirSync(dir)
-    .map(name => {
-      const full = path.join(dir, name);
-      const stat = fs.statSync(full);
-      return { full, mtimeMs: stat.mtimeMs, isFile: stat.isFile() };
-    })
-    .filter(entry => entry.isFile)
-    .sort((a, b) => a.mtimeMs - b.mtimeMs);
-
-  while (entries.length >= maxFiles) {
-    const oldest = entries.shift();
-    if (oldest) {
-      fs.unlinkSync(oldest.full);
-    }
-  }
-}
-
-export type WriteBufferedLogsOptions = {
-  dir: string;
-  commandName: string;
-  maxFiles?: number;
-};
 
 export const logger = {
   error(...args: any[]) {
-    recordToBuffer('ERROR', args);
+    _logBuffer.record('ERROR', args);
     if (shouldLog(LOG_LEVEL.ERROR)) {
       currentLogger.error(...args);
     }
   },
   warn(...args: any[]) {
-    recordToBuffer('WARN', args);
+    _logBuffer.record('WARN', args);
     if (shouldLog(LOG_LEVEL.WARN)) {
       currentLogger.warn(...args);
     }
   },
   log(...args: any[]) {
-    recordToBuffer('LOG', args);
+    _logBuffer.record('LOG', args);
     if (shouldLog(LOG_LEVEL.LOG)) {
       currentLogger.log(...args);
     }
   },
   success(...args: any[]) {
-    recordToBuffer('SUCCESS', args);
+    _logBuffer.record('SUCCESS', args);
     if (shouldLog(LOG_LEVEL.LOG)) {
       currentLogger.success(...args);
     }
   },
   info(...args: any[]) {
-    recordToBuffer('INFO', args);
+    _logBuffer.record('INFO', args);
     if (shouldLog(LOG_LEVEL.LOG)) {
       currentLogger.info(...args);
     }
   },
   debug(...args: any[]) {
-    recordToBuffer('DEBUG', args);
+    _logBuffer.record('DEBUG', args);
     if (shouldLog(LOG_LEVEL.DEBUG)) {
       currentLogger.debug(...args);
     }
   },
   group(...args: any[]) {
-    recordToBuffer('GROUP', args);
+    _logBuffer.record('GROUP', args);
     currentLogger.group(...args);
   },
   groupEnd() {
     currentLogger.groupEnd();
   },
   viewLogBuffer(): string {
-    return logBuffer.join('\n');
+    return _logBuffer.view();
   },
   flushLogBuffer(): string {
-    const out = logBuffer.join('\n');
-    logBuffer.length = 0;
-    logBufferBytes = 0;
-    return out;
+    return _logBuffer.flush();
   },
   writeBufferedLogsToFile(options: WriteBufferedLogsOptions): string | null {
-    const { dir, commandName, maxFiles = DEFAULT_MAX_LOG_FILES } = options;
-    const contents = this.flushLogBuffer();
-    if (!contents) {
-      return null;
-    }
-    try {
-      fs.mkdirSync(dir, { recursive: true });
-      rotateLogFiles(dir, maxFiles);
-      const filename = `${sanitizeFilenamePart(commandName)}-${timestampForFilename()}.log`;
-      const filePath = path.join(dir, filename);
-      fs.writeFileSync(filePath, contents, 'utf8');
-      return filePath;
-    } catch (_e) {
-      return null;
-    }
+    return _logBuffer.writeToFile(options);
   },
 };

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -155,11 +155,35 @@ export function getLogLevel(): number {
   }
 }
 
+const DEFAULT_LOG_BUFFER_BYTE_LIMIT = 128 * 1024 * 1024;
+
 const logBuffer: string[] = [];
+let logBufferBytes = 0;
+let logBufferByteLimit = DEFAULT_LOG_BUFFER_BYTE_LIMIT;
+
+function entrySize(entry: string): number {
+  return Buffer.byteLength(entry, 'utf8') + 1;
+}
+
+function trimBufferToByteLimit(): void {
+  // Keep at least one entry so a single large message is still captured.
+  while (logBufferBytes > logBufferByteLimit && logBuffer.length > 1) {
+    const removed = logBuffer.shift() as string;
+    logBufferBytes -= entrySize(removed);
+  }
+}
+
+export function setLogBufferByteLimit(bytes: number): void {
+  logBufferByteLimit = bytes;
+  trimBufferToByteLimit();
+}
 
 function recordToBuffer(level: string, args: any[]): void {
   const message = args.map(arg => String(arg)).join(' ');
-  logBuffer.push(`[${new Date().toISOString()}] [${level}] ${message}`);
+  const entry = `[${new Date().toISOString()}] [${level}] ${message}`;
+  logBuffer.push(entry);
+  logBufferBytes += entrySize(entry);
+  trimBufferToByteLimit();
 }
 
 function sanitizeFilenamePart(name: string): string {
@@ -245,6 +269,7 @@ export const logger = {
   flushBuffer(): string {
     const out = logBuffer.join('\n');
     logBuffer.length = 0;
+    logBufferBytes = 0;
     return out;
   },
   writeBufferedLogsToFile(options: WriteBufferedLogsOptions): string | null {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -263,10 +263,10 @@ export const logger = {
   groupEnd() {
     currentLogger.groupEnd();
   },
-  viewBuffer(): string {
+  viewLogBuffer(): string {
     return logBuffer.join('\n');
   },
-  flushBuffer(): string {
+  flushLogBuffer(): string {
     const out = logBuffer.join('\n');
     logBuffer.length = 0;
     logBufferBytes = 0;
@@ -274,7 +274,7 @@ export const logger = {
   },
   writeBufferedLogsToFile(options: WriteBufferedLogsOptions): string | null {
     const { dir, commandName, maxFiles = DEFAULT_MAX_LOG_FILES } = options;
-    const contents = this.flushBuffer();
+    const contents = this.flushLogBuffer();
     if (!contents) {
       return null;
     }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -156,10 +156,6 @@ export function getLogLevel(): number {
 
 const _logBuffer = new LogBuffer();
 
-export function setLogBufferByteLimit(bytes: number): void {
-  _logBuffer.setByteLimit(bytes);
-}
-
 export const logger = {
   error(...args: any[]) {
     _logBuffer.record('ERROR', args);


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->

Capture every call into an in-memory buffer (timestamped + level-tagged) regardless of the active LOG_LEVEL, so callers can flush the captured context after a failure.

Adds three new methods to the exported logger:
- viewBuffer(): peek at the joined buffer without clearing
- flushBuffer(): return the joined buffer and clear it
- writeBufferedLogsToFile({ dir, commandName, maxFiles? }): flush the buffer to a rotating log file under the consumer-provided dir. Caps the directory at maxFiles (default 3) by deleting oldest entries. Always clears the buffer, even on write failure.
