### PR TITLE
chore: remove chiragchadha1 as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brandenrodgers @camden11 @joe-yeager @chiragchadha1
+* @brandenrodgers @camden11 @joe-yeager


### PR DESCRIPTION
## Description and Context

Removes `@chiragchadha1` from the global CODEOWNERS rule.

## Pre-review checklist

- [x] The `/ldl:code-check` skill has been run and the feedback has been addressed
- [ ] Tests have been added for new behaviors
- [x] Manually tested the changes

## Screenshots

N/A

## TODO

N/A

## Who to Notify

/cc @brandenrodgers @camden11 @joe-yeager