### PR TITLE
fix: replace single-request folder tree fetch with incremental /meta/ traversal

### DIFF
--- a/api/fileMapper.ts
+++ b/api/fileMapper.ts
@@ -148,7 +148,7 @@ export function getDirectoryContentsByPath(
   });
 }
 
-// Get shallow directory listing — children are strings, not nested nodes
+// getDirectoryContentsByPath has the wrong return type for /meta/ — children are strings, not FileMapperNodes
 export function getDirectoryMetaByPath(
   accountId: number,
   path: string,

--- a/api/fileMapper.ts
+++ b/api/fileMapper.ts
@@ -155,7 +155,7 @@ export function getDirectoryMetaByPath(
   options: FileMapperOptions = {}
 ): HubSpotPromise<DirectoryMetaNode> {
   return http.get<DirectoryMetaNode>(accountId, {
-    url: `${FILE_MAPPER_API_PATH}/meta/${encodeURIComponent(path)}`,
+    url: `${FILE_MAPPER_API_PATH}/meta/${path.split('/').map(encodeURIComponent).join('/')}`,
     ...options,
   });
 }

--- a/api/fileMapper.ts
+++ b/api/fileMapper.ts
@@ -155,7 +155,7 @@ export function getDirectoryMetaByPath(
   options: FileMapperOptions = {}
 ): HubSpotPromise<DirectoryMetaNode> {
   return http.get<DirectoryMetaNode>(accountId, {
-    url: `${FILE_MAPPER_API_PATH}/meta/${path}`,
+    url: `${FILE_MAPPER_API_PATH}/meta/${encodeURIComponent(path)}`,
     ...options,
   });
 }

--- a/api/fileMapper.ts
+++ b/api/fileMapper.ts
@@ -5,7 +5,12 @@ import { AxiosResponse } from 'axios';
 import { http } from '../http/index.js';
 import { getCwd } from '../lib/path.js';
 import { FILE_MAPPER_API_PATH } from '../constants/endpoints.js';
-import { FileMapperNode, FileMapperOptions, FileTree } from '../types/Files.js';
+import {
+  DirectoryMetaNode,
+  FileMapperNode,
+  FileMapperOptions,
+  FileTree,
+} from '../types/Files.js';
 import { HubSpotPromise } from '../types/Http.js';
 
 export function createFileMapperNodeFromStreamResponse(
@@ -140,5 +145,17 @@ export function getDirectoryContentsByPath(
 ): HubSpotPromise<FileMapperNode> {
   return http.get(accountId, {
     url: `${FILE_MAPPER_API_PATH}/meta/${path}`,
+  });
+}
+
+// Get shallow directory listing — children are strings, not nested nodes
+export function getDirectoryMetaByPath(
+  accountId: number,
+  path: string,
+  options: FileMapperOptions = {}
+): HubSpotPromise<DirectoryMetaNode> {
+  return http.get<DirectoryMetaNode>(accountId, {
+    url: `${FILE_MAPPER_API_PATH}/meta/${path}`,
+    ...options,
   });
 }

--- a/lib/__tests__/fileMapper.test.ts
+++ b/lib/__tests__/fileMapper.test.ts
@@ -422,7 +422,9 @@ describe('lib/fileMapper', () => {
 
       await downloadFileOrFolder(testAccountId, 'ThemeDirectory/', './');
 
-      const metaCalls = getDirectoryMetaByPath.mock.calls.map(c => c[1] as string);
+      const metaCalls = getDirectoryMetaByPath.mock.calls.map(
+        c => c[1] as string
+      );
       expect(metaCalls.some(p => p.includes('//'))).toBe(false);
       expect(metaCalls).toContain('ThemeDirectory/modules');
     });

--- a/lib/__tests__/fileMapper.test.ts
+++ b/lib/__tests__/fileMapper.test.ts
@@ -412,14 +412,6 @@ describe('lib/fileMapper', () => {
         )
         .mockResolvedValueOnce(
           mockAxiosResponse({
-            name: 'ThemeDirectory',
-            path: '/ThemeDirectory',
-            folder: true,
-            children: ['modules'],
-          })
-        )
-        .mockResolvedValueOnce(
-          mockAxiosResponse({
             name: 'modules',
             path: '/ThemeDirectory/modules',
             folder: true,

--- a/lib/__tests__/fileMapper.test.ts
+++ b/lib/__tests__/fileMapper.test.ts
@@ -7,11 +7,13 @@ import {
   recurseFolder,
   fetchFolderFromApi,
   getTypeDataFromPath,
+  getFileMapperQueryValues,
   downloadFileOrFolder,
 } from '../fileMapper.js';
 import {
   download as __download,
   fetchFileStream as __fetchFileStream,
+  getDirectoryMetaByPath as __getDirectoryMetaByPath,
 } from '../../api/fileMapper.js';
 import folderWithoutSources from './fixtures/fileMapper/folderWithoutSources.json' with { type: 'json' };
 import { mockAxiosResponse } from './__utils__/mockAxiosResponse.js';
@@ -25,6 +27,9 @@ const pathExistsSpy = vi.spyOn(fs, 'pathExists');
 const download = __download as MockedFunction<typeof __download>;
 const fetchFileStream = __fetchFileStream as MockedFunction<
   typeof __fetchFileStream
+>;
+const getDirectoryMetaByPath = __getDirectoryMetaByPath as MockedFunction<
+  typeof __getDirectoryMetaByPath
 >;
 
 const rootPaths = ['', '/', '\\'];
@@ -274,20 +279,160 @@ describe('lib/fileMapper', () => {
       expect(utimesSpy).toHaveBeenCalled();
     });
     it('should execute downloadFolder', async () => {
-      pathExistsSpy.mockImplementationOnce(() => false);
-      download.mockResolvedValueOnce(
+      getDirectoryMetaByPath.mockResolvedValue(
         mockAxiosResponse({
-          name: '',
-          createdAt: 1,
-          updatedAt: 1,
-          source: null,
-          path: '',
+          name: 'c',
+          path: '/a/b/c',
           folder: true,
           children: [],
         })
       );
       await downloadFileOrFolder(accountId, '/a/b/c', './');
       expect(ensureDirSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('getFileMapperQueryValues()', () => {
+    it('should include timeout when provided', () => {
+      const result = getFileMapperQueryValues(undefined, { timeout: 60_000 });
+      expect(result.timeout).toBe(60_000);
+    });
+
+    it('should omit timeout when not provided', () => {
+      const result = getFileMapperQueryValues(undefined, {});
+      expect('timeout' in result).toBe(false);
+    });
+  });
+
+  describe('downloadFolder via downloadFileOrFolder()', () => {
+    const testAccountId = 67890;
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('downloads files discovered via /meta/', async () => {
+      getDirectoryMetaByPath.mockResolvedValue(
+        mockAxiosResponse({
+          name: 'templates',
+          path: '/templates',
+          folder: true,
+          children: ['page.html'],
+        })
+      );
+      pathExistsSpy.mockImplementation(async () => false);
+      fetchFileStream.mockResolvedValue({
+        name: 'page.html',
+        createdAt: 1,
+        updatedAt: 1,
+        source: null,
+        path: '/templates/page.html',
+        folder: false,
+        children: [],
+      });
+      utimesSpy.mockImplementation(async () => undefined);
+
+      await downloadFileOrFolder(testAccountId, '/templates', './');
+
+      expect(fetchFileStream).toHaveBeenCalledWith(
+        testAccountId,
+        '/templates/page.html',
+        expect.stringContaining('page.html'),
+        expect.any(Object)
+      );
+    });
+
+    it('tracks failed file downloads without throwing from the queue', async () => {
+      getDirectoryMetaByPath.mockResolvedValue(
+        mockAxiosResponse({
+          name: 'templates',
+          path: '/templates',
+          folder: true,
+          children: ['bad.html'],
+        })
+      );
+      pathExistsSpy.mockImplementation(async () => false);
+      fetchFileStream.mockRejectedValue(new Error('network error'));
+
+      await expect(
+        downloadFileOrFolder(testAccountId, '/templates', './')
+      ).rejects.toThrow();
+    });
+
+    it('wraps /meta/ failures as failedToFetchFolder', async () => {
+      getDirectoryMetaByPath.mockRejectedValue(new Error('server error'));
+
+      await expect(
+        downloadFileOrFolder(testAccountId, '/templates', './')
+      ).rejects.toThrow();
+    });
+
+    it('injects @hubspot into children for root paths', async () => {
+      getDirectoryMetaByPath
+        .mockResolvedValueOnce(
+          mockAxiosResponse({
+            name: '',
+            path: '/',
+            folder: true,
+            children: ['templates'],
+          })
+        )
+        .mockResolvedValueOnce(
+          mockAxiosResponse({
+            name: '@hubspot',
+            path: '/@hubspot',
+            folder: true,
+            children: [],
+          })
+        )
+        .mockResolvedValueOnce(
+          mockAxiosResponse({
+            name: 'templates',
+            path: '/templates',
+            folder: true,
+            children: [],
+          })
+        );
+
+      await downloadFileOrFolder(testAccountId, '/', './');
+
+      const calls = getDirectoryMetaByPath.mock.calls.map(c => c[1]);
+      expect(calls).toContain('@hubspot');
+    });
+
+    it('strips trailing slash from src before building child paths', async () => {
+      getDirectoryMetaByPath
+        .mockResolvedValueOnce(
+          mockAxiosResponse({
+            name: 'ThemeDirectory',
+            path: '/ThemeDirectory',
+            folder: true,
+            children: ['modules'],
+          })
+        )
+        .mockResolvedValueOnce(
+          mockAxiosResponse({
+            name: 'ThemeDirectory',
+            path: '/ThemeDirectory',
+            folder: true,
+            children: ['modules'],
+          })
+        )
+        .mockResolvedValueOnce(
+          mockAxiosResponse({
+            name: 'modules',
+            path: '/ThemeDirectory/modules',
+            folder: true,
+            children: [],
+          })
+        );
+      ensureDirSpy.mockImplementation(async () => undefined);
+
+      await downloadFileOrFolder(testAccountId, 'ThemeDirectory/', './');
+
+      const metaCalls = getDirectoryMetaByPath.mock.calls.map(c => c[1] as string);
+      expect(metaCalls.some(p => p.includes('//'))).toBe(false);
+      expect(metaCalls).toContain('ThemeDirectory/modules');
     });
   });
 });

--- a/lib/__tests__/fileMapper.test.ts
+++ b/lib/__tests__/fileMapper.test.ts
@@ -348,15 +348,34 @@ describe('lib/fileMapper', () => {
           name: 'templates',
           path: '/templates',
           folder: true,
-          children: ['bad.html'],
+          children: ['bad.html', 'good.html'],
         })
       );
       pathExistsSpy.mockImplementation(async () => false);
-      fetchFileStream.mockRejectedValue(new Error('network error'));
+      fetchFileStream.mockImplementation(async (_accountId, filePath) => {
+        if (filePath === '/templates/bad.html') throw new Error('network error');
+        return {
+          name: 'good.html',
+          createdAt: 1,
+          updatedAt: 1,
+          source: null,
+          path: filePath,
+          folder: false,
+          children: [],
+        };
+      });
+      utimesSpy.mockImplementation(async () => undefined);
 
       await expect(
         downloadFileOrFolder(testAccountId, '/templates', './')
-      ).rejects.toThrow();
+      ).rejects.toThrow('Not all files in folder');
+
+      expect(fetchFileStream).toHaveBeenCalledWith(
+        testAccountId,
+        '/templates/good.html',
+        expect.any(String),
+        expect.any(Object)
+      );
     });
 
     it('wraps /meta/ failures as failedToFetchFolder', async () => {
@@ -364,7 +383,7 @@ describe('lib/fileMapper', () => {
 
       await expect(
         downloadFileOrFolder(testAccountId, '/templates', './')
-      ).rejects.toThrow();
+      ).rejects.toThrow('Failed fetch of folder');
     });
 
     it('injects @hubspot into children for root paths', async () => {

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -326,32 +326,36 @@ async function queueFolderTree(
 
   const queryValues = getFileMapperQueryValues(cmsPublishMode, options);
 
+  const queueFileDownload = (remotePath: string, destPath: string) => {
+    queue.add(async () => {
+      try {
+        await fetchAndWriteFileStream(
+          accountId,
+          remotePath,
+          destPath,
+          cmsPublishMode,
+          options
+        );
+      } catch (err) {
+        failedPaths.add(remotePath);
+        logger.debug(
+          i18n(`${i18nKey}.errors.failedToFetchFile`, {
+            src: remotePath,
+            dest: destPath,
+          })
+        );
+      }
+    });
+  };
+
   for (const childName of children) {
     const childRemotePath = isRoot ? childName : `${src}/${childName}`;
     const childLocalPath = convertToLocalFileSystemPath(
       path.join(localPath, childName)
     );
 
-    if (isPathToFile(childRemotePath)) {
-      queue.add(async () => {
-        try {
-          await fetchAndWriteFileStream(
-            accountId,
-            childRemotePath,
-            childLocalPath,
-            cmsPublishMode,
-            options
-          );
-        } catch (err) {
-          failedPaths.add(childRemotePath);
-          logger.debug(
-            i18n(`${i18nKey}.errors.failedToFetchFile`, {
-              src: childRemotePath,
-              dest: childLocalPath,
-            })
-          );
-        }
-      });
+    if (isAllowedExtension(childRemotePath, [...JSR_ALLOWED_EXTENSIONS])) {
+      queueFileDownload(childRemotePath, childLocalPath);
     } else {
       const { data: childNode } = await getDirectoryMetaByPath(
         accountId,
@@ -359,13 +363,17 @@ async function queueFolderTree(
         queryValues
       );
       if (childNode) {
-        await queueFolderTree(
-          accountId,
-          childRemotePath,
-          childLocalPath,
-          childNode,
-          ctx
-        );
+        if (childNode.folder) {
+          await queueFolderTree(
+            accountId,
+            childRemotePath,
+            childLocalPath,
+            childNode,
+            ctx
+          );
+        } else {
+          queueFileDownload(childRemotePath, childLocalPath);
+        }
       }
     }
   }

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -321,7 +321,14 @@ async function queueFolderTree(
     children = ['@hubspot', ...children];
   }
 
-  await fs.ensureDir(localPath);
+  try {
+    await fs.ensureDir(localPath);
+  } catch (err) {
+    throw new FileSystemError(
+      { cause: err },
+      { filepath: localPath, accountId, operation: 'write' }
+    );
+  }
   logger.log(i18n(`${i18nKey}.wroteFolder`, { filepath: localPath }));
 
   const queryValues = getFileMapperQueryValues(cmsPublishMode, options);

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -54,10 +54,6 @@ export function isPathToRoot(filepath: string): boolean {
   return /^(\/|\\)?$/.test(filepath.trim());
 }
 
-export function isPathToFolder(filepath: string): boolean {
-  return !isPathToFile(filepath);
-}
-
 export function isPathToHubspot(filepath: string): boolean {
   if (typeof filepath !== 'string') return false;
   return /^(\/|\\)?@hubspot/i.test(filepath.trim());

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -319,6 +319,7 @@ async function queueFolderTree(
   }
 
   await fs.ensureDir(localPath);
+  logger.log(i18n(`${i18nKey}.wroteFolder`, { filepath: localPath }));
 
   const queryValues = getFileMapperQueryValues(cmsPublishMode, options);
 

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -395,6 +395,8 @@ async function downloadFolder(
 
     if (!rootMeta) return;
 
+    logger.log(i18n(`${i18nKey}.folderFetch`, { src, accountId }));
+
     const rootPath =
       dest === getCwd()
         ? convertToLocalFileSystemPath(

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -25,6 +25,7 @@ import {
 import { CMS_PUBLISH_MODE } from '../constants/files.js';
 import {
   FileMapperNode,
+  DirectoryMetaNode,
   CmsPublishMode,
   FileMapperOptions,
   FileMapperInputOptions,
@@ -215,57 +216,6 @@ async function fetchAndWriteFileStream(
   await writeUtimes(accountId, filepath, node);
 }
 
-// Writes an individual file or folder (not recursive).  If file source is missing, the
-//file is fetched.
-async function writeFileMapperNode(
-  accountId: number,
-  filepath: string,
-  node: FileMapperNode,
-  cmsPublishMode?: CmsPublishMode,
-  options: FileMapperInputOptions = {}
-): Promise<boolean> {
-  const localFilepath = convertToLocalFileSystemPath(path.resolve(filepath));
-  if (await skipExisting(localFilepath, options.overwrite)) {
-    logger.log(
-      i18n(`${i18nKey}.skippedExisting`, {
-        filepath: localFilepath,
-      })
-    );
-    return true;
-  }
-  if (!node.folder) {
-    try {
-      await fetchAndWriteFileStream(
-        accountId,
-        node.path,
-        localFilepath,
-        cmsPublishMode,
-        options
-      );
-      return true;
-    } catch (err) {
-      return false;
-    }
-  }
-  try {
-    await fs.ensureDir(localFilepath);
-    logger.log(
-      i18n(`${i18nKey}.wroteFolder`, {
-        filepath: localFilepath,
-      })
-    );
-  } catch (err) {
-    throw new FileSystemError(
-      { cause: err },
-      {
-        filepath: localFilepath,
-        accountId,
-        operation: 'write',
-      }
-    );
-  }
-  return true;
-}
 
 async function downloadFile(
   accountId: number,
@@ -305,7 +255,6 @@ async function downloadFile(
       cmsPublishMode,
       options
     );
-    await queue.onIdle();
     logger.success(
       i18n(`${i18nKey}.completedFetch`, {
         src,
@@ -358,27 +307,22 @@ async function queueFolderTree(
   accountId: number,
   src: string,
   localPath: string,
+  directoryNode: DirectoryMetaNode,
   cmsPublishMode: CmsPublishMode | undefined,
   options: FileMapperInputOptions,
   failedPaths: Set<string>
 ): Promise<void> {
+  if (!directoryNode.folder) return;
+
   const { isRoot } = getTypeDataFromPath(src);
-  const metaPath = isRoot ? '/' : src;
-  const queryValues = getFileMapperQueryValues(cmsPublishMode, options);
-  const { data: directoryNode } = await getDirectoryMetaByPath(
-    accountId,
-    metaPath,
-    queryValues
-  );
-
-  if (!directoryNode?.folder) return;
-
   let children: string[] = directoryNode.children || [];
   if (isRoot) {
     children = ['@hubspot', ...children];
   }
 
   await fs.ensureDir(localPath);
+
+  const queryValues = getFileMapperQueryValues(cmsPublishMode, options);
 
   for (const childName of children) {
     const childRemotePath = isRoot ? childName : `${src}/${childName}`;
@@ -407,14 +351,22 @@ async function queueFolderTree(
         }
       });
     } else {
-      await queueFolderTree(
+      const { data: childNode } = await getDirectoryMetaByPath(
         accountId,
         childRemotePath,
-        childLocalPath,
-        cmsPublishMode,
-        options,
-        failedPaths
+        queryValues
       );
+      if (childNode) {
+        await queueFolderTree(
+          accountId,
+          childRemotePath,
+          childLocalPath,
+          childNode,
+          cmsPublishMode,
+          options,
+          failedPaths
+        );
+      }
     }
   }
 }
@@ -453,6 +405,7 @@ async function downloadFolder(
       accountId,
       src,
       rootPath,
+      rootMeta,
       cmsPublishMode,
       options,
       failedPaths

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -38,9 +38,6 @@ import { FileSystemError } from '../models/FileSystemError.js';
 
 const i18nKey = 'lib.fileMapper';
 
-const queue = new PQueue({
-  concurrency: 10,
-});
 
 export function isPathToFile(filepath: string): boolean {
   const ext = getExt(filepath);
@@ -310,7 +307,8 @@ async function queueFolderTree(
   directoryNode: DirectoryMetaNode,
   cmsPublishMode: CmsPublishMode | undefined,
   options: FileMapperInputOptions,
-  failedPaths: Set<string>
+  failedPaths: Set<string>,
+  queue: PQueue
 ): Promise<void> {
   if (!directoryNode.folder) return;
 
@@ -364,7 +362,8 @@ async function queueFolderTree(
           childNode,
           cmsPublishMode,
           options,
-          failedPaths
+          failedPaths,
+          queue
         );
       }
     }
@@ -384,6 +383,7 @@ async function downloadFolder(
   const metaPath = isRoot ? '/' : src;
   const queryValues = getFileMapperQueryValues(cmsPublishMode, options);
   const failedPaths = new Set<string>();
+  const queue = new PQueue({ concurrency: 10 });
 
   try {
     const { data: rootMeta } = await getDirectoryMetaByPath(
@@ -408,7 +408,8 @@ async function downloadFolder(
       rootMeta,
       cmsPublishMode,
       options,
-      failedPaths
+      failedPaths,
+      queue
     );
     await queue.onIdle();
   } catch (err) {

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -38,7 +38,6 @@ import { FileSystemError } from '../models/FileSystemError.js';
 
 const i18nKey = 'lib.fileMapper';
 
-
 export function isPathToFile(filepath: string): boolean {
   const ext = getExt(filepath);
   return !!ext && ext !== MODULE_EXTENSION && ext !== FUNCTIONS_EXTENSION;
@@ -212,7 +211,6 @@ async function fetchAndWriteFileStream(
   );
   await writeUtimes(accountId, filepath, node);
 }
-
 
 async function downloadFile(
   accountId: number,

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -298,16 +298,21 @@ export async function fetchFolderFromApi(
   return node;
 }
 
+type QueueFolderTreeContext = {
+  cmsPublishMode: CmsPublishMode | undefined;
+  options: FileMapperInputOptions;
+  failedPaths: Set<string>;
+  queue: PQueue;
+};
+
 async function queueFolderTree(
   accountId: number,
   src: string,
   localPath: string,
   directoryNode: DirectoryMetaNode,
-  cmsPublishMode: CmsPublishMode | undefined,
-  options: FileMapperInputOptions,
-  failedPaths: Set<string>,
-  queue: PQueue
+  ctx: QueueFolderTreeContext
 ): Promise<void> {
+  const { cmsPublishMode, options, failedPaths, queue } = ctx;
   if (!directoryNode.folder) return;
 
   const { isRoot } = getTypeDataFromPath(src);
@@ -359,10 +364,7 @@ async function queueFolderTree(
           childRemotePath,
           childLocalPath,
           childNode,
-          cmsPublishMode,
-          options,
-          failedPaths,
-          queue
+          ctx
         );
       }
     }
@@ -402,16 +404,12 @@ async function downloadFolder(
           )
         : dest;
 
-    await queueFolderTree(
-      accountId,
-      src,
-      rootPath,
-      rootMeta,
+    await queueFolderTree(accountId, src, rootPath, rootMeta, {
       cmsPublishMode,
       options,
       failedPaths,
-      queue
-    );
+      queue,
+    });
     await queue.onIdle();
   } catch (err) {
     queue.clear();

--- a/lib/fileMapper.ts
+++ b/lib/fileMapper.ts
@@ -15,6 +15,7 @@ import {
   fetchFileStream,
   download,
   downloadDefault,
+  getDirectoryMetaByPath,
 } from '../api/fileMapper.js';
 import {
   MODULE_EXTENSION,
@@ -56,6 +57,10 @@ export function isPathToRoot(filepath: string): boolean {
   return /^(\/|\\)?$/.test(filepath.trim());
 }
 
+export function isPathToFolder(filepath: string): boolean {
+  return !isPathToFile(filepath);
+}
+
 export function isPathToHubspot(filepath: string): boolean {
   if (typeof filepath !== 'string') return false;
   return /^(\/|\\)?@hubspot/i.test(filepath.trim());
@@ -68,7 +73,7 @@ function useApiBuffer(cmsPublishMode?: CmsPublishMode | null): boolean {
 // Determines API param based on publish mode and options
 export function getFileMapperQueryValues(
   cmsPublishMode?: CmsPublishMode | null,
-  { staging, assetVersion }: FileMapperInputOptions = {}
+  { staging, assetVersion, timeout }: FileMapperInputOptions = {}
 ): FileMapperOptions {
   return {
     params: {
@@ -76,6 +81,7 @@ export function getFileMapperQueryValues(
       environmentId: staging ? 2 : 1,
       version: assetVersion,
     },
+    ...(timeout !== undefined && { timeout }),
   };
 }
 
@@ -320,6 +326,11 @@ async function downloadFile(
   }
 }
 
+/**
+ * @deprecated Use downloadFileOrFolder instead. This function fetches the
+ * entire directory tree in a single request, which times out for large
+ * directories.
+ */
 export async function fetchFolderFromApi(
   accountId: number,
   src: string,
@@ -343,6 +354,71 @@ export async function fetchFolderFromApi(
   return node;
 }
 
+async function queueFolderTree(
+  accountId: number,
+  src: string,
+  localPath: string,
+  cmsPublishMode: CmsPublishMode | undefined,
+  options: FileMapperInputOptions,
+  failedPaths: Set<string>
+): Promise<void> {
+  const { isRoot } = getTypeDataFromPath(src);
+  const metaPath = isRoot ? '/' : src;
+  const queryValues = getFileMapperQueryValues(cmsPublishMode, options);
+  const { data: directoryNode } = await getDirectoryMetaByPath(
+    accountId,
+    metaPath,
+    queryValues
+  );
+
+  if (!directoryNode?.folder) return;
+
+  let children: string[] = directoryNode.children || [];
+  if (isRoot) {
+    children = ['@hubspot', ...children];
+  }
+
+  await fs.ensureDir(localPath);
+
+  for (const childName of children) {
+    const childRemotePath = isRoot ? childName : `${src}/${childName}`;
+    const childLocalPath = convertToLocalFileSystemPath(
+      path.join(localPath, childName)
+    );
+
+    if (isPathToFile(childRemotePath)) {
+      queue.add(async () => {
+        try {
+          await fetchAndWriteFileStream(
+            accountId,
+            childRemotePath,
+            childLocalPath,
+            cmsPublishMode,
+            options
+          );
+        } catch (err) {
+          failedPaths.add(childRemotePath);
+          logger.debug(
+            i18n(`${i18nKey}.errors.failedToFetchFile`, {
+              src: childRemotePath,
+              dest: childLocalPath,
+            })
+          );
+        }
+      });
+    } else {
+      await queueFolderTree(
+        accountId,
+        childRemotePath,
+        childLocalPath,
+        cmsPublishMode,
+        options,
+        failedPaths
+      );
+    }
+  }
+}
+
 async function downloadFolder(
   accountId: number,
   src: string,
@@ -350,62 +426,40 @@ async function downloadFolder(
   cmsPublishMode?: CmsPublishMode,
   options: FileMapperInputOptions = {}
 ) {
+  src = src.length > 1 ? src.replace(/\/+$/, '') : src;
+  const dest = path.resolve(destPath);
+  const { isRoot } = getTypeDataFromPath(src);
+  const metaPath = isRoot ? '/' : src;
+  const queryValues = getFileMapperQueryValues(cmsPublishMode, options);
+  const failedPaths = new Set<string>();
+
   try {
-    const node = await fetchFolderFromApi(
+    const { data: rootMeta } = await getDirectoryMetaByPath(
       accountId,
-      src,
-      cmsPublishMode,
-      options
+      metaPath,
+      queryValues
     );
-    if (!node) {
-      return;
-    }
-    const dest = path.resolve(destPath);
+
+    if (!rootMeta) return;
+
     const rootPath =
       dest === getCwd()
-        ? convertToLocalFileSystemPath(path.resolve(dest, node.name))
+        ? convertToLocalFileSystemPath(
+            path.resolve(dest, rootMeta.name || path.basename(src))
+          )
         : dest;
-    let success = true;
-    recurseFolder(
-      node,
-      (childNode, filepath) => {
-        queue.add(async () => {
-          const succeeded = await writeFileMapperNode(
-            accountId,
-            filepath || '',
-            childNode,
-            cmsPublishMode,
-            options
-          );
-          if (succeeded === false) {
-            success = false;
-            logger.debug(
-              i18n(`${i18nKey}.errors.failedToFetchFile`, {
-                src: childNode.path,
-                dest: filepath || '',
-              })
-            );
-          }
-        });
-        return success;
-      },
-      rootPath
+
+    await queueFolderTree(
+      accountId,
+      src,
+      rootPath,
+      cmsPublishMode,
+      options,
+      failedPaths
     );
     await queue.onIdle();
-
-    if (success) {
-      logger.success(
-        i18n(`${i18nKey}.completedFolderFetch`, {
-          src,
-          version: getAssetVersionIdentifier(options.assetVersion, src),
-          dest,
-        })
-      );
-    } else {
-      // TODO: Fix this exception. It is triggering the catch block so this error is being rewritten
-      throw new Error(i18n(`${i18nKey}.errors.incompleteFetch`, { src }));
-    }
   } catch (err) {
+    queue.clear();
     const error = err as AxiosError;
     if (isTimeoutError(error)) {
       throw new Error(i18n(`${i18nKey}.errors.assetTimeout`), { cause: error });
@@ -416,6 +470,18 @@ async function downloadFolder(
       );
     }
   }
+
+  if (failedPaths.size > 0) {
+    throw new Error(i18n(`${i18nKey}.errors.incompleteFetch`, { src }));
+  }
+
+  logger.success(
+    i18n(`${i18nKey}.completedFolderFetch`, {
+      src,
+      version: getAssetVersionIdentifier(options.assetVersion, src),
+      dest,
+    })
+  );
 }
 
 /**

--- a/types/Files.ts
+++ b/types/Files.ts
@@ -26,6 +26,15 @@ export type FileMapperNode = {
   children: Array<FileMapperNode>;
 };
 
+export type DirectoryMetaNode = {
+  name: string;
+  path: string;
+  folder: boolean;
+  children: Array<string>;
+  createdAt?: number;
+  updatedAt?: number;
+};
+
 export type CmsPublishMode = ValueOf<typeof CMS_PUBLISH_MODE>;
 
 export type FileMapperOptions = Omit<HttpOptions, 'url'>;


### PR DESCRIPTION
## Description and Context

`hs cms fetch` times out on directories with ~1300+ files. The root cause is that `downloadFolder` made a single `GET /filemapper/v1/download/{path}` call which required the server to serialize the entire recursive directory tree into one JSON response before returning. With enough files, this exceeds the HTTP timeout before the response completes.

Related issues on the public CLI repo: [#1575](https://github.com/HubSpot/hubspot-cli/issues/1575) and [#746](https://github.com/HubSpot/hubspot-cli/issues/746), both closed without a structural fix.

There was also a secondary bug: the `timeout: 60_000` passed by the `hs cms fetch` command was silently dropped by `getFileMapperQueryValues`, which only destructured `staging` and `assetVersion` from options — so the actual HTTP timeout was always the 15s default regardless of what the caller passed.

### Fix

Replace the single `/download/` call with an incremental walk using the existing `/meta/` endpoint (shallow listing) + `/stream/` (individual file download), which is already used by `hs cms list` and the VS Code extension.

**Before:**
downloadFolder → GET /download/{path} → entire tree in one JSON → times out

**After:**
downloadFolder → GET /meta/{path} → immediate children only
  → files: queue fetchAndWriteFileStream (PQueue, concurrency 10)
  → folders/modules: recurse into each subdirectory via /meta/

The `/meta/` endpoint returns a shallow listing (children as strings) and is fast — no server-side tree serialization.

### Research findings that shaped the implementation

- `/meta/` returns `children` as `string[]` (child names), not nested `FileMapperNode` objects. The TypeScript type was wrong; a separate `DirectoryMetaNode` type was added.
- `/meta/` works for `@hubspot` paths, but `/meta/` on `/` does NOT include `@hubspot` in children — it must be manually prepended, the same way the VS Code extension handles it.
- Module folders (`.module`) are treated as folders in the tree — `isPathToFile` returns false for them, so they recurse correctly.
- The module-level `PQueue` was shared across concurrent `downloadFolder` calls. One call's `onIdle()` would wait on another call's items; `clear()` would cancel unrelated work. The queue is now created inside `downloadFolder`, giving each download its own isolated instance.
- The old `success` variable was set inside async `queue.add` callbacks but read synchronously — the early break never actually fired. Replaced with a `Set<string>` of failed paths, read after `queue.onIdle()`.

### Design decisions

- **Subdirectory traversal is sequential** — `queueFolderTree` awaits each child folder's `/meta/` fetch and recursion before continuing. The single `PQueue` is used only for file downloads (concurrency 10); directory traversal is not parallelized.
- **`queue.onIdle()` called only once** — at the outermost `downloadFolder` level, after the full tree walk completes. `queueFolderTree` never waits on the queue.

### Open questions / known risks

- **Do `/meta/` query params work the same as `/download/`?** The `buffer` and `environmentId` params are now passed to `/meta/` calls. If the endpoint doesn't support them, draft mode fetching may behave differently. Basic testing looked fine but edge cases around staging/draft mode should be verified.
- **Performance for deep trees** — Sequential `/meta/` traversal for deeply nested directories adds latency before file downloads begin. Acceptable for now; subdirectory traversal could be parallelized in a follow-up.

## Pre-review checklist

- [x] The `/ldl:code-check` skill has been run and the feedback has been addressed
- [x] Tests have been added for new behaviors
- [x] Manually tested the changes

## Screenshots

N/A — no UI changes.

## Who to Notify

<!-- /cc those you wish to know about the PR -->
