### PR TITLE
feat: add getBaseUrl util to simplify website origin lookups

### DIFF
--- a/lib/__tests__/themes.test.ts
+++ b/lib/__tests__/themes.test.ts
@@ -1,13 +1,13 @@
 import findup from 'findup-sync';
 import { vi, MockedFunction } from 'vitest';
-import { getBaseUrl } from '../urls.js';
+import { getHubSpotWebsiteOriginByAccountId } from '../urls.js';
 import { getThemeJSONPath, getThemePreviewUrl } from '../cms/themes.js';
 
 vi.mock('findup-sync');
 vi.mock('../urls');
 
 const mockedFindup = findup as MockedFunction<typeof findup>;
-const mockedGetBaseUrl = getBaseUrl as MockedFunction<typeof getBaseUrl>;
+const mockedGetBaseUrl = getHubSpotWebsiteOriginByAccountId as MockedFunction<typeof getHubSpotWebsiteOriginByAccountId>;
 
 describe('lib/cms/themes', () => {
   describe('getThemeJSONPath', () => {
@@ -43,7 +43,7 @@ describe('lib/cms/themes', () => {
 
       const result = getThemePreviewUrl('/path/to/file', 12345);
 
-      expect(getBaseUrl).toHaveBeenCalledWith(12345);
+      expect(getHubSpotWebsiteOriginByAccountId).toHaveBeenCalledWith(12345);
       expect(result).toBe(
         'https://app.hubspot.com/theme-previewer/12345/edit/my-theme'
       );
@@ -55,7 +55,7 @@ describe('lib/cms/themes', () => {
 
       const result = getThemePreviewUrl('/path/to/file', 12345);
 
-      expect(getBaseUrl).toHaveBeenCalledWith(12345);
+      expect(getHubSpotWebsiteOriginByAccountId).toHaveBeenCalledWith(12345);
       expect(result).toBe(
         'https://app.hubspotqa.com/theme-previewer/12345/edit/my-theme'
       );

--- a/lib/__tests__/themes.test.ts
+++ b/lib/__tests__/themes.test.ts
@@ -1,28 +1,13 @@
 import findup from 'findup-sync';
 import { vi, MockedFunction } from 'vitest';
-import { getHubSpotWebsiteOrigin } from '../urls.js';
+import { getBaseUrl } from '../urls.js';
 import { getThemeJSONPath, getThemePreviewUrl } from '../cms/themes.js';
-import { getConfigAccountEnvironment } from '../../config/index.js';
-import { ENVIRONMENTS } from '../../constants/environments.js';
 
 vi.mock('findup-sync');
 vi.mock('../urls');
-vi.mock('../../config');
-vi.mock('../../constants/environments', () => ({
-  ENVIRONMENTS: {
-    PROD: 'https://prod.hubspot.com',
-    QA: 'https://qa.hubspot.com',
-  },
-}));
 
 const mockedFindup = findup as MockedFunction<typeof findup>;
-const mockedGetConfigAccountEnvironment =
-  getConfigAccountEnvironment as MockedFunction<
-    typeof getConfigAccountEnvironment
-  >;
-const mockedGetHubSpotWebsiteOrigin = getHubSpotWebsiteOrigin as MockedFunction<
-  typeof getHubSpotWebsiteOrigin
->;
+const mockedGetBaseUrl = getBaseUrl as MockedFunction<typeof getBaseUrl>;
 
 describe('lib/cms/themes', () => {
   describe('getThemeJSONPath', () => {
@@ -54,29 +39,25 @@ describe('lib/cms/themes', () => {
   describe('getThemePreviewUrl', () => {
     it('should return the correct theme preview URL for PROD environment', () => {
       mockedFindup.mockReturnValue('/src/my-theme/theme.json');
-      mockedGetConfigAccountEnvironment.mockReturnValue('prod');
-      mockedGetHubSpotWebsiteOrigin.mockReturnValue('https://prod.hubspot.com');
+      mockedGetBaseUrl.mockReturnValue('https://app.hubspot.com');
 
       const result = getThemePreviewUrl('/path/to/file', 12345);
 
-      expect(getConfigAccountEnvironment).toHaveBeenCalledWith(12345);
-      expect(getHubSpotWebsiteOrigin).toHaveBeenCalledWith(ENVIRONMENTS.PROD);
+      expect(getBaseUrl).toHaveBeenCalledWith(12345);
       expect(result).toBe(
-        'https://prod.hubspot.com/theme-previewer/12345/edit/my-theme'
+        'https://app.hubspot.com/theme-previewer/12345/edit/my-theme'
       );
     });
 
     it('should return the correct theme preview URL for QA environment', () => {
       mockedFindup.mockReturnValue('/src/my-theme/theme.json');
-      mockedGetConfigAccountEnvironment.mockReturnValue('qa');
-      mockedGetHubSpotWebsiteOrigin.mockReturnValue('https://qa.hubspot.com');
+      mockedGetBaseUrl.mockReturnValue('https://app.hubspotqa.com');
 
       const result = getThemePreviewUrl('/path/to/file', 12345);
 
-      expect(getConfigAccountEnvironment).toHaveBeenCalledWith(12345);
-      expect(getHubSpotWebsiteOrigin).toHaveBeenCalledWith(ENVIRONMENTS.QA);
+      expect(getBaseUrl).toHaveBeenCalledWith(12345);
       expect(result).toBe(
-        'https://qa.hubspot.com/theme-previewer/12345/edit/my-theme'
+        'https://app.hubspotqa.com/theme-previewer/12345/edit/my-theme'
       );
     });
 

--- a/lib/__tests__/urls.test.ts
+++ b/lib/__tests__/urls.test.ts
@@ -1,5 +1,5 @@
 import { vi, MockedFunction } from 'vitest';
-import { getHubSpotApiOrigin, getBaseUrl } from '../urls.js';
+import { getHubSpotApiOrigin, getHubSpotWebsiteOriginByAccountId } from '../urls.js';
 import { getConfigAccountEnvironment } from '../../config/index.js';
 
 vi.mock('../../config');
@@ -14,18 +14,18 @@ describe('lib/urls', () => {
     vi.restoreAllMocks();
   });
 
-  describe('getBaseUrl()', () => {
+  describe('getHubSpotWebsiteOriginByAccountId()', () => {
     it('returns prod origin for prod accounts', () => {
       mockedGetConfigAccountEnvironment.mockReturnValue('prod');
 
-      expect(getBaseUrl(123)).toBe('https://app.hubspot.com');
+      expect(getHubSpotWebsiteOriginByAccountId(123)).toBe('https://app.hubspot.com');
       expect(getConfigAccountEnvironment).toHaveBeenCalledWith(123);
     });
 
     it('returns qa origin for qa accounts', () => {
       mockedGetConfigAccountEnvironment.mockReturnValue('qa');
 
-      expect(getBaseUrl(456)).toBe('https://app.hubspotqa.com');
+      expect(getHubSpotWebsiteOriginByAccountId(456)).toBe('https://app.hubspotqa.com');
       expect(getConfigAccountEnvironment).toHaveBeenCalledWith(456);
     });
   });

--- a/lib/__tests__/urls.test.ts
+++ b/lib/__tests__/urls.test.ts
@@ -1,6 +1,35 @@
-import { getHubSpotApiOrigin } from '../urls.js';
+import { vi, MockedFunction } from 'vitest';
+import { getHubSpotApiOrigin, getBaseUrl } from '../urls.js';
+import { getConfigAccountEnvironment } from '../../config/index.js';
+
+vi.mock('../../config');
+
+const mockedGetConfigAccountEnvironment =
+  getConfigAccountEnvironment as MockedFunction<
+    typeof getConfigAccountEnvironment
+  >;
 
 describe('lib/urls', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getBaseUrl()', () => {
+    it('returns prod origin for prod accounts', () => {
+      mockedGetConfigAccountEnvironment.mockReturnValue('prod');
+
+      expect(getBaseUrl(123)).toBe('https://app.hubspot.com');
+      expect(getConfigAccountEnvironment).toHaveBeenCalledWith(123);
+    });
+
+    it('returns qa origin for qa accounts', () => {
+      mockedGetConfigAccountEnvironment.mockReturnValue('qa');
+
+      expect(getBaseUrl(456)).toBe('https://app.hubspotqa.com');
+      expect(getConfigAccountEnvironment).toHaveBeenCalledWith(456);
+    });
+  });
+
   describe('getHubSpotApiOrigin()', () => {
     // Suggestion taken from stack overflow https://stackoverflow.com/a/48042799
     const OLD_ENV = process.env;

--- a/lib/cms/themes.ts
+++ b/lib/cms/themes.ts
@@ -1,7 +1,5 @@
 import findup from 'findup-sync';
-import { getHubSpotWebsiteOrigin } from '../urls.js';
-import { ENVIRONMENTS } from '../../constants/environments.js';
-import { getConfigAccountEnvironment } from '../../config/index.js';
+import { getBaseUrl } from '../urls.js';
 
 export function getThemeJSONPath(path: string): string | null {
   return findup('theme.json', {
@@ -25,11 +23,7 @@ export function getThemePreviewUrl(
   const themeName = getThemeNameFromPath(filePath);
   if (!themeName) return;
 
-  const baseUrl = getHubSpotWebsiteOrigin(
-    getConfigAccountEnvironment(accountId) === 'qa'
-      ? ENVIRONMENTS.QA
-      : ENVIRONMENTS.PROD
-  );
+  const baseUrl = getBaseUrl(accountId);
 
   return `${baseUrl}/theme-previewer/${accountId}/edit/${encodeURIComponent(
     themeName

--- a/lib/cms/themes.ts
+++ b/lib/cms/themes.ts
@@ -1,5 +1,5 @@
 import findup from 'findup-sync';
-import { getBaseUrl } from '../urls.js';
+import { getHubSpotWebsiteOriginByAccountId } from '../urls.js';
 
 export function getThemeJSONPath(path: string): string | null {
   return findup('theme.json', {
@@ -23,7 +23,7 @@ export function getThemePreviewUrl(
   const themeName = getThemeNameFromPath(filePath);
   if (!themeName) return;
 
-  const baseUrl = getBaseUrl(accountId);
+  const baseUrl = getHubSpotWebsiteOriginByAccountId(accountId);
 
   return `${baseUrl}/theme-previewer/${accountId}/edit/${encodeURIComponent(
     themeName

--- a/lib/urls.ts
+++ b/lib/urls.ts
@@ -12,7 +12,7 @@ function getEnvUrlString(env?: string): string {
 export const getHubSpotWebsiteOrigin = (env: string) =>
   `https://app.hubspot${getEnvUrlString(env)}.com`;
 
-export function getBaseUrl(accountId: number): string {
+export function getHubSpotWebsiteOriginByAccountId(accountId: number): string {
   return getHubSpotWebsiteOrigin(
     getConfigAccountEnvironment(accountId) === ENVIRONMENTS.QA
       ? ENVIRONMENTS.QA

--- a/lib/urls.ts
+++ b/lib/urls.ts
@@ -1,4 +1,5 @@
 import { ENVIRONMENTS } from '../constants/environments.js';
+import { getConfigAccountEnvironment } from '../config/index.js';
 
 function getEnvUrlString(env?: string): string {
   if (typeof env !== 'string') {
@@ -10,6 +11,14 @@ function getEnvUrlString(env?: string): string {
 
 export const getHubSpotWebsiteOrigin = (env: string) =>
   `https://app.hubspot${getEnvUrlString(env)}.com`;
+
+export function getBaseUrl(accountId: number): string {
+  return getHubSpotWebsiteOrigin(
+    getConfigAccountEnvironment(accountId) === ENVIRONMENTS.QA
+      ? ENVIRONMENTS.QA
+      : ENVIRONMENTS.PROD
+  );
+}
 
 export function getHubSpotApiOrigin(
   env?: string,


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
- Adds a `getBaseUrl(accountId)` utility in `lib/urls.ts` that wraps the verbose `getHubSpotWebsiteOrigin(getConfigAccountEnvironment(...))` pattern into a single call
- Updates `lib/cms/themes.ts` to use the new util, replacing the inline baseUrl construction
- This util can also be used in `hubspot-cli-private` to simplify the same repeated pattern there

Towards https://linear.app/hubspot/issue/DPGDXFE-63/replace-baseurl-creation-with-a-call-to-a-library-wrapper-function

## Pre-review checklist

<!-- It is expected that all of these have been run before bringing in teammates for review -->

- [x] The `/ldl:code-check` skill has been run and the feedback has been addressed
- [x] Tests have been added for new behaviors
- [x] Manually tested the changes

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
