### PR TITLE
docs: add npm badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # hubspot/local-dev-lib
 
+[![npm version](https://img.shields.io/npm/v/@hubspot/local-dev-lib.svg)](https://www.npmjs.com/package/@hubspot/local-dev-lib)
+[![npm downloads](https://img.shields.io/npm/dm/@hubspot/local-dev-lib)](https://www.npmjs.com/package/@hubspot/local-dev-lib)
+[![npm license](https://img.shields.io/npm/l/@hubspot/local-dev-lib)](https://www.npmjs.com/package/@hubspot/local-dev-lib)
+[![node version](https://img.shields.io/node/v/@hubspot/local-dev-lib)](https://www.npmjs.com/package/@hubspot/local-dev-lib)
+
 Provides library functionality for HubSpot local development tooling, including the [HubSpot CLI](https://github.com/HubSpot/hubspot-cli).
 
 **NOTE:** This library is intended to replace the deprecated [@hubspot/cli-lib](https://github.com/HubSpot/cli-lib) library.


### PR DESCRIPTION
## Description and Context

- Adds four shields.io badges to the top of the README: npm version, npm downloads, npm license, and node version
- Each badge links to the package page on npmjs.com

## Pre-review checklist

- [ ] The `/ldl:code-check` skill has been run and the feedback has been addressed
- [ ] Tests have been added for new behaviors
- [ ] Manually tested the changes

## Screenshots

**Before:** Plain heading with no badges

**After:**

[![npm version](https://img.shields.io/npm/v/@hubspot/local-dev-lib.svg)](https://www.npmjs.com/package/@hubspot/local-dev-lib) [![npm downloads](https://img.shields.io/npm/dm/@hubspot/local-dev-lib)](https://www.npmjs.com/package/@hubspot/local-dev-lib) [![npm license](https://img.shields.io/npm/l/@hubspot/local-dev-lib)](https://www.npmjs.com/package/@hubspot/local-dev-lib) [![node version](https://img.shields.io/node/v/@hubspot/local-dev-lib)](https://www.npmjs.com/package/@hubspot/local-dev-lib)

## TODO

## Who to Notify