### PR TITLE
feat: add commerceLevel to DeveloperTestAccount type

### DIFF
--- a/types/developerTestAccounts.ts
+++ b/types/developerTestAccounts.ts
@@ -39,6 +39,7 @@ export type DeveloperTestAccountConfig = {
   serviceLevel?: AccountLevel;
   salesLevel?: AccountLevel;
   contentLevel?: AccountLevel;
+  commerceLevel?: AccountLevel;
 };
 
 export type InstallOauthAppIntoDeveloperTestAccountResponse = {


### PR DESCRIPTION
Added an optional `commerceLevel` property to the `DeveloperTestAccountConfig` type.
