### PR TITLE
feat: add skipAutoDeploy parameter to uploadProject

### DIFF
--- a/api/__tests__/projects.test.ts
+++ b/api/__tests__/projects.test.ts
@@ -175,6 +175,70 @@ describe('api/projects', () => {
             ...intermediateRepresentation,
             projectName,
             buildMessage: uploadMessage,
+            skipAutoDeploy: false,
+          }),
+        },
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+    });
+
+    it('should include skipAutoDeploy in the v1 form data when true', async () => {
+      await uploadProject(
+        accountId,
+        projectName,
+        projectFile,
+        uploadMessage,
+        platformVersion,
+        undefined,
+        true
+      );
+      expect(http.post).toHaveBeenCalledTimes(1);
+      expect(http.post).toHaveBeenCalledWith(accountId, {
+        url: `dfs/v1/projects/upload/${projectName}`,
+        timeout: 60_000,
+        data: {
+          file: formData,
+          uploadMessage,
+          platformVersion,
+          skipAutoDeploy: 'true',
+        },
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+    });
+
+    it('should include skipAutoDeploy in the v3 uploadRequest when true', async () => {
+      // @ts-expect-error Wants full axios response
+      httpPostMock.mockResolvedValue({
+        data: {
+          createdBuildId: 123,
+        },
+      });
+
+      const intermediateRepresentation = {
+        intermediateNodesIndexedByUid: {},
+      };
+
+      await uploadProject(
+        accountId,
+        projectName,
+        projectFile,
+        uploadMessage,
+        platformVersion,
+        intermediateRepresentation,
+        true
+      );
+      expect(http.post).toHaveBeenCalledTimes(1);
+      expect(http.post).toHaveBeenCalledWith(accountId, {
+        url: `project-components-external/v3/upload/new-api`,
+        timeout: 60_000,
+        data: {
+          projectFilesZip: formData,
+          platformVersion,
+          uploadRequest: JSON.stringify({
+            ...intermediateRepresentation,
+            projectName,
+            buildMessage: uploadMessage,
+            skipAutoDeploy: true,
           }),
         },
         headers: { 'Content-Type': 'multipart/form-data' },

--- a/api/projects.ts
+++ b/api/projects.ts
@@ -63,7 +63,8 @@ export async function uploadProject(
   projectFile: string,
   uploadMessage: string,
   platformVersion?: string,
-  intermediateRepresentation?: unknown
+  intermediateRepresentation?: unknown,
+  skipAutoDeploy?: boolean
 ): HubSpotPromise<UploadProjectResponse | UploadIRResponse> {
   if (intermediateRepresentation) {
     const formData = {
@@ -73,6 +74,7 @@ export async function uploadProject(
         ...intermediateRepresentation,
         projectName,
         buildMessage: uploadMessage,
+        skipAutoDeploy: skipAutoDeploy || false,
       }),
     };
 
@@ -95,6 +97,9 @@ export async function uploadProject(
   };
   if (platformVersion) {
     formData.platformVersion = platformVersion;
+  }
+  if (skipAutoDeploy) {
+    formData.skipAutoDeploy = String(skipAutoDeploy);
   }
   return http.post<UploadProjectResponse>(accountId, {
     url: `${PROJECTS_API_PATH}/upload/${encodeURIComponent(projectName)}`,


### PR DESCRIPTION
## Summary

- Adds `skipAutoDeploy?: boolean` as an optional parameter to `uploadProject()`
- v3 path (with IR): includes `skipAutoDeploy` in the `uploadRequest` JSON body
- v1 path (legacy): adds `skipAutoDeploy` as a string form-data field when `true`
- Defaults to `false`, so existing callers are unaffected

This supports the `--skip-auto-deploy` CLI flag being added in [hubspot-cli-private#721](https://github.com/HubSpotEngineering/hubspot-cli-private/pull/721). Backend support landed in [ProjectComponents#579](https://github.com/HubSpotEngineering/ProjectComponents/pull/579).

## Test plan
- [x] `yarn build` passes
- [x] `yarn test api/__tests__/projects.test.ts` -- 50 tests pass (2 new, 1 updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)