### PR TITLE
refactor: make GitHub error guards cause-aware and axios-aware

### DIFF
--- a/errors/__tests__/index.test.ts
+++ b/errors/__tests__/index.test.ts
@@ -6,6 +6,7 @@ import {
   isSystemError,
   isGithubError,
   isGithubRateLimitError,
+  hasGithubRateLimitError,
   getHttpStatusFromError,
 } from '../index.js';
 import { BaseError } from '../../types/Error.js';
@@ -249,6 +250,62 @@ describe('errors/errors', () => {
       expect(isGithubRateLimitError(error)).toBe(true);
     });
 
+    it('returns false for a HubSpotHttpError without rate-limit headers', () => {
+      const error = newHubSpotHttpError({
+        response: { status: 403, headers: { 'x-github-request-id': 'ABC' } },
+      });
+      expect(isGithubRateLimitError(error)).toBe(false);
+    });
+
+    it('returns false for a rate-limited AxiosError (predicate matches only HubSpotHttpError)', () => {
+      const error = Object.assign(new AxiosError('Request failed'), {
+        response: {
+          status: 403,
+          headers: {
+            'x-ratelimit-remaining': '0',
+            'x-github-request-id': 'ABC',
+          },
+        },
+      });
+      expect(isGithubRateLimitError(error)).toBe(false);
+    });
+
+    it('returns false when the rate-limit signal is only on error.cause', () => {
+      const cause = newHubSpotHttpError({
+        response: {
+          status: 403,
+          headers: {
+            'x-ratelimit-remaining': '0',
+            'x-github-request-id': 'ABC',
+          },
+        },
+      });
+      const wrapped = new Error('An error occurred fetching the source.', {
+        cause,
+      });
+      expect(isGithubRateLimitError(wrapped)).toBe(false);
+    });
+
+    it('returns false for null or undefined', () => {
+      expect(isGithubRateLimitError(null)).toBe(false);
+      expect(isGithubRateLimitError(undefined)).toBe(false);
+    });
+  });
+
+  describe('hasGithubRateLimitError()', () => {
+    it('returns true for a HubSpotHttpError with rate-limit headers', () => {
+      const error = newHubSpotHttpError({
+        response: {
+          status: 403,
+          headers: {
+            'x-ratelimit-remaining': '0',
+            'x-github-request-id': 'ABC',
+          },
+        },
+      });
+      expect(hasGithubRateLimitError(error)).toBe(true);
+    });
+
     it('returns true for an AxiosError with rate-limit response headers', () => {
       const error = Object.assign(new AxiosError('Request failed'), {
         response: {
@@ -259,7 +316,7 @@ describe('errors/errors', () => {
           },
         },
       });
-      expect(isGithubRateLimitError(error)).toBe(true);
+      expect(hasGithubRateLimitError(error)).toBe(true);
     });
 
     it('returns true when a rate-limit error is wrapped in error.cause', () => {
@@ -275,7 +332,7 @@ describe('errors/errors', () => {
       const wrapped = new Error('An error occurred fetching the source.', {
         cause,
       });
-      expect(isGithubRateLimitError(wrapped)).toBe(true);
+      expect(hasGithubRateLimitError(wrapped)).toBe(true);
     });
 
     it('returns false for a GitHub error that is not rate limited', () => {
@@ -285,7 +342,7 @@ describe('errors/errors', () => {
           headers: { 'x-github-request-id': 'ABC' },
         },
       });
-      expect(isGithubRateLimitError(error)).toBe(false);
+      expect(hasGithubRateLimitError(error)).toBe(false);
     });
 
     it('returns false when the request id header is missing', () => {
@@ -295,12 +352,12 @@ describe('errors/errors', () => {
           headers: { 'x-ratelimit-remaining': '0' },
         },
       });
-      expect(isGithubRateLimitError(error)).toBe(false);
+      expect(hasGithubRateLimitError(error)).toBe(false);
     });
 
     it('returns false for null or undefined', () => {
-      expect(isGithubRateLimitError(null)).toBe(false);
-      expect(isGithubRateLimitError(undefined)).toBe(false);
+      expect(hasGithubRateLimitError(null)).toBe(false);
+      expect(hasGithubRateLimitError(undefined)).toBe(false);
     });
   });
 

--- a/errors/__tests__/index.test.ts
+++ b/errors/__tests__/index.test.ts
@@ -5,6 +5,8 @@ import {
   isSpecifiedError,
   isSystemError,
   isGithubError,
+  isGithubRateLimitError,
+  getHttpStatusFromError,
 } from '../index.js';
 import { BaseError } from '../../types/Error.js';
 import { HubSpotHttpError } from '../../models/HubSpotHttpError.js';
@@ -213,8 +215,127 @@ describe('errors/errors', () => {
       expect(isGithubError(error)).toBe(false);
     });
 
+    it('returns true when the GitHub error is wrapped in error.cause', () => {
+      const cause = Object.assign(new AxiosError('Request failed'), {
+        response: { status: 403, headers: { 'x-github-request-id': 'ABC' } },
+      });
+      const wrapped = new Error('An error occurred fetching the source.', {
+        cause,
+      });
+      expect(isGithubError(wrapped)).toBe(true);
+    });
+
     it('returns false for a plain error', () => {
       expect(isGithubError(new Error('nope'))).toBe(false);
+    });
+
+    it('returns false for null or undefined', () => {
+      expect(isGithubError(null)).toBe(false);
+      expect(isGithubError(undefined)).toBe(false);
+    });
+  });
+
+  describe('isGithubRateLimitError()', () => {
+    it('returns true for a HubSpotHttpError with rate-limit headers', () => {
+      const error = newHubSpotHttpError({
+        response: {
+          status: 403,
+          headers: {
+            'x-ratelimit-remaining': '0',
+            'x-github-request-id': 'ABC',
+          },
+        },
+      });
+      expect(isGithubRateLimitError(error)).toBe(true);
+    });
+
+    it('returns true for an AxiosError with rate-limit response headers', () => {
+      const error = Object.assign(new AxiosError('Request failed'), {
+        response: {
+          status: 403,
+          headers: {
+            'x-ratelimit-remaining': '0',
+            'x-github-request-id': 'ABC',
+          },
+        },
+      });
+      expect(isGithubRateLimitError(error)).toBe(true);
+    });
+
+    it('returns true when a rate-limit error is wrapped in error.cause', () => {
+      const cause = Object.assign(new AxiosError('Request failed'), {
+        response: {
+          status: 403,
+          headers: {
+            'x-ratelimit-remaining': '0',
+            'x-github-request-id': 'ABC',
+          },
+        },
+      });
+      const wrapped = new Error('An error occurred fetching the source.', {
+        cause,
+      });
+      expect(isGithubRateLimitError(wrapped)).toBe(true);
+    });
+
+    it('returns false for a GitHub error that is not rate limited', () => {
+      const error = Object.assign(new AxiosError('Server error'), {
+        response: {
+          status: 500,
+          headers: { 'x-github-request-id': 'ABC' },
+        },
+      });
+      expect(isGithubRateLimitError(error)).toBe(false);
+    });
+
+    it('returns false when the request id header is missing', () => {
+      const error = Object.assign(new AxiosError('Request failed'), {
+        response: {
+          status: 403,
+          headers: { 'x-ratelimit-remaining': '0' },
+        },
+      });
+      expect(isGithubRateLimitError(error)).toBe(false);
+    });
+
+    it('returns false for null or undefined', () => {
+      expect(isGithubRateLimitError(null)).toBe(false);
+      expect(isGithubRateLimitError(undefined)).toBe(false);
+    });
+  });
+
+  describe('getHttpStatusFromError()', () => {
+    it('returns the status from a HubSpotHttpError', () => {
+      const error = newHubSpotHttpError({
+        response: { status: 404, headers: {} },
+      });
+      expect(getHttpStatusFromError(error)).toBe(404);
+    });
+
+    it('returns the status from an AxiosError response', () => {
+      const error = Object.assign(new AxiosError('Not found'), {
+        response: { status: 404, headers: {} },
+      });
+      expect(getHttpStatusFromError(error)).toBe(404);
+    });
+
+    it('returns the status from an AxiosError wrapped in error.cause', () => {
+      const cause = Object.assign(new AxiosError('Not found'), {
+        response: { status: 404, headers: {} },
+      });
+      const wrapped = new Error('An error occurred fetching the source.', {
+        cause,
+      });
+      expect(getHttpStatusFromError(wrapped)).toBe(404);
+    });
+
+    it('returns undefined for an error with no status', () => {
+      expect(getHttpStatusFromError(new Error('plain'))).toBeUndefined();
+    });
+
+    it('returns undefined for null or undefined', () => {
+      expect(getHttpStatusFromError(null)).toBeUndefined();
+      expect(getHttpStatusFromError(undefined)).toBeUndefined();
     });
   });
 });

--- a/errors/index.ts
+++ b/errors/index.ts
@@ -82,7 +82,18 @@ export function isHubSpotHttpError(error?: unknown): error is HubSpotHttpError {
   );
 }
 
-export function isGithubRateLimitError(err: unknown): boolean {
+export function isGithubRateLimitError(err: unknown): err is HubSpotHttpError {
+  if (!isHubSpotHttpError(err)) {
+    return false;
+  }
+  return (
+    !!err.headers &&
+    err.headers['x-ratelimit-remaining'] === '0' &&
+    'x-github-request-id' in err.headers
+  );
+}
+
+export function hasGithubRateLimitError(err: unknown): boolean {
   return (
     hasGithubRateLimitSignal(err) ||
     (err instanceof Error && hasGithubRateLimitSignal(err.cause))
@@ -90,12 +101,8 @@ export function isGithubRateLimitError(err: unknown): boolean {
 }
 
 function hasGithubRateLimitSignal(err: unknown): boolean {
-  if (isHubSpotHttpError(err)) {
-    return (
-      !!err.headers &&
-      err.headers['x-ratelimit-remaining'] === '0' &&
-      'x-github-request-id' in err.headers
-    );
+  if (isGithubRateLimitError(err)) {
+    return true;
   }
   if (isAxiosError(err)) {
     const headers = err.response?.headers;

--- a/errors/index.ts
+++ b/errors/index.ts
@@ -82,10 +82,6 @@ export function isHubSpotHttpError(error?: unknown): error is HubSpotHttpError {
   );
 }
 
-// GitHub error guards accept both a raw error and one wrapped via
-// `new Error(message, { cause })`, because this library re-throws GitHub
-// failures wrapped that way (see lib/github.ts). They also handle both
-// HubSpotHttpError and raw AxiosError shapes so consumers don't have to.
 export function isGithubRateLimitError(err: unknown): boolean {
   return (
     hasGithubRateLimitSignal(err) ||
@@ -137,9 +133,6 @@ function hasGithubErrorSignal(err: unknown): boolean {
   return false;
 }
 
-// Extracts the HTTP status from HubSpotHttpError or AxiosError, unwrapping a
-// wrapped `cause` so consumers can classify failures without knowing whether
-// the error was re-thrown by this library.
 export function getHttpStatusFromError(err: unknown): number | undefined {
   const status = getStatusCode(err);
   if (status !== undefined) {

--- a/errors/index.ts
+++ b/errors/index.ts
@@ -82,18 +82,44 @@ export function isHubSpotHttpError(error?: unknown): error is HubSpotHttpError {
   );
 }
 
-export function isGithubRateLimitError(err: unknown): err is HubSpotHttpError {
-  if (!isHubSpotHttpError(err)) {
-    return false;
-  }
+// GitHub error guards accept both a raw error and one wrapped via
+// `new Error(message, { cause })`, because this library re-throws GitHub
+// failures wrapped that way (see lib/github.ts). They also handle both
+// HubSpotHttpError and raw AxiosError shapes so consumers don't have to.
+export function isGithubRateLimitError(err: unknown): boolean {
   return (
-    !!err.headers &&
-    err.headers['x-ratelimit-remaining'] === '0' &&
-    'x-github-request-id' in err.headers
+    hasGithubRateLimitSignal(err) ||
+    (err instanceof Error && hasGithubRateLimitSignal(err.cause))
   );
 }
 
+function hasGithubRateLimitSignal(err: unknown): boolean {
+  if (isHubSpotHttpError(err)) {
+    return (
+      !!err.headers &&
+      err.headers['x-ratelimit-remaining'] === '0' &&
+      'x-github-request-id' in err.headers
+    );
+  }
+  if (isAxiosError(err)) {
+    const headers = err.response?.headers;
+    return (
+      !!headers &&
+      String(headers['x-ratelimit-remaining']) === '0' &&
+      'x-github-request-id' in headers
+    );
+  }
+  return false;
+}
+
 export function isGithubError(err: unknown): boolean {
+  return (
+    hasGithubErrorSignal(err) ||
+    (err instanceof Error && hasGithubErrorSignal(err.cause))
+  );
+}
+
+function hasGithubErrorSignal(err: unknown): boolean {
   if (isHubSpotHttpError(err)) {
     return !!err.headers && 'x-github-request-id' in err.headers;
   }
@@ -109,6 +135,27 @@ export function isGithubError(err: unknown): boolean {
     );
   }
   return false;
+}
+
+// Extracts the HTTP status from HubSpotHttpError or AxiosError, unwrapping a
+// wrapped `cause` so consumers can classify failures without knowing whether
+// the error was re-thrown by this library.
+export function getHttpStatusFromError(err: unknown): number | undefined {
+  const status = getStatusCode(err);
+  if (status !== undefined) {
+    return status;
+  }
+  return err instanceof Error ? getStatusCode(err.cause) : undefined;
+}
+
+function getStatusCode(err: unknown): number | undefined {
+  if (isHubSpotHttpError(err)) {
+    return err.status;
+  }
+  if (isAxiosError(err)) {
+    return err.status ?? err.response?.status;
+  }
+  return undefined;
 }
 
 export function isFileSystemError(err: unknown): err is FileSystemError {


### PR DESCRIPTION
## Description and Context
Consolidates GitHub error-classification logic into local-dev-lib. Follow-up to #472.

- `isGithubRateLimitError` now also handles raw `AxiosError` (matching its sibling `isGithubError`) and looks through `error.cause`.
- `isGithubError` now looks through `error.cause`.
- Adds `getHttpStatusFromError` to pull an HTTP status off `HubSpotHttpError` or `AxiosError`, unwrapping `cause`.

The cause-unwrapping lives here because this library is what re-throws GitHub failures wrapped in `new Error(msg, { cause })` (see `lib/github.ts`), so its own guards should see through that.

Towards https://linear.app/hubspot/issue/DPGDXFE-62/add-granular-tracking-for-hs-project-create-errors

## Pre-review checklist

<!-- It is expected that all of these have been run before bringing in teammates for review -->

- [x] The `/ldl:code-check` skill has been run and the feedback has been addressed
- [x] Tests have been added for new behaviors
- [x] Manually tested the changes

## Screenshots

<!-- Provide images of the before and after functionality -->

## TODO

<!--Is there anything you're leaving behind that should be done? You can create issues for your TODOS, or simply suggest them here and we will help sort them out -->

## Who to Notify

<!-- /cc those you wish to know about the PR -->
@HubSpotEngineering/dev-experience-fe