### PR TITLE
feat: include userId in access token

### DIFF
--- a/lib/__tests__/personalAccessKey.test.ts
+++ b/lib/__tests__/personalAccessKey.test.ts
@@ -60,6 +60,33 @@ const fetchDeveloperTestAccountData =
   >;
 
 describe('lib/personalAccessKey', () => {
+  describe('getAccessToken()', () => {
+    it('includes userId when fetching an access token', async () => {
+      const accountId = 123;
+      const userId = 456;
+      fetchAccessToken.mockResolvedValue(
+        mockAxiosResponse({
+          oauthAccessToken: 'fresh-token',
+          expiresAtMillis: moment().add(1, 'hours').valueOf(),
+          encodedOAuthRefreshToken: 'let-me-in',
+          scopeGroups: ['content'],
+          hubId: accountId,
+          userId,
+          hubName: 'test-hub',
+          accountType: HUBSPOT_ACCOUNT_TYPES.STANDARD,
+        })
+      );
+
+      const accessToken = await getAccessToken(
+        'let-me-in',
+        ENVIRONMENTS.PROD,
+        accountId
+      );
+
+      expect(accessToken.userId).toBe(userId);
+    });
+  });
+
   describe('accessTokenForPersonalAccessKey()', () => {
     it('refreshes access token when access token is missing', async () => {
       const accountId = 123;

--- a/lib/personalAccessKey.ts
+++ b/lib/personalAccessKey.ts
@@ -46,6 +46,7 @@ export async function getAccessToken(
 
   return {
     portalId: response.hubId,
+    userId: response.userId,
     accessToken: response.oauthAccessToken,
     expiresAt: moment(response.expiresAtMillis).toISOString(),
     scopeGroups: response.scopeGroups,

--- a/types/Accounts.ts
+++ b/types/Accounts.ts
@@ -101,6 +101,7 @@ export type EnabledFeaturesResponse = {
 
 export type AccessToken = {
   portalId: number;
+  userId?: number;
   accessToken: string;
   expiresAt: string;
   scopeGroups: Array<string>;


### PR DESCRIPTION
## Description and Context
Expose the HubSpot user ID returned by the personal access key token endpoint through the public `getAccessToken()` API.

This keeps `utils` internal while giving CLI usage tracking a production-ready way to populate `userId`. The new `AccessToken.userId` field is optional so this is not a required type change for existing consumers.

## Pre-review checklist
- [ ] The `/ldl:code-check` skill has been run and the feedback has been addressed
- [x] Tests have been added for new behaviors
- [ ] Manually tested the changes

## Screenshots
N/A

## TODO
Release LDL and bump the CLI dependency after this lands so hubspot-cli-private can consume the updated type/API.

## Who to Notify
