### PR TITLE
chore(deps): upgrade axios from 1.16.0 to 1.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "address": "2.0.2",
-    "axios": "1.16.0",
+    "axios": "1.18.1",
     "chalk": "5.6.2",
     "chokidar": "3.6.0",
     "content-disposition": "0.5.4",


### PR DESCRIPTION
## Description and Context

Upgrades `axios` from `1.16.0` to `1.18.1` to address security vulnerabilities. This is a patch/minor version bump with no breaking changes to the library's public API.

## Pre-review checklist

- [ ] The `/ldl:code-check` skill has been run and the feedback has been addressed
- [ ] Tests have been added for new behaviors
- [ ] Manually tested the changes

## Screenshots

N/A — dependency-only change.

## TODO

<!-- None -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
