### PR TITLE
chore(deps): upgrade @hubspot/npm-scripts from 0.0.6 to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@hubspot/npm-scripts": "0.0.6",
+    "@hubspot/npm-scripts": "0.3.1",
     "@types/content-disposition": "^0.5.5",
     "@types/cors": "^2.8.15",
     "@types/debounce": "^1.2.1",


### PR DESCRIPTION
## Description and Context

- Upgrades `@hubspot/npm-scripts` from `0.0.6` to `0.3.1` in `devDependencies`
- The `buildReleaseScript` API contract is unchanged — `repositoryUrl`, `build`, and `mainBranch` options used in `scripts/release.ts` are all still valid
- New version adds `ignoreScripts` and `previousBranch` optional fields and a `buildRepoSyncScript` utility, none of which require changes here

## Pre-review checklist

- [ ] The `/ldl:code-check` skill has been run and the feedback has been addressed
- [ ] Tests have been added for new behaviors
- [ ] Manually tested the changes

## Screenshots

N/A — dependency-only change

## TODO

None

## Who to Notify

<!-- /cc those you wish to know about the PR -->