### PR TITLE
chore: fix prettier violations

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,4 @@
 
 @../AGENTS.md
 
-Use `.claude/rules/` for Claude-specific scoped rule files and
-`.claude/skills/` for Claude project skills. Some Claude skills may be symlinks
-to portable skills exposed under `.agents/skills/`.
+Use `.claude/rules/` for Claude-specific scoped rule files and `.claude/skills/` for Claude project skills. Some Claude skills may be symlinks to portable skills exposed under `.agents/skills/`.

--- a/.claude/rules/GENERAL.md
+++ b/.claude/rules/GENERAL.md
@@ -1,12 +1,10 @@
 # Claude-Specific Rules for @hubspot/local-dev-lib
 
-These rules apply to Claude Code sessions in this repository. They supplement
-the shared agent instructions in `AGENTS.md`.
+These rules apply to Claude Code sessions in this repository. They supplement the shared agent instructions in `AGENTS.md`.
 
 ## What NOT to Use From Managed Rules
 
-The following tools and patterns from the org-wide managed rules do NOT apply
-here. This is a Yarn/Node.js library — not a Java backend or frontend app:
+The following tools and patterns from the org-wide managed rules do NOT apply here. This is a Yarn/Node.js library — not a Java backend or frontend app:
 
 - `mcp__devex-mcp-server__build_java` — this is a yarn/node project
 - `mcp__devex-mcp-server__get_onepager` — not required before edits in this repo

--- a/.claude/skills/code-check/SKILL.md
+++ b/.claude/skills/code-check/SKILL.md
@@ -3,7 +3,7 @@ name: ldl:code-check
 description: Review code changes in current branch for adherence to team guidelines and conventions
 disable-model-invocation: false
 allowed-tools: Bash(git:*), Read, Grep, Glob
-argument-hint: "[base-branch]"
+argument-hint: '[base-branch]'
 ---
 
 # Code Style & Guidelines Checker
@@ -38,6 +38,7 @@ Check each modified file for compliance with these guidelines:
 **Note:** This skill focuses on architectural patterns and conventions that require human judgment. Run `yarn lint` and `yarn prettier:write` for automated style checks (quotes, indentation, line length, etc.).
 
 #### Code Quality & Patterns
+
 - [ ] Descriptive variable names that clearly indicate purpose
 - [ ] Functional patterns preferred over classes
 - [ ] Early returns for readability (avoid deep nesting)
@@ -46,12 +47,14 @@ Check each modified file for compliance with these guidelines:
 - [ ] No direct user prompts (return data, let consumers prompt)
 
 #### TypeScript Organization
+
 - [ ] Reusable/exported type definitions in `/types` directory
 - [ ] Proper type imports from type files
 - [ ] No usage of `@ts-ignore` (use proper types or `@ts-expect-error` with explanation)
 - [ ] All exports declared in `package.json` `exports` field
 
 #### Project Organization
+
 - [ ] API calls in `api/` returning `HubSpotPromise<T>`
 - [ ] Config read/write in `config/`
 - [ ] Exported functions in `lib/`
@@ -64,12 +67,14 @@ Check each modified file for compliance with these guidelines:
 - [ ] File names use camelCase
 
 #### Error Handling
+
 - [ ] Throws custom error classes from `errors/`, never returns error objects
 - [ ] Uses `HubSpotHttpError` for API failures
 - [ ] Uses `HubSpotConfigError` for config issues
 - [ ] Uses `FileSystemError` for FS operations
 
 #### Testing
+
 - [ ] Tests in co-located `__tests__/` directories
 - [ ] Uses Vitest (not Jest, not jasmine)
 - [ ] No try/catch blocks in tests (use `expect().toThrow()`)
@@ -78,16 +83,19 @@ Check each modified file for compliance with these guidelines:
 - [ ] Uses `vi.mock()` at module level for dependency mocking
 
 #### Dependencies and Breaking Changes
+
 - [ ] Flag newly-added dependencies and challenge whether they're necessary
 - [ ] Identify potential breaking changes (API changes, removed features, changed behavior)
 - [ ] New exports added to `package.json` `exports` field
 
 #### Pull Request Size
+
 - [ ] Prefer multiple smaller PRs over large ones for easier review
 - [ ] If PR is large (>500 lines), suggest ways to break into smaller chunks
 - [ ] Each PR should have a single, well-defined purpose
 
 #### Git Practices
+
 - [ ] No commits directly to `main` branch
 - [ ] Changes are on a feature/fix branch
 
@@ -98,8 +106,7 @@ Provide a structured report with these sections:
 ```markdown
 # Code Style Review for Branch: <branch-name>
 
-**Base:** <base-branch>
-**Files Changed:** <count>
+**Base:** <base-branch> **Files Changed:** <count>
 
 ## Summary
 
@@ -114,7 +121,9 @@ _If failed, include the relevant linter errors in the Critical Issues section be
 ## Issues Found
 
 ### Critical Issues
+
 _Issues that MUST be fixed before merging:_
+
 - Linter/build failures
 - Using `process.exit()`
 - Using `any` without justification
@@ -125,7 +134,9 @@ _Issues that MUST be fixed before merging:_
 - [ ] **<file-path>:<line>** - <description>
 
 ### Pattern Violations
+
 _Issues that violate codebase conventions and should be fixed before merging:_
+
 - Type definitions in wrong place (not in `/types`)
 - Internal utils exported (should stay in `utils/`)
 - Strings not in `lang/en.json`
@@ -136,7 +147,9 @@ _Issues that violate codebase conventions and should be fixed before merging:_
 - [ ] **<file-path>:<line>** - <description>
 
 ### Suggestions
+
 _Optional improvements that would enhance code quality:_
+
 - Variable naming could be more descriptive
 - Early return opportunities
 - Refactoring for readability
@@ -159,6 +172,7 @@ _Optional improvements that would enhance code quality:_
 ## Next Steps
 
 **Before merging:**
+
 1. Fix all Critical Issues (blocking)
 2. Fix all Pattern Violations (maintain codebase standards)
 3. Consider addressing Suggestions for code quality
@@ -194,6 +208,7 @@ STATUS: FAILED - [brief summary of critical issues]
 This status line is used by automated workflows. Do not modify this format.
 
 **Determining Status:**
+
 - **PASSED**: No Critical Issues AND no Pattern Violations found (Suggestions only are still PASSED)
 - **FAILED**: Any Critical Issues OR Pattern Violations found
 

--- a/.claude/skills/create-pull-request/SKILL.md
+++ b/.claude/skills/create-pull-request/SKILL.md
@@ -25,6 +25,7 @@ When this skill is invoked:
 Invoke the `ldl:push-changes` skill with any arguments passed to this skill.
 
 Wait for completion. Look for the completion message:
+
 - If output contains "Branch pushed to remote": **IMMEDIATELY continue to Step 2 without sending any message**
 - If output contains error or failure: **STOP** and show the user the full output
 
@@ -35,6 +36,7 @@ Do NOT send any acknowledgment message if push-changes succeeds - just continue 
 **CRITICAL**: You MUST complete PR creation in a SINGLE message. PRs are ALWAYS created in draft mode.
 
 In ONE message:
+
 1. Analyze the context gathered above (diff summary, commit messages) to generate PR content
 2. Determine PR title:
    - If an argument was provided to this skill: use that as the title (it should already follow Conventional Commits)
@@ -43,32 +45,29 @@ In ONE message:
    - Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `perf`, `ci`, `build`
 3. Generate PR body using this template:
 
-  ```
-  ## Description and Context
-  [Brief description of what changed and WHY — 2-3 sentences. The diff shows the "what", so focus on the motivation and context behind the change.]
+```
+## Description and Context
+[Brief description of what changed and WHY — 2-3 sentences. The diff shows the "what", so focus on the motivation and context behind the change.]
 
-  ## Pre-review checklist
-  - [ ] The `/ldl:code-check` skill has been run and the feedback has been addressed
-  - [ ] Tests have been added for new behaviors
-  - [ ] Manually tested the changes
+## Pre-review checklist
+- [ ] The `/ldl:code-check` skill has been run and the feedback has been addressed
+- [ ] Tests have been added for new behaviors
+- [ ] Manually tested the changes
 
-  ## Screenshots
-  [Add screenshots here if applicable, otherwise remove this section]
+## Screenshots
+[Add screenshots here if applicable, otherwise remove this section]
 
-  ## TODO
-  [Any remaining work or follow-ups, otherwise remove this section]
+## TODO
+[Any remaining work or follow-ups, otherwise remove this section]
 
-  ## Who to Notify
-  @brandenrodgers @camden11 @joe-yeager @chiragchadha1
-  ```
+## Who to Notify
+@brandenrodgers @camden11 @joe-yeager @chiragchadha1
+```
 
 4. Create the PR: `gh pr create --draft --title "..." --body "..."`
 5. Display completion message with PR URL
 
-You have the capability to call multiple tools in a single response.
-Complete the analysis and PR creation in ONE message.
-Do not send intermediate messages like "Analyzing changes..." or "Creating PR...".
-Do not send any text before the tool calls.
+You have the capability to call multiple tools in a single response. Complete the analysis and PR creation in ONE message. Do not send intermediate messages like "Analyzing changes..." or "Creating PR...". Do not send any text before the tool calls.
 
 After PR creation completes, display:
 

--- a/.claude/skills/push-changes/SKILL.md
+++ b/.claude/skills/push-changes/SKILL.md
@@ -25,17 +25,18 @@ When this skill is invoked:
 Invoke the `ldl:code-check` skill and wait for its completion.
 
 Look for the STATUS line in its output:
+
 - If output contains "STATUS: PASSED": **IMMEDIATELY continue to Step 2 without sending any message to the user**
 - If output contains "STATUS: FAILED": **STOP** and show the user the full code-check output
 
-Do NOT proceed to Step 2 if STATUS is not PASSED.
-Do NOT send any acknowledgment or summary message if checks pass - just continue to Step 2.
+Do NOT proceed to Step 2 if STATUS is not PASSED. Do NOT send any acknowledgment or summary message if checks pass - just continue to Step 2.
 
 ### 2. Atomic commit and push
 
 **CRITICAL**: After checks pass in Step 1, you MUST complete ALL of the following in a SINGLE message with multiple tool calls.
 
 Before executing any tool calls, analyze the context gathered above:
+
 1. Verify current branch is not main/master
    - If branch is "main" or "master": STOP and tell user: "You're currently on the main branch. Please create a feature branch first using `git checkout -b <branch-name>`"
 2. Check if there are uncommitted changes (from context above)
@@ -49,6 +50,7 @@ Before executing any tool calls, analyze the context gathered above:
    - If user declines: STOP and tell them to manually stage files
 
 After analysis, execute in ONE message:
+
 1. Stage changes: `git add .` (if there are uncommitted changes)
 2. Create commit (if there are uncommitted changes):
    - If an argument was provided to this skill: use that as the commit message (it should already follow Conventional Commits)
@@ -62,11 +64,7 @@ After analysis, execute in ONE message:
    - If upstream exists: `git push`
 4. Verify: `git status`
 
-You have the capability to call multiple tools in a single response.
-Execute ALL of the above git operations in ONE message using parallel tool calls where possible.
-Do not send any intermediate messages.
-Do not send any text before the tool calls.
-Do not report progress during execution.
+You have the capability to call multiple tools in a single response. Execute ALL of the above git operations in ONE message using parallel tool calls where possible. Do not send any intermediate messages. Do not send any text before the tool calls. Do not report progress during execution.
 
 After ALL tool calls complete, then display the completion message:
 

--- a/.cursor/rules/build-commands.md
+++ b/.cursor/rules/build-commands.md
@@ -15,5 +15,4 @@ Use these commands when working with this codebase:
 - Check circular dependencies: `yarn circular-deps`
 - Local dev (symlink to CLI): `yarn local-dev`
 
-Follow `AGENTS.md` for the validation scope. Ask before committing or pushing
-changes.
+Follow `AGENTS.md` for the validation scope. Ask before committing or pushing changes.

--- a/.cursor/rules/code-style.md
+++ b/.cursor/rules/code-style.md
@@ -1,6 +1,6 @@
 ---
 description: HubSpot Local Dev Lib Code Style Guidelines
-globs: "**/*.{js,ts}"
+globs: '**/*.{js,ts}'
 alwaysApply: true
 ---
 
@@ -16,8 +16,7 @@ Follow these guidelines when working with code in this repository:
 - No `process.exit()` — throw errors and let consumers handle them
 - No direct user prompts — return data and let the CLI prompt
 - All user-facing strings in `lang/en.json` using `i18n()` with interpolation
-- Throw custom errors from `errors/` (`HubSpotHttpError`, `HubSpotConfigError`,
-  `FileSystemError`)
+- Throw custom errors from `errors/` (`HubSpotHttpError`, `HubSpotConfigError`, `FileSystemError`)
 - Write tests in co-located `__tests__/` directories using Vitest
 - Use single quotes, 2-space indentation, trailing commas
 - Keep lines under 80 characters

--- a/.cursor/rules/formatting.md
+++ b/.cursor/rules/formatting.md
@@ -1,6 +1,6 @@
 ---
 description: Code Formatting Guidelines
-globs: "**/*.{js,ts}"
+globs: '**/*.{js,ts}'
 alwaysApply: false
 ---
 

--- a/.cursor/rules/testing.md
+++ b/.cursor/rules/testing.md
@@ -1,6 +1,6 @@
 ---
 description: Testing Guidelines
-globs: "**/__tests__/**/*.ts"
+globs: '**/__tests__/**/*.ts'
 alwaysApply: false
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,25 @@
 ## Description and Context
+
 <!-- Provide a summary of what has changed -->
 <!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
 <!-- Describe any packages you'd like to add and the reasons why. -->
 
 ## Pre-review checklist
+
 <!-- It is expected that all of these have been run before bringing in teammates for review -->
+
 - [ ] The `/ldl:code-check` skill has been run and the feedback has been addressed
 - [ ] Tests have been added for new behaviors
 - [ ] Manually tested the changes
 
 ## Screenshots
+
 <!-- Provide images of the before and after functionality -->
 
 ## TODO
+
 <!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->
 
 ## Who to Notify
+
 <!-- /cc those you wish to know about the PR -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,6 @@
 # HubSpot Local Dev Lib Agent Instructions
 
-This repository is `@hubspot/local-dev-lib` — a shared TypeScript library that
-provides core functionality for HubSpot local development tooling. It is
-consumed by the HubSpot CLI and VS Code extension.
+This repository is `@hubspot/local-dev-lib` — a shared TypeScript library that provides core functionality for HubSpot local development tooling. It is consumed by the HubSpot CLI and VS Code extension.
 
 ## Stack
 
@@ -13,13 +11,11 @@ consumed by the HubSpot CLI and VS Code extension.
 - Lint: `yarn lint`
 - Format: `yarn prettier:write`
 
-Do not use Java, Maven, CHIRP, Bend, Trellis, or HubSpot backend/frontend
-platform workflows for normal work in this repo.
+Do not use Java, Maven, CHIRP, Bend, Trellis, or HubSpot backend/frontend platform workflows for normal work in this repo.
 
 ## This is a Library, Not a CLI
 
-This repo is consumed via `@hubspot/local-dev-lib` by the CLI and other tools.
-Key implications:
+This repo is consumed via `@hubspot/local-dev-lib` by the CLI and other tools. Key implications:
 
 - No `process.exit()` — throw errors and let consumers handle them.
 - No direct user prompts — return data and let the CLI prompt.
@@ -31,35 +27,28 @@ Key consumers:
 - `hubspot-cli` — the primary consumer
 - VS Code extension — uses config and API functions
 
-Changes here affect all consumers. Be careful with breaking changes to exported
-function signatures.
+Changes here affect all consumers. Be careful with breaking changes to exported function signatures.
 
 ## Start Here
 
-Before creating or modifying code, study how the repo already does the same
-kind of work.
+Before creating or modifying code, study how the repo already does the same kind of work.
 
-- Search for similar files and read at least two comparable examples before
-  adding a new file.
+- Search for similar files and read at least two comparable examples before adding a new file.
 - Check `lib/`, `config/`, `api/`, or `utils/` before adding a new function.
 - Check `types/` before adding a new shared type.
 - Follow the discriminated union pattern used for account types.
-- Check `lang/en.json` before adding user-facing strings. Use the `i18n()`
-  function with `{{ variable }}` interpolation.
-- If existing implementations disagree in a meaningful way, stop and surface
-  the discrepancy instead of silently choosing one pattern.
+- Check `lang/en.json` before adding user-facing strings. Use the `i18n()` function with `{{ variable }}` interpolation.
+- If existing implementations disagree in a meaningful way, stop and surface the discrepancy instead of silently choosing one pattern.
 
 ## Code Organization
 
 - `api/` — HTTP calls to HubSpot services. Return `HubSpotPromise<T>`.
 - `config/` — Config file read/write (YAML). Core account resolution logic.
 - `constants/` — Shared constants.
-- `errors/` — Custom error classes (`HubSpotHttpError`, `HubSpotConfigError`,
-  `FileSystemError`).
+- `errors/` — Custom error classes (`HubSpotHttpError`, `HubSpotConfigError`, `FileSystemError`).
 - `http/` — Axios wrapper with HubSpot auth.
 - `lang/` — i18n strings (`en.json`).
-- `lib/` — Exported functions and modules. Anything exported from the repo
-  should live here (excluding special cases like `config/`).
+- `lib/` — Exported functions and modules. Anything exported from the repo should live here (excluding special cases like `config/`).
 - `utils/` — Internal helper functions that are NOT exported.
 - `models/` — Business logic classes.
 - `types/` — TypeScript type definitions.
@@ -67,8 +56,7 @@ kind of work.
 ## Error Handling
 
 - Throw custom error classes from `errors/`, never return error objects.
-- Use `HubSpotHttpError` for API failures, `HubSpotConfigError` for config
-  issues, `FileSystemError` for FS operations.
+- Use `HubSpotHttpError` for API failures, `HubSpotConfigError` for config issues, `FileSystemError` for FS operations.
 - Never call `process.exit()` — that is the consumer's responsibility.
 
 ## Code Style
@@ -78,8 +66,7 @@ kind of work.
 - Use descriptive variable names.
 - Do not introduce `any` unless there is a narrow, well-justified reason.
 - Do not add comments unless the code would otherwise be hard to follow.
-- Follow the repo formatter for single quotes, 2-space indentation, trailing
-  commas, and 80-character line length.
+- Follow the repo formatter for single quotes, 2-space indentation, trailing commas, and 80-character line length.
 - Do not use the word `comprehensive` in repo copy or generated docs.
 
 ## Tests
@@ -99,8 +86,7 @@ After code changes, run the smallest useful validation set:
 2. `yarn build`
 3. `yarn test <path>` for changed or closely related tests
 
-Run broader checks when the change touches shared behavior or foundational
-modules.
+Run broader checks when the change touches shared behavior or foundational modules.
 
 Additional checks:
 
@@ -110,8 +96,7 @@ Additional checks:
 
 ### Option 1: Local linking (for active development)
 
-1. In this repo: `yarn local-dev` — builds, runs `yarn link`, and watches for
-   changes.
+1. In this repo: `yarn local-dev` — builds, runs `yarn link`, and watches for changes.
 2. In CLI: `yarn local-link` — interactive prompt to symlink local packages.
 3. Changes here are reflected in the CLI after `yarn build`.
 
@@ -120,39 +105,26 @@ To stop: run `yarn unlink` here, then `yarn install --force` in CLI.
 ### Option 2: Experimental NPM release (for CI testing or sharing)
 
 1. In this repo: `yarn release -v=prerelease -t=experimental`
-2. In CLI: update `package.json` to the experimental version and run
-   `yarn install --force`.
+2. In CLI: update `package.json` to the experimental version and run `yarn install --force`.
 
 ## Git And PR Workflow
 
-- Use Conventional Commits for all commit messages and PR titles. Format:
-  `<type>: <short description>`. Types: `feat`, `fix`, `chore`, `refactor`,
-  `test`, `docs`, `perf`, `ci`, `build`.
-- Do not amend commits on an existing PR unless the user explicitly asks for an
-  amend, rebase, squash, or history rewrite.
-- When addressing review feedback on a PR, create a new follow-up commit by
-  default.
-- For stacked PRs, prefer merging parent branch updates into the child branch
-  over rebasing, because PRs are squash-merged into `main`.
-- Ask before committing, pushing, force-pushing, creating PRs, posting comments,
-  merging, closing, or otherwise mutating GitHub state.
+- Use Conventional Commits for all commit messages and PR titles. Format: `<type>: <short description>`. Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `perf`, `ci`, `build`.
+- Do not amend commits on an existing PR unless the user explicitly asks for an amend, rebase, squash, or history rewrite.
+- When addressing review feedback on a PR, create a new follow-up commit by default.
+- For stacked PRs, prefer merging parent branch updates into the child branch over rebasing, because PRs are squash-merged into `main`.
+- Ask before committing, pushing, force-pushing, creating PRs, posting comments, merging, closing, or otherwise mutating GitHub state.
 
 ## Shared Skills
 
-Portable project skills are exposed under `.agents/skills/`. When a task
-matches one of these workflows, read that skill before proceeding:
+Portable project skills are exposed under `.agents/skills/`. When a task matches one of these workflows, read that skill before proceeding:
 
 - `code-check`: review branch changes against repo conventions.
 - `push-changes`: run pre-commit checks, commit, and push to remote.
 - `create-pull-request`: commit, push, and create a draft PR.
 
-Claude-specific skills and orchestration workflows may still live only under
-`.claude/skills/`.
+Claude-specific skills and orchestration workflows may still live only under `.claude/skills/`.
 
 ## Agent-Specific Config
 
-`AGENTS.md` is the canonical behavioral entry point. Agent-specific permission
-or runtime configuration should stay in that agent's own local config, such as
-`.claude/settings.local.json` for Claude or `.codex/rules/*.rules` for Codex
-command execution policy. Do not duplicate behavioral rules into permission
-files.
+`AGENTS.md` is the canonical behavioral entry point. Agent-specific permission or runtime configuration should stay in that agent's own local config, such as `.claude/settings.local.json` for Claude or `.codex/rules/*.rules` for Codex command execution policy. Do not duplicate behavioral rules into permission files.

--- a/api/__tests__/appLogs.test.ts
+++ b/api/__tests__/appLogs.test.ts
@@ -34,7 +34,10 @@ describe('api/appLogs', () => {
     });
 
     it('should include optional after cursor when provided', async () => {
-      const bodyWithCursor: SearchLogsRequest = { ...requestBody, after: 'abc123' };
+      const bodyWithCursor: SearchLogsRequest = {
+        ...requestBody,
+        after: 'abc123',
+      };
       await searchAppLogs(accountId, appId, bodyWithCursor);
       expect(http.post).toHaveBeenCalledWith(accountId, {
         url: `developers/logs/search/${appId}`,


### PR DESCRIPTION
## Description and Context

Fixes pre-existing prettier formatting violations across markdown and test files so the pre-commit hook passes cleanly. No logic changes.

## Pre-review checklist

- [ ] The `/ldl:code-check` skill has been run and the feedback has been addressed
- [x] Tests have been added for new behaviors
- [x] Manually tested the changes

## Screenshots

N/A

## TODO

N/A

## Who to Notify