### PR TITLE
fix: skip .gitignore creation outside git repos and improve .hs README

### DIFF
--- a/config/hsSettings.ts
+++ b/config/hsSettings.ts
@@ -11,15 +11,25 @@ import { HsSettingsFile } from '../types/HsSettings.js';
 import { FileSystemError } from '../models/FileSystemError.js';
 
 const HS_README_CONTENTS = `Why do I have a folder named ".hs" in my project?
-The ".hs" folder is created when you link a directory to a HubSpot project.
+The ".hs" folder is created when you link a directory to a HubSpot account using "hs account link". The CLI walks up parent directories to find the nearest ".hs/settings.json", so subdirectories inherit the same configuration.
 
 What does the "settings.json" file contain?
 The "settings.json" file contains:
-- The ID(s) of the HubSpot account(s) that you linked ("accounts")
-- The ID of the HubSpot account that you set as the default for this directory ("linkedDefaultAccount")
+- The ID(s) of the HubSpot account(s) linked to this directory ("accounts")
+- The ID of the default account for this directory ("localDefaultAccount")
+
+These accounts are a subset of those authenticated in your global CLI config (~/.hscli/config.yml).
 
 Should I commit the ".hs" folder?
-No, the ".hs" folder should not be committed to version control. It is automatically added to your .gitignore file when the directory is linked.
+We recommend not committing this folder. These settings are per-developer configuration, and different team members typically use different accounts or defaults. If your directory is in a Git repository, ".hs" is automatically added to .gitignore when you link.
+
+If your team shares the same accounts, you can remove the .gitignore entry and commit the folder.
+
+How do I manage linked accounts?
+Run "hs account link" to add accounts, "hs account unlink" to remove them, or "hs account list" to see what's linked.
+
+Can I delete this file?
+Yes. This README is for your reference only and can be safely deleted.
 `;
 
 export function getHsSettingsFilePath(): string | null {

--- a/lib/__tests__/gitignore.test.ts
+++ b/lib/__tests__/gitignore.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../../utils/git.js';
 import {
   checkAndAddConfigToGitignore,
+  checkAndAddHsFolderToGitignore,
   checkGitInclusion,
 } from '../gitignore.js';
 import { readFileSync, writeFileSync } from 'fs-extra';
@@ -95,6 +96,37 @@ describe('lib/gitignore', () => {
 
       expect(() => checkAndAddConfigToGitignore(configPath)).toThrow(
         'Unable to determine if config file is properly ignored by git.'
+      );
+    });
+  });
+
+  describe('checkAndAddHsFolderToGitignore', () => {
+    const settingsPath = `${configDirectoryPath}/.hs/settings.json`;
+
+    it('should return early when not in a git repo', () => {
+      isConfigPathInGitRepoMock.mockReturnValue(false);
+      checkAndAddHsFolderToGitignore(settingsPath);
+      expect(readFileSync).not.toHaveBeenCalled();
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should return early when the .hs folder is already ignored', () => {
+      configFilenameIsIgnoredByGitignoreMock.mockReturnValue(true);
+      checkAndAddHsFolderToGitignore(settingsPath);
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should return early when .gitignore already contains .hs', () => {
+      vi.mocked(readFileSync).mockReturnValue('.hs\n');
+      checkAndAddHsFolderToGitignore(settingsPath);
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should add .hs to .gitignore when in a git repo and not yet ignored', () => {
+      checkAndAddHsFolderToGitignore(settingsPath);
+      expect(writeFileSync).toHaveBeenCalledWith(
+        gitIgnoreFiles[0],
+        `${fileContents}\n\n# HubSpot link folder\n.hs\n`
       );
     });
   });

--- a/lib/gitignore.ts
+++ b/lib/gitignore.ts
@@ -41,8 +41,9 @@ export function checkAndAddConfigToGitignore(configPath: string): void {
 export function checkAndAddHsFolderToGitignore(settingsPath: string): void {
   try {
     const hsDirPath = path.resolve(path.dirname(settingsPath));
-    const { configIgnored, gitignoreFiles } = checkGitInclusion(hsDirPath);
-    if (configIgnored) return;
+    const { inGit, configIgnored, gitignoreFiles } =
+      checkGitInclusion(hsDirPath);
+    if (!inGit || configIgnored) return;
 
     let gitignoreFilePath =
       gitignoreFiles && gitignoreFiles.length ? gitignoreFiles[0] : null;


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
`checkAndAddHsFolderToGitignore` was always creating a `.gitignore`. Users who don't use git (e.g. using HubSpot as their source of truth) would get an unexpected `.gitignore` file after running hs account link. This was raised in a feedback session on linking.

The .hs/README.txt copy was also missing key context: the correct field name (localDefaultAccount, not linkedDefaultAccount), the findup inheritance behavior, CLI command references, the relationship to global config, and guidance for teams that want to share linked settings.

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
@joe-yeager 