### PR TITLE
feat: add isGithubError error guard

### DIFF
--- a/errors/__tests__/index.test.ts
+++ b/errors/__tests__/index.test.ts
@@ -1,8 +1,10 @@
+import { AxiosError } from 'axios';
 import {
   isMissingScopeError,
   isGatingError,
   isSpecifiedError,
   isSystemError,
+  isGithubError,
 } from '../index.js';
 import { BaseError } from '../../types/Error.js';
 import { HubSpotHttpError } from '../../models/HubSpotHttpError.js';
@@ -169,6 +171,50 @@ describe('errors/errors', () => {
       expect(isSystemError(error1)).toBe(false);
       expect(isSystemError(error2)).toBe(false);
       expect(isSystemError(error3)).toBe(false);
+    });
+  });
+
+  describe('isGithubError()', () => {
+    it('returns true for a HubSpotHttpError with a GitHub request id header', () => {
+      const error = newHubSpotHttpError({
+        response: { status: 200, headers: { 'x-github-request-id': 'ABC' } },
+      });
+      expect(isGithubError(error)).toBe(true);
+    });
+
+    it('returns true for an AxiosError with a GitHub request id response header', () => {
+      const error = Object.assign(new AxiosError('Request failed'), {
+        response: { status: 403, headers: { 'x-github-request-id': 'ABC' } },
+      });
+      expect(isGithubError(error)).toBe(true);
+    });
+
+    it('returns true for an AxiosError whose request URL is a GitHub host', () => {
+      const error = Object.assign(new AxiosError('Network Error'), {
+        config: {
+          url: 'https://api.github.com/repos/HubSpot/example/zipball/main',
+        },
+      });
+      expect(isGithubError(error)).toBe(true);
+    });
+
+    it('returns false for a non-GitHub HubSpotHttpError', () => {
+      const error = newHubSpotHttpError({
+        response: { status: 403, headers: {} },
+      });
+      expect(isGithubError(error)).toBe(false);
+    });
+
+    it('returns false for a non-GitHub AxiosError', () => {
+      const error = Object.assign(new AxiosError('Server error'), {
+        response: { status: 500, headers: {} },
+        config: { url: 'https://api.hubapi.com/foo' },
+      });
+      expect(isGithubError(error)).toBe(false);
+    });
+
+    it('returns false for a plain error', () => {
+      expect(isGithubError(new Error('nope'))).toBe(false);
     });
   });
 });

--- a/errors/index.ts
+++ b/errors/index.ts
@@ -1,4 +1,4 @@
-import { AxiosError } from 'axios';
+import { isAxiosError } from 'axios';
 import {
   HubSpotHttpError,
   HubSpotHttpErrorName,
@@ -97,7 +97,7 @@ export function isGithubError(err: unknown): boolean {
   if (isHubSpotHttpError(err)) {
     return !!err.headers && 'x-github-request-id' in err.headers;
   }
-  if (err instanceof AxiosError) {
+  if (isAxiosError(err)) {
     const headers = err.response?.headers;
     if (headers && 'x-github-request-id' in headers) {
       return true;

--- a/errors/index.ts
+++ b/errors/index.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import {
   HubSpotHttpError,
   HubSpotHttpErrorName,
@@ -90,6 +91,24 @@ export function isGithubRateLimitError(err: unknown): err is HubSpotHttpError {
     err.headers['x-ratelimit-remaining'] === '0' &&
     'x-github-request-id' in err.headers
   );
+}
+
+export function isGithubError(err: unknown): boolean {
+  if (isHubSpotHttpError(err)) {
+    return !!err.headers && 'x-github-request-id' in err.headers;
+  }
+  if (err instanceof AxiosError) {
+    const headers = err.response?.headers;
+    if (headers && 'x-github-request-id' in headers) {
+      return true;
+    }
+    const url = err.config?.url;
+    return (
+      typeof url === 'string' &&
+      (url.includes('github.com') || url.includes('githubusercontent.com'))
+    );
+  }
+  return false;
 }
 
 export function isFileSystemError(err: unknown): err is FileSystemError {


### PR DESCRIPTION
## Description and Context

The HubSpot CLI is adding failure tracking to `hs project create` and needs to tell GitHub-origin errors apart from other failures. The existing guards (`isSpecifiedError`, `isGithubRateLimitError`) only recognize `HubSpotHttpError`, but the GitHub API layer (`api/github.ts`) uses plain `axios`, so real GitHub failures arrive as raw `AxiosError`s that those guards miss. 

Adds `isGithubError(err)` in `errors/index.ts`, detecting GitHub origin on either error shape:
- `x-github-request-id` response header — present on every GitHub response, so it works for any GitHub HTTP failure (404, 403, 5xx), on both `HubSpotHttpError` (`.headers`) and `AxiosError` (`.response.headers`).
- Request URL host (`error.config.url` contains `github.com` / `githubusercontent.com`) as a fallback for network errors that have no response.

Towards https://linear.app/hubspot/issue/DPGDXFE-62/add-granular-tracking-for-hs-project-create-errors

## Pre-review checklist

<!-- It is expected that all of these have been run before bringing in teammates for review -->

- [x] The `/ldl:code-check` skill has been run and the feedback has been addressed
- [x] Tests have been added for new behaviors
- [x] Manually tested the changes

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
@HubSpotEngineering/dev-experience-fe