### PR TITLE
fix: move handleFieldsJS __dirname to function scope to prevent Windows activation crash

### DIFF
--- a/lib/cms/handleFieldsJS.ts
+++ b/lib/cms/handleFieldsJS.ts
@@ -9,7 +9,6 @@ import { logger } from '../logger.js';
 import { BaseError } from '../../types/Error.js';
 import { i18n } from '../../utils/lang.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const i18nKey = 'lib.cms.handleFieldsJs';
 
 export class FieldsJs {
@@ -48,6 +47,11 @@ export class FieldsJs {
   convertFieldsJs(writeDir: string): Promise<string | void> {
     const filePath = this.filePath;
     const dirName = path.dirname(filePath);
+    // Keep this inside the function: at module scope, webpack inlines
+    // `import.meta.url` as a build-machine string literal, which crashes
+    // bundled consumers (e.g. the VS Code extension) on Windows with
+    // "File URL path must be absolute".
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
     return new Promise<string>((resolve, reject) => {
       const fieldOptionsAsString = Array.isArray(this.fieldOptions)


### PR DESCRIPTION
## Description and Context

Moves the `__dirname` declaration in `lib/cms/handleFieldsJS.ts` from module scope into `convertFieldsJs()`. One-line behavioral change; no API surface change.

### Why a fields.js helper was crashing the VS Code extension on Windows

At first glance this file has nothing to do with the VS Code extension's activation path — it's a CMS helper that forks a child process to convert `fields.js` files. But after the v4 → v5 (CJS → pure ESM) bump, the extension started failing to activate on Windows with:

> Activating extension 'HubSpot.hubl' failed: File URL path must be absolute.

The chain:

1. The VS Code extension bundles its dependencies with **webpack** (`target: node`, CJS output). Webpack walks the entire dependency graph and inlines every reachable module — including this one, even if the extension never calls `convertFieldsJs`.
2. Webpack does not preserve `import.meta.url` semantics. It replaces it with a **string literal** containing the absolute path of the source file **on the build machine** (macOS): `"file:///Users/.../lib/cms/handleFieldsJS.js"`.
3. The expression `path.dirname(fileURLToPath(import.meta.url))` lived at **module scope**, so it ran the moment the bundle loaded — before `activate()`.
4. On Windows, `fileURLToPath` requires a drive-letter path. The hardcoded Unix path has none, so Node throws synchronously at module load. The extension never activates; all commands go unregistered; the sidebar shows "No authenticated accounts were found" regardless of CLI auth state.

The `__dirname` value is only used to fork `processFieldsJs.js` — a CLI-only operation that no bundled consumer should ever hit. Moving the declaration inside `convertFieldsJs` means:

- **Native Node ESM (CLI):** `import.meta.url` is evaluated at call time and is correct. No behavior change.
- **Webpack bundles:** the module loads without executing `fileURLToPath`, so the crash is gone. If `convertFieldsJs` were ever called in a bundled context the fork path would still be wrong, but that's contained to the call site and was never a supported path.

A comment on the moved line documents why it must stay inside the function, so future refactors don't innocently hoist it back out.

## Pre-review checklist

- [x] The `/ldl:code-check` skill has been run and the feedback has been addressed
- [x] Tests have been added for new behaviors — N/A; the existing `convertFieldsJs returns a Promise` test still exercises the moved code path. The actual bug only manifests in a webpack bundle loaded on Windows, which isn't reproducible from a vitest run in this repo.
- [x] Manually tested the changes — pending verification in the VS Code extension on Windows via experimental release or `yarn local-link`

## Screenshots

N/A — no user-visible UI in this library.

## TODO

- Verify the fix end-to-end by publishing an experimental release of `@hubspot/local-dev-lib`, bumping the VS Code extension to it, building the extension bundle, and confirming activation succeeds on Windows.

## Who to Notify

<!-- /cc reviewers -->
